### PR TITLE
chore: release v0.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.9] — 2026-07-18
+
+### Fixed
+- **Robust string escaping in parser** — Hardened `@markdy/core` parsing for quoted values so scripts embedded in Markdown/MDX/JS strings are less error-prone:
+  - supports both single-quoted and double-quoted string literals
+  - correctly handles escaped quotes (`\"`, `\'`) while parsing comments and comma-delimited params
+  - supports common escapes (`\\`, `\n`, `\r`, `\t`)
+  - preserves unknown escape sequences instead of silently dropping backslashes
+- **Regression coverage** — Added parser tests for escaped quotes, commas/hash inside strings, backslash-heavy paths, single-quoted literals, and unknown-escape preservation.
+
+### Docs
+- Updated [AGENT.md](docs/AGENT.md) and [SYNTAX.md](docs/SYNTAX.md) to reflect the expanded string-literal and escaping behavior.
+
 ## [0.7.8] — 2026-07-18
 
 ### Internal

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -30,7 +30,7 @@ statement      = var_decl | scene_decl | asset_decl | actor_decl
 
 var_decl       = "var" IDENT "=" REST_OF_LINE
 scene_decl     = "scene" (IDENT "=" VALUE)*
-asset_decl     = "asset" IDENT "=" ("image" | "icon") "(" QUOTED ")"
+asset_decl     = "asset" IDENT "=" ("image" | "icon") "(" STRING ")"
 actor_decl     = "actor" IDENT "=" TYPE "(" ARGS? ")" POSITION TRAILER?
 position       = "at" "(" NUM "," NUM ")"             # any actor type
                | "at" ANCHOR                          # caption actors only
@@ -53,19 +53,22 @@ seq_block      = "seq" IDENT ("(" PARAM_LIST? ")")? "{" NEWLINE
                  "}"
 seq_event      = "@+" NUM ":" "$." BANG? ACTION "(" PARAMS? ")"
 
-chapter_block  = "scene" QUOTED "{" NEWLINE
+chapter_block  = "scene" STRING "{" NEWLINE
                    (event | blank | comment)*
                  "}"
 
-import_decl    = "import" QUOTED "as" IDENT
+import_decl    = "import" STRING "as" IDENT
 preset_call    = "preset" IDENT "(" ARGS? ")"          # must be sole top-level content
 
 PARAMS         = PARAM ("," PARAM)*
 PARAM          = VALUE                           # positional
                | IDENT "=" VALUE                  # named
-VALUE          = QUOTED | NUM | TUPLE | DOTTED_IDENT
+VALUE          = STRING | NUM | TUPLE | DOTTED_IDENT
 TUPLE          = "(" NUM "," NUM ")"
