### PR TITLE
chore: release v0.7.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.17] — 2026-07-19
+
+### Added
+- **Restored homepage default scene** — Brought back the original Love Story example as a shipped scene file and made it the default playground example again.
+
+### Changed
+- **Homepage example curation** — Reduced the homepage example picker to a smaller, stronger set of scenes so the sidebar focuses on the best demos.
+- **Preview sizing behavior** — Adjusted the playground preview to scale scenes up while preserving their original aspect ratio, rather than using a crop/zoom style fill.
+- **Default preview framing** — Start the Love Story default example from a more meaningful moment so the preview is visually informative on first load.
+
 ## [0.7.16] — 2026-07-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdy",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "private": true,
   "description": "An open-source animation DSL engine. Write MarkdyScript, get animated scenes in the browser.",
   "license": "MIT",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/astro",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Astro island component for MarkdyScript animations.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/cli",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "First-party CLI for MarkdyScript: lint, format, explain, render, and local playground tooling.",
   "license": "MIT",
   "type": "module",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/compat",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "private": true,
   "description": "Backwards-compatibility gate for MarkdyScript. Snapshots every fixture in packages/compat/fixtures with the current parser and diffs ASTs on every CI run.",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/core",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "MarkdyScript parser and AST types — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/markdy-language-server/package.json
+++ b/packages/markdy-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/language-server",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Language Server Protocol implementation for MarkdyScript.",
   "license": "MIT",
   "type": "module",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/mdx",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "MDX integration plugin and lightweight React player for Markdy.",
   "license": "MIT",
   "type": "module",

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/renderer-dom",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Web Animations API renderer for MarkdyScript scenes.",
   "license": "MIT",
   "type": "module",

--- a/packages/stdlib-systems/package.json
+++ b/packages/stdlib-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/stdlib-systems",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "System diagram actor/action pack for Markdy.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump workspace and package versions to 0.7.17
- restore the Love Story homepage default example
- refine preview sizing while preserving original scene ratios
- update release notes for this patch

## Validation
- pnpm run build
- pnpm run lint
- pnpm run test