### PR TITLE
chore: release v0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.6] — 2026-05-26
+
+### Internal
+- **Dependency bundle (May 2026)** — Consolidated 9 stale dependabot PRs into a single bundle (#22) and regenerated the workspace lockfile. No runtime changes to the published packages. Notable bumps: `jsdom` 26.1.0 → 29.1.1 (renderer-dom devDep, 3 major versions, all 14 renderer-dom tests still pass), `vitest` 4.1.4 → 4.1.7, `astro` 6.1.5 → 6.2.1, `@codemirror/view` 6.41.0 → 6.43.0, `@codemirror/search` 6.6.0 → 6.7.0, `@lezer/lr` 1.4.8 → 1.4.10, `wrangler` 4.81.1 → 4.94.0, `lighthouse` 13.1.0 → 13.2.0.
+- **CI** — Updated `softprops/action-gh-release` from v2 to v3 in the release workflow (#8).
+
 ## [0.7.5] — 2026-05-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdy",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "An open-source animation DSL engine. Write MarkdyScript, get animated scenes in the browser.",
   "license": "MIT",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/astro",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Astro island component for MarkdyScript animations.",
   "license": "MIT",
   "type": "module",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/compat",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "description": "Backwards-compatibility gate for MarkdyScript. Snapshots every fixture in packages/compat/fixtures with the current parser and diffs ASTs on every CI run.",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/core",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "MarkdyScript parser and AST types — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/renderer-dom",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Web Animations API renderer for MarkdyScript scenes.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Cuts **v0.7.6** — a maintenance release that picks up the dependency bundle from #22 plus the GitHub Action update from #8.

Bumps all 4 published/internal packages from `0.7.5` to `0.7.6`:

- `markdy` (root)
- `@markdy/astro`
- `@markdy/core`
- `@markdy/renderer-dom`
- `@markdy/compat` (private)

## Why a release

The published packages' runtime code is unchanged — this release only refreshes
dev/build dependencies (jsdom, vitest), website deps (astro, codemirror,
lighthouse, lezer, wrangler), and CI infra. Cut as a patch so consumers' lockfiles
can re-resolve cleanly and so the v0.7.6 git tag matches the dep state on `main`.

## Release flow

Once this PR is merged into `main`, push the `v0.7.6` tag to trigger the
`Release` workflow which:
1. Publishes `@markdy/core`, `@markdy/renderer-dom`, `@markdy/astro` to npm.
2. Creates a GitHub Release with auto-generated notes.

## Verified locally

- `pnpm run typecheck` → pass
- `pnpm run test` → 128 pass
- `pnpm run build` → pass (packages + website)
- `pnpm run gate` → 15 fixtures, 0 regressions
- `pnpm run verify:examples` → 30 files, 0 failures


Made with [Cursor](https://cursor.com)