-QUOTED         = '"' [^"]* '"'
+STRING         = DQUOTE_STRING | SQUOTE_STRING
+DQUOTE_STRING  = '"' ( ESC | [^"\\] )* '"'
+SQUOTE_STRING  = "'" ( ESC | [^'\\] )* "'"
+ESC            = "\\" ( "\"" | "'" | "\\" | "n" | "r" | "t" )
 NUM            = [0-9]+ ("." [0-9]+)?
 IDENT          = [a-zA-Z_][a-zA-Z0-9_]*
 DOTTED_IDENT   = IDENT ("." IDENT)*                    # allows ns-scoped refs
@@ -89,7 +92,15 @@ var <name> = <value>
 
 - Parsed **before** comment stripping (safe for `#hex` colours)
 - Substituted everywhere via `${name}`
+- Also supports MDX `String.raw` form `\${name}`
 - Forward references are invalid — declare before use
+
+### String literals
+
+- Both `"double-quoted"` and `'single-quoted'` strings are valid.
+- Supported escapes: `\"`, `\'`, `\\`, `\n`, `\r`, `\t`.
+- `#` inside a quoted string is literal text, not a comment.
+- Commas inside quoted strings do not split args/params.
 
 ### `scene` — Scene Configuration
 
@@ -146,10 +157,10 @@ actor <name> = caption("<text>") at top | bottom | center
 | Type | Arguments | Notes |
 |---|---|---|
 | `sprite` | `assetName` | References a declared asset |
-| `text` | `"quoted string"` | Renders text label |
+| `text` | string literal | Renders text label |
 | `box` | *(none)* | 100×100 grey box |
 | `figure` | `skinColor [, gender [, face]]` | Emoji stick figure |
-| `caption` | `"quoted string"` | Auto-centered overlay text; see anchor syntax below |
+| `caption` | string literal | Auto-centered overlay text; see anchor syntax below |
 
 The actor name `camera` is **reserved**. Never declare `actor camera = ...` — reference `camera.pan`, `camera.zoom`, `camera.shake` directly in events.
 
@@ -582,7 +593,9 @@ Other ready-to-use preset names: `explainer`, `reaction`, `pov`, `chat_bubble`, 
 | Using `#comment` inside `var` value | `var` lines skip comment stripping — `#hex` is safe |
 | Referencing actor before declaration | Move `actor` line above the `@time` event |
 | Using `punch`/`kick`/`face`/`jump`/`bounce` on non-figure | These only work on `figure` actors |
-| Missing quotes on `say` text | `say("text")` — text must be quoted |
+| Missing quotes on `say` text | `say("text")` or `say('text')` |
+| Quote conflicts inside strings | Escape inner quote: `\"` or `\'` |
+| Windows/file paths lose backslashes | Escape slashes: `"C:\\\\work\\\\scene"` |
 | Forgetting `$` in seq body | Use `$` not the actor name: `@+0.0: $.action(...)` |
 | Using absolute `@time` in seq | Use relative `@+offset` inside seq blocks |
 | Putting multiple statements on one line | One statement per line |

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -29,6 +29,18 @@ scene width=1024 height=576 fps=60 bg=#1a1a2e
 
 ---
 
+## String literals and escaping
+
+Markdy supports both double-quoted (`"..."`) and single-quoted (`'...'`) string literals.
+
+- Use `\"` or `\'` to include quote characters inside strings.
+- Use `\\` for a literal backslash.
+- `\n`, `\r`, and `\t` are supported.
+- `#` inside quoted strings is treated as text, not a comment.
+- Commas inside quoted strings do not split argument lists.
+
+---
+
 ## Asset declarations
 
 ```markdy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdy",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "An open-source animation DSL engine. Write MarkdyScript, get animated scenes in the browser.",
   "license": "MIT",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/astro",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Astro island component for MarkdyScript animations.",
   "license": "MIT",
   "type": "module",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/compat",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "private": true,
   "description": "Backwards-compatibility gate for MarkdyScript. Snapshots every fixture in packages/compat/fixtures with the current parser and diffs ASTs on every CI run.",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/core",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "MarkdyScript parser and AST types — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -43,12 +43,17 @@ export class ParseError extends Error {
  */
 function stripComment(line: string): string {
   let depth = 0;
-  let inString = false;
+  let stringQuote: '"' | "'" | null = null;
   let lastNonSpace = "";
   for (let i = 0; i < line.length; i++) {
     const ch = line[i];
-    if (ch === '"') { inString = !inString; lastNonSpace = ch; continue; }
-    if (inString) continue;
+    if ((ch === '"' || ch === "'") && !isEscapedChar(line, i)) {
+      if (stringQuote === ch) stringQuote = null;
+      else if (stringQuote === null) stringQuote = ch;
+      lastNonSpace = ch;
+      continue;
+    }
+    if (stringQuote !== null) continue;
     if (ch === '(') { depth++; lastNonSpace = ch; continue; }
     if (ch === ')') { depth--; lastNonSpace = ch; continue; }
     if (ch === '#' && depth === 0 && lastNonSpace !== '=') return line.slice(0, i);
@@ -65,12 +70,16 @@ function stripComment(line: string): string {
 function splitByComma(s: string): string[] {
   const parts: string[] = [];
   let depth = 0;
-  let inString = false;
+  let stringQuote: '"' | "'" | null = null;
   let start = 0;
   for (let i = 0; i < s.length; i++) {
     const ch = s[i];
-    if (ch === '"') { inString = !inString; continue; }
-    if (inString) continue;
+    if ((ch === '"' || ch === "'") && !isEscapedChar(s, i)) {
+      if (stringQuote === ch) stringQuote = null;
+      else if (stringQuote === null) stringQuote = ch;
+      continue;
+    }
+    if (stringQuote !== null) continue;
     if (ch === "(") depth++;
     else if (ch === ")") depth--;
     else if (ch === "," && depth === 0) {
@@ -92,8 +101,9 @@ function splitByComma(s: string): string[] {
 function parseValue(s: string): unknown {
   const t = s.trim();
 
-  if (t.startsWith('"') && t.endsWith('"')) {
-    return t.slice(1, -1);
+  const quoted = parseQuotedLiteral(t);
+  if (quoted !== null) {
+    return quoted;
   }
 
   if (t.startsWith("(") && t.endsWith(")")) {
@@ -109,6 +119,60 @@ function parseValue(s: string): unknown {
   if (!Number.isNaN(n) && t !== "") return n;
 
   return t;
+}
+
+/**
+ * Returns true when the character at `idx` is escaped by an odd number of
+ * immediately preceding backslashes.
+ */
+function isEscapedChar(s: string, idx: number): boolean {
+  let slashCount = 0;
+  for (let i = idx - 1; i >= 0 && s[i] === "\\"; i--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
+}
+
+/**
+ * Parses a wrapped string literal (`"..."` or `'...'`) and unescapes common
+ * escape sequences. Returns null for non-literals.
+ */
+function parseQuotedLiteral(token: string): string | null {
+  if (token.length < 2) return null;
+  const quote = token[0];
+  if ((quote !== '"' && quote !== "'") || token[token.length - 1] !== quote) {
+    return null;
+  }
+  if (isEscapedChar(token, token.length - 1)) {
+    return null;
+  }
+  return unescapeQuotedContent(token.slice(1, -1), quote);
+}
+
+function unescapeQuotedContent(content: string, quote: '"' | "'"): string {
+  let out = "";
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i];
+    if (ch !== "\\") {
+      out += ch;
+      continue;
+    }
+
+    if (i + 1 >= content.length) {
+      out += "\\";
+      continue;
+    }
+
+    const next = content[++i];
+    if (next === "n") out += "\n";
+    else if (next === "r") out += "\r";
+    else if (next === "t") out += "\t";
+    else if (next === "\\") out += "\\";
+    else if (next === quote) out += quote;
+    else if (next === '"' || next === "'") out += next;
+    else out += `\\${next}`;
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
@@ -805,7 +869,8 @@ function parseActorCallArgs(argsRaw: string): string[] {
   if (!argsRaw.trim()) return [];
   return splitByComma(argsRaw).map((a) => {
     const t = a.trim();
-    return t.startsWith('"') && t.endsWith('"') ? t.slice(1, -1) : t;
+    const q = parseQuotedLiteral(t);
+    return q ?? t;
   });
 }
 
@@ -1148,7 +1213,8 @@ function tryExpandSolePreset(source: string): string | null {
   const args = argsRaw
     ? splitByComma(argsRaw).map((a) => {
         const t = a.trim();
-        return t.startsWith('"') && t.endsWith('"') ? t.slice(1, -1) : t;
+        const q = parseQuotedLiteral(t);
+        return q ?? t;
       })
     : [];
   return fn(args);

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -404,6 +404,37 @@ describe("var declarations", () => {
   });
 });
 
+describe("string escaping robustness", () => {
+  it("keeps escaped quotes/hash/comma inside quoted params", () => {
+    const ast = parse([
+      "actor h = figure(#c68642, m, 😎) at (0,0)",
+      '@0.0: h.say("He said \\"ship it, #now\\"", dur=0.5)',
+    ].join("\n"));
+    expect(ast.events[0].params.text).toBe('He said "ship it, #now"');
+  });
+
+  it("supports escaped backslashes in quoted actor args", () => {
+    const ast = parse(
+      'actor path = text("C:\\\\work\\\\markdy\\\\scene") at (0,0)',
+    );
+    expect(ast.actors.path.args[0]).toBe("C:\\work\\markdy\\scene");
+  });
+
+  it("accepts single-quoted literals in args and params", () => {
+    const ast = parse([
+      "actor t = text('hello, world') at (0,0)",
+      "@0.0: t.say('done', dur=0.3)",
+    ].join("\n"));
+    expect(ast.actors.t.args[0]).toBe("hello, world");
+    expect(ast.events[0].params.text).toBe("done");
+  });
+
+  it("preserves unknown escapes instead of silently dropping backslashes", () => {
+    const ast = parse('actor t = text("price \\\\$5") at (0,0)');
+    expect(ast.actors.t.args[0]).toBe("price \\$5");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Def (user-defined actor templates)
 // ---------------------------------------------------------------------------

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/renderer-dom",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "description": "Web Animations API renderer for MarkdyScript scenes.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- harden MarkdyScript escaping and quoted-string parsing in @markdy/core
- support single-quoted string literals and robust escaped quote handling
- add regression tests for escaped quotes/backslashes/hash/comma cases
- update docs/AGENT.md and docs/SYNTAX.md for new escaping rules
- bump root + workspace versions to 0.7.9 and add changelog entry

## Validation
- pnpm run build
- pnpm run test
- pnpm run lint