### PR TITLE
chore: release v0.7.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: 💬 Ask a question
     url: https://github.com/HoangYell/markdy-com/discussions
-    about: Need help using Markdy? Please ask in our Discussions tab.
+    about: Need help writing Markdy animations? Ask in Discussions (Q&A category).
   - name: 🐞 Markdy Playground
     url: https://markdy.com
     about: Test out animations visually before reporting syntax vs engine errors

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           body: |
             ## 🎬 Markdy ${{ github.ref_name }}
 
-            **Animation DSL engine — Like Mermaid, but for motion.**
+            **Open-source text-to-motion animation DSL engine.**
 
             ### Packages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.7] — 2026-07-18
+
+### Changed
+- **Clearer product positioning** — Updated core messaging across the repository and website to describe Markdy as a **text-to-motion animation DSL** and explicitly clarify that it is not a static diagram generator.
+- **Landing page copy refresh** — Updated homepage title, hero, footer tagline, and SEO metadata to reduce Mermaid-style diagram confusion and set expectations earlier.
+- **Package discoverability** — Replaced the `mermaid-alternative` keyword with `text-to-motion` in root and `@markdy/core` package metadata.
+
+### Community
+- **Discussions path fixed** — Enabled GitHub Discussions and updated issue template guidance to route usage questions to Discussions Q&A.
+- **Issue follow-up** — Replied on issue #33 with clarification and the new Discussions link.
+
+### Internal
+- **Release template wording** — Updated GitHub release workflow body copy to match the new text-to-motion positioning.
+
 ## [0.7.6] — 2026-05-26
 
 ### Internal

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@
 
 **Markdy is a framework-agnostic Animation DSL.** Write animations like Markdown.
 
-It is like [Mermaid](https://mermaid.js.org/) but for motion. Define actors, timelines, and interactions in a simple, readable DSL — the engine handles rendering with the Web Animations API. No Canvas, no GSAP, no bloated dependencies.
+Define actors, timelines, and interactions in a simple, readable DSL. The engine handles rendering with the Web Animations API. No Canvas, no GSAP, no bloated dependencies.
+
+> Markdy is built for **text-to-motion scenes**.
+> It is **not** a static diagram generator for flowcharts, ERDs, or network graphs.
 
 ```markdy
 scene width=600 height=300 bg=white

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdy",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "An open-source animation DSL engine. Write MarkdyScript, get animated scenes in the browser.",
   "license": "MIT",
@@ -22,7 +22,7 @@
     "dsl",
     "markdy",
     "markdyscript",
-    "mermaid-alternative",
+    "text-to-motion",
     "framer-motion-alternative",
     "markdown-animation",
     "declarative-animation",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/astro",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Astro island component for MarkdyScript animations.",
   "license": "MIT",
   "type": "module",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/compat",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "description": "Backwards-compatibility gate for MarkdyScript. Snapshots every fixture in packages/compat/fixtures with the current parser and diffs ASTs on every CI run.",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/core",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "MarkdyScript parser and AST types — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",
@@ -26,7 +26,7 @@
     "parser",
     "ast",
     "declarative-animation",
-    "mermaid-alternative",
+    "text-to-motion",
     "markdown-animation"
   ],
   "author": "Hoang Yell <hoangyell@gmail.com> (https://hoangyell.com)",

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/renderer-dom",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Web Animations API renderer for MarkdyScript scenes.",
   "license": "MIT",
   "type": "module",

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -11,10 +11,10 @@ export interface Props extends HTMLAttributes<"html"> {
 
 const {
   title,
-  description = "Markdy is an open-source animation DSL engine. Write stick-figure animations in a simple text language — no keyframes, no drag-and-drop. Like Mermaid, but for motion.",
+  description = "Markdy is an open-source text-to-motion animation DSL. Write animated scenes in a simple text language with no keyframes and no drag-and-drop.",
   canonicalURL = "https://markdy.com",
   ogImage = "https://markdy.com/og-image.png",
-  keywords = "animation dsl, declarative animation, markdown animation, mermaid alternative, framer motion alternative, gsap alternative, astro animation, web animations api",
+  keywords = "animation dsl, text-to-motion, declarative animation, markdown animation, framer motion alternative, gsap alternative, astro animation, web animations api",
 } = Astro.props;
 ---
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -303,8 +303,8 @@ const USAGE_MDX = `<span class="u-kw">import</span> { Markdy } <span class="u-kw
 
 <Layout 
   title="Markdy — Open-Source Animation DSL Engine"
-  description="Markdy is a framework-agnostic Animation DSL. Write animations like Markdown. It is like Mermaid but for motion. No Canvas, no GSAP, no bloated dependencies."
-  keywords="open-source animation dsl, declarative animation, mermaid alternative, framer motion alternative, gsap alternative, markdown animation, web animations api, stick figure animation"
+  description="Markdy is a framework-agnostic text-to-motion animation DSL. Write animated scenes like Markdown. No Canvas, no GSAP, no bloated dependencies."
+  keywords="open-source animation dsl, text-to-motion, declarative animation, framer motion alternative, gsap alternative, markdown animation, web animations api, stick figure animation"
 >
 
   <!-- ─── Nav ──────────────────────────────────────────────────────────── -->
@@ -348,10 +348,10 @@ const USAGE_MDX = `<span class="u-kw">import</span> { Markdy } <span class="u-kw
   <!-- ─── Hero ─────────────────────────────────────────────────────────── -->
   <header class="hero">
     <div class="hero-badge">Open-Source Animation DSL</div>
-    <h1>Like <span class="gradient-text">Mermaid</span>, but for motion.</h1>
+    <h1>Text-to-motion <span class="gradient-text">animation DSL</span>.</h1>
     <p class="hero-sub">
       Define actors, timelines, and interactions in a simple text language.
-      The engine handles rendering. No keyframes, no drag-and-drop.
+      Markdy is built for animated scenes, not static chart or graph diagrams.
     </p>
     <div class="hero-actions">
       <a href="#playground" class="btn-primary">Try the Playground</a>
@@ -895,7 +895,7 @@ seq wave(arm, angle) {
       <div class="footer-top">
         <div class="footer-brand-col">
           <span class="footer-brand">🎬 markdy</span>
-          <p class="footer-tagline">Open-source animation DSL engine.<br />Like Mermaid, but for motion.</p>
+          <p class="footer-tagline">Open-source text-to-motion DSL.<br />Built for animated scenes on the web.</p>
         </div>
         <div class="footer-cols">
           <h2 class="sr-only">Footer Links</h2>


### PR DESCRIPTION
## Summary
- clarify Markdy positioning as a text-to-motion animation DSL across README, website copy, metadata, and issue templates
- update release workflow copy and add changelog entry for v0.7.7
- bump root and workspace package versions to 0.7.7

## Validation
- pnpm run lint
- pnpm run build
- pnpm run test

## Release
- pushed tag v0.7.7 (triggers publish + GitHub Release workflow)