### PR TITLE
fix(astro): keep Markdy rescue script out of Rocket Loader (v0.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4] — 2026-05-16
+
+### Fixed
+- **Cloudflare Rocket Loader autoplay** — The `@markdy/astro` rescue script now opts out of Rocket Loader via `data-cfasync="false"` and re-injects rescued module scripts with the same opt-out. This keeps Markdy hydration executable on Rocket Loader pages where inline rescue scripts were being rewritten to a custom `*-text/javascript` type, fixing autoplay on Vietnamese article pages such as `/vi/five-days-five-years-apple-m5-kernel-exploit/`.
+
 ## [0.7.3] — 2026-05-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdy",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "An open-source animation DSL engine. Write MarkdyScript, get animated scenes in the browser.",
   "license": "MIT",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/astro",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Astro island component for MarkdyScript animations.",
   "license": "MIT",
   "type": "module",

--- a/packages/astro/src/Markdy.astro
+++ b/packages/astro/src/Markdy.astro
@@ -121,7 +121,7 @@ const {
   </noscript>
 </div>
 
-<script is:inline>
+<script is:inline data-cfasync="false">
   // ── Rocket Loader rescue ──────────────────────────────────────────────────
   // Cloudflare Rocket Loader rewrites <script type="module" src="..."> in
   // one of two ways, both of which prevent the hydration logic from running:
@@ -131,8 +131,8 @@ const {
   //        <!--<script type="{uuid}-module" src="..."></script>-->
   //      making it invisible to querySelectorAll.
   //
-  // This inline script is NOT touched by Rocket Loader (no src, no type attr).
-  // It rescues module scripts via two strategies:
+  // `data-cfasync="false"` keeps this rescue script executable even when
+  // Rocket Loader is active. It rescues module scripts via two strategies:
   //   1. Query the DOM for type$="-module" + src (covers case A)
   //   2. Regex-parse the raw HTML for commented-out script tags (covers case B)
   // Dynamically-created scripts bypass Rocket Loader entirely.
@@ -176,6 +176,7 @@ const {
         var fix = document.createElement('script');
         fix.type = 'module';
         fix.src = src;
+        fix.setAttribute('data-cfasync', 'false');
         document.head.appendChild(fix);
       });
     }

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/compat",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Backwards-compatibility gate for MarkdyScript. Snapshots every fixture in packages/compat/fixtures with the current parser and diffs ASTs on every CI run.",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/core",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "MarkdyScript parser and AST types — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/renderer-dom",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Web Animations API renderer for MarkdyScript scenes.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Cloudflare Rocket Loader was rewriting the Markdy `is:inline` rescue script in `@markdy/astro` to a custom `*-text/javascript` type, so the rescue never ran and `.markdy-root` elements never hydrated. On affected pages (e.g. `https://hn.hoangyell.com/vi/five-days-five-years-apple-m5-kernel-exploit/`) every Markdy scene stayed on the `▶ markdy` placeholder and no Web Animations were created.
- Mark the rescue `<script>` with `data-cfasync="false"` so Rocket Loader leaves it alone, and tag every dynamically re-injected module script with the same opt-out so the rescued modules survive too.
- Bump all package versions to `0.7.4` and add a `CHANGELOG.md` entry.

## Repro

1. Open https://hn.hoangyell.com/ (Rocket Loader is enabled by Cloudflare).
2. Click the "Tiếng Việt" flag → navigates to https://hn.hoangyell.com/vi/.
3. Open the post `five-days-five-years-apple-m5-kernel-exploit`.
4. Before: all Markdy scenes stay paused with the `▶ markdy` placeholder and `document.getAnimations({subtree:true})` returns `[]`. After this fix: scenes autoplay on first navigation.

## Root cause

`packages/astro/src/Markdy.astro` shipped the rescue logic as an `is:inline` script with no `data-cfasync` attribute. Rocket Loader rewrote the `type` attribute, so the rescue script itself was deferred / never executed, and the module scripts it was supposed to rescue stayed inert.

## Fix

\`\`\`diff
-<script is:inline>
+<script is:inline data-cfasync=\"false\">
 ...
         var fix = document.createElement('script');
         fix.type = 'module';
         fix.src = src;
+        fix.setAttribute('data-cfasync', 'false');
         document.head.appendChild(fix);
\`\`\`

## Release

This PR contains the version bump commit `chore: release v0.7.4` so that merging it directly publishes the patch. After merge, please tag and push:

\`\`\`bash
git fetch origin
git checkout main
git pull --ff-only
git tag v0.7.4
git push origin v0.7.4
\`\`\`

CI will then publish `@markdy/*` to npm and create the GitHub Release.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` (core: 114 ✓, renderer-dom: 14 ✓)
- [x] `pnpm run build`
- [ ] Verify on https://hn.hoangyell.com/vi/five-days-five-years-apple-m5-kernel-exploit/ after deploy: Markdy scenes autoplay on first navigation.


Made with [Cursor](https://cursor.com)