### PR TITLE
chore: release v0.7.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.16] — 2026-07-19
+
+### Changed
+- **Homepage layout polish** — Rebalanced the package showcase into a more intentional desktop/tablet layout so the section no longer leaves an awkward orphan card row.
+- **Playground UX cleanup** — Improved the homepage playground copy, source-link labeling, preview spacing, and stage scaling so examples fit more comfortably and read more clearly.
+- **Mobile landing-page refinement** — Tightened the hero, CTA stack, and usage tabs/code sample on small screens to improve above-the-fold density and readability.
+
+### Fixed
+- **Website example loading** — Made homepage example-file loading work consistently in both `astro dev` and `astro build` environments.
+
 ## [0.7.15] — 2026-07-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdy",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "private": true,
   "description": "An open-source animation DSL engine. Write MarkdyScript, get animated scenes in the browser.",
   "license": "MIT",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/astro",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Astro island component for MarkdyScript animations.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/cli",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "First-party CLI for MarkdyScript: lint, format, explain, render, and local playground tooling.",
   "license": "MIT",
   "type": "module",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/compat",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "private": true,
   "description": "Backwards-compatibility gate for MarkdyScript. Snapshots every fixture in packages/compat/fixtures with the current parser and diffs ASTs on every CI run.",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/core",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "MarkdyScript parser and AST types — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/markdy-language-server/package.json
+++ b/packages/markdy-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/language-server",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Language Server Protocol implementation for MarkdyScript.",
   "license": "MIT",
   "type": "module",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/mdx",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "MDX integration plugin and lightweight React player for Markdy.",
   "license": "MIT",
   "type": "module",

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/renderer-dom",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Web Animations API renderer for MarkdyScript scenes.",
   "license": "MIT",
   "type": "module",

--- a/packages/stdlib-systems/package.json
+++ b/packages/stdlib-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/stdlib-systems",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "System diagram actor/action pack for Markdy.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump workspace and package versions to 0.7.16
- release the homepage UI/UX refinements
- update changelog notes for this release

## Validation
- pnpm run build
- pnpm run lint
- pnpm run test