### PR TITLE
feat(website): curate homepage showcase

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# Copilot instructions for this repository
+
+- When the user says `ship it`, `release it`, or gives shorthand like `commit, PR, merge, release, tag it`, interpret that as a request to run the full shipping workflow for the current completed changes.
+- The default shipping workflow for this repo is:
+  1. validate the current change with the existing project checks
+  2. commit the finished product changes with a repo-style commit message
+  3. open a PR and wait for checks
+  4. merge the PR once checks pass
+  5. cut the next patch release with `pnpm run release <next-version>`
+  6. ensure `CHANGELOG.md` contains concrete release notes before the release commit is created
+  7. push the version tag and confirm the GitHub Release workflow succeeds
+- Prefer the existing release automation in [scripts/release.sh](/Users/yell/Projects/markdy-com/scripts/release.sh) instead of manually stitching together a release flow.
+- Keep the homepage example picker curated. Favor the strongest showcase scenes and avoid cluttering the homepage with weak, repetitive, or overly diagnostic examples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.18] — 2026-07-19
+
+### Changed
+- **Love Story default refresh** — Replaced the older homepage Love Story with the newer chapter-based `Full Story` variant from recent history so the default demo is once again the best version.
+- **Homepage example curation** — Reduced the playground picker to a tighter showcase of five stronger demos: Love Story, Feature Tour, Fight Beat, @+ Timing, and Modifiers.
+- **Copilot shipping shortcut** — Added repo-level Copilot instructions so short prompts like `ship it` can map to the full commit, PR, merge, release, and tag workflow for this repository.
+
 ## [0.7.17] — 2026-07-19
 
 ### Added

--- a/examples/00-love-story.markdy
+++ b/examples/00-love-story.markdy
@@ -1,4 +1,4 @@
-# The original love story scene — keep this as the default homepage example.
+# The newest Love Story / Full Story variant from recent history.
 scene width=800 height=400 fps=30 bg=#fafafa
 
 var skin_a = #c68642
@@ -13,62 +13,94 @@ def girl(skin, face) {
   figure(${skin}, f, ${face})
 }
 
-seq wave(arm, angle) {
-  @+0.0: $.rotate_part(part=${arm}, to=${angle}, dur=0.3)
-  @+0.3: $.rotate_part(part=${arm}, to=25, dur=0.3)
-}
-
 seq hit(side, power) {
   @+0.0: $.punch(side=${side}, dur=0.3)
   @+0.05: $.shake(intensity=${power}, dur=0.3)
 }
 
-actor bruno = fighter(${skin_a}, 😏) at (640, 180)
-actor alex  = fighter(${skin_b}, 😤) at (100, 180)
-actor lily  = girl(${skin_g}, 😊) at (370, 180) opacity 0
+actor act1 = caption("I. Boys See Girl") at top opacity 0
+actor act2 = caption("II. Boys Fight") at top opacity 0
+actor act3 = caption("III. Girl Says No") at top opacity 0
+actor act4 = caption("IV. Girl Picks the Loser") at top opacity 0
 
-@0.0: lily.fade_in(dur=0.7)
-@0.8: bruno.enter(from=right, dur=0.8)
-@1.0: alex.enter(from=left, dur=0.8)
-@2.0: bruno.play(wave, arm=arm_left, angle=-80)
-@2.0: alex.play(wave, arm=arm_right, angle=80)
-@3.0: bruno.face("😍")
-@3.0: alex.face("😍")
-@3.1: bruno.say("I love you! 😍", dur=1.4)
-@3.5: alex.say("She is mine! 😤", dur=1.4)
-@5.0: lily.face("😳")
-@5.0: lily.say("Oh my... 😳", dur=1.1)
-@6.5: lily.move(to=(700, 180), dur=0.5, ease=out)
-@7.0: bruno.face("😠")
-@7.0: alex.face("😠")
-@7.0: bruno.move(to=(400, 180), dur=0.6, ease=in)
-@7.0: alex.move(to=(320, 180), dur=0.6, ease=in)
-@7.8: bruno.play(hit, side=left, power=7)
-@7.8: alex.play(hit, side=right, power=7)
-@8.3: alex.kick(side=right, dur=0.35)
-@8.4: bruno.shake(intensity=9, dur=0.3)
-@8.6: bruno.play(hit, side=left, power=9)
-@9.4: bruno.punch(side=left, dur=0.25)
-@9.5: alex.shake(intensity=12, dur=0.4)
-@9.5: alex.face("😵")
-@10.0: alex.rotate(to=90, dur=0.4)
-@10.2: alex.fade_out(dur=0.4)
-@10.0: bruno.face("😁")
-@10.0: bruno.say("I win! 💪", dur=1.5)
-@11.5: bruno.face("🥰")
-@11.5: bruno.move(to=(520, 180), dur=0.8, ease=out)
-@14.0: lily.face("🙅")
-@14.0: lily.say("No thanks. 🙅", dur=2.0)
-@14.1: lily.shake(intensity=5, dur=0.4)
-@16.0: bruno.face("😢")
-@16.2: bruno.say("But I fought! 😢", dur=1.4)
-@17.0: bruno.move(to=(750, 180), dur=1.0, ease=in)
-@18.0: alex.fade_in(dur=0.7)
-@18.5: lily.face("🥺")
-@18.5: lily.move(to=(380, 280), dur=0.8, ease=out)
-@19.5: lily.face("🤗")
-@19.5: lily.say("Hey, you okay? 💕", dur=2.0)
-@20.0: alex.face("🥺")
-@20.0: alex.say("You came... 🥺", dur=1.8)
-@22.0: bruno.face("😔")
-@22.0: bruno.say("...why 😔", dur=2.0)
+actor chad = fighter(${skin_a}, 😏) at (640, 180)
+actor kevin = fighter(${skin_b}, 😤) at (100, 180)
+actor mia = girl(${skin_g}, 👧) at (370, 180) opacity 0
+actor bush = text("🪨") at (50, 285) size 80 opacity 0
+
+scene "rivals" {
+  @+0.0: act1.fade_in(dur=0.3)
+  @+0.1: mia.fade_in(dur=0.5)
+  @+0.0: chad.enter(from=right, dur=0.6)
+  @+0.0: kevin.enter(from=left, dur=0.6)
+  @+0.2: chad.wave(side=left, dur=0.5)
+  @+0.0: kevin.wave(side=right, dur=0.5)
+  @+0.2: chad.face("😍")
+  @+0.0: kevin.face("😍")
+  @+0.2: chad.say("Hey gorgeous 😘", dur=1.3)
+  @+0.3: kevin.say("Back off, she's mine!", dur=1.3)
+  @+0.6: act1.fade_out(dur=0.3)
+  @+0.1: mia.face("😳")
+  @+0.2: mia.say("…do I get a say?", dur=1.2)
+  @+0.4: mia.move(to=(600, 180), dur=0.5, ease=out)
+}
+
+scene "duel" {
+  @+0.0: act2.fade_in(dur=0.3)
+  @+0.3: chad.face("😠")
+  @+0.0: kevin.face("😠")
+  @+0.1: chad.move(to=(400, 180), dur=0.5, ease=in)
+  @+0.0: kevin.move(to=(320, 180), dur=0.5, ease=in)
+  @+0.3: act2.fade_out(dur=0.3)
+  @+0.2: kevin.say("En garde, bro!", dur=1.0)
+  @+0.3: chad.play(hit, side=left, power=7)
+  @+0.0: camera.shake(intensity=6, dur=0.3)
+  @+0.1: kevin.play(hit, side=right, power=7)
+  @+0.2: kevin.kick(side=right, dur=0.3)
+  @+0.0: chad.shake(intensity=9, dur=0.3)
+  @+0.2: chad.say("Is that all?", dur=0.9)
+  @+0.9: chad.punch(side=left, dur=0.25)
+  @+0.0: camera.shake(intensity=16, dur=0.5)
+  @+0.0: kevin.face("😵")
+  @+0.0: bush.fade_in(dur=0.2)
+  @+0.1: kevin.move(to=(110, 275), dur=0.55, ease=out)
+  @+0.0: kevin.rotate(to=-80, dur=0.55, ease=out)
+  @+0.4: bush.shake(intensity=7, dur=0.4)
+  @+0.0: bush.fade_out(dur=0.3)
+  @+0.0: kevin.face("🤕")
+  @+0.3: chad.face("😎")
+  @+0.2: chad.say("Too easy. She's mine!", dur=1.4)
+}
+
+scene "rejection" {
+  @+0.0: act3.fade_in(dur=0.3)
+  @+0.3: chad.face("🥰")
+  @+0.0: chad.move(to=(520, 180), dur=0.6, ease=out)
+  @+0.5: chad.say("My queen 👑", dur=1.1)
+  @+0.3: mia.face("🙅")
+  @+0.2: mia.say("Hard pass.", dur=1.1)
+  @+0.0: mia.shake(intensity=5, dur=0.4)
+  @+0.4: act3.fade_out(dur=0.3)
+  @+0.1: chad.face("😨")
+  @+0.2: chad.say("But… I WON??", dur=1.3)
+  @+0.4: mia.face("😒")
+  @+0.2: mia.say("That's the problem.", dur=1.4)
+  @+0.6: chad.face("😭")
+  @+0.4: chad.exit(to=right, dur=0.8)
+}
+
+scene "aftermath" {
+  @+0.0: act4.fade_in(dur=0.3)
+  @+0.2: mia.face("🥺")
+  @+0.1: mia.move(to=(230, 210), dur=1.2, ease=out)
+  @+0.0: camera.pan(to=(100, 345), dur=1.2, ease=out)
+  @+0.0: camera.zoom(to=1.3, dur=1.2, ease=out)
+  @+0.6: act4.fade_out(dur=0.3)
+  @+0.3: mia.face("😊")
+  @+0.2: mia.say("You okay down there?", dur=1.6)
+  @+0.2: kevin.face("🥲")
+  @+0.2: kevin.face("🥹")
+  @+0.2: kevin.say("Mission failed…", dur=1.3)
+  @+0.2: kevin.say("…successfully. 💖", dur=1.6)
+  @+0.2: mia.face("😘")
+}

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -14,24 +14,29 @@ type PlaygroundExample = {
   previewStart?: number;
 };
 
-const PLAYGROUND_EXAMPLE_FILES = [
-  "00-love-story.markdy",
-  "02-at-plus-shorthand.markdy",
-  "03-chapters.markdy",
-  "06-camera-shake.markdy",
-  "09-exit-action.markdy",
-  "10-unified-modifiers.markdy",
-  "13-combined.markdy",
-  "15-must-understand.markdy",
-];
-
-function titleizeExample(fileName: string): string {
-  const base = fileName.replace(/^\d+-/, "").replace(/\.markdy$/, "");
-  return base
-    .split("-")
-    .map((part) => part === "at" ? "@+" : part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
+const PLAYGROUND_EXAMPLES = [
+  {
+    fileName: "00-love-story.markdy",
+    label: "Love Story",
+    previewStart: 3.2,
+  },
+  {
+    fileName: "13-combined.markdy",
+    label: "Feature Tour",
+  },
+  {
+    fileName: "06-camera-shake.markdy",
+    label: "Fight Beat",
+  },
+  {
+    fileName: "02-at-plus-shorthand.markdy",
+    label: "@+ Timing",
+  },
+  {
+    fileName: "10-unified-modifiers.markdy",
+    label: "Modifiers",
+  },
+] as const;
 
 function firstCommentDescription(code: string): string {
   const first = code.split(/\r?\n/).find((line) => line.trim().startsWith("#"));
@@ -39,16 +44,16 @@ function firstCommentDescription(code: string): string {
 }
 
 const EXAMPLES: PlaygroundExample[] = await Promise.all(
-  PLAYGROUND_EXAMPLE_FILES.map(async (fileName) => {
+  PLAYGROUND_EXAMPLES.map(async ({ fileName, label, previewStart }) => {
     const sourcePath = `examples/${fileName}`;
     const code = await readFile(join(ROOT, sourcePath), "utf8");
     return {
-      label: titleizeExample(fileName),
+      label,
       sourcePath,
       sourceUrl: `https://github.com/HoangYell/markdy-com/blob/main/${sourcePath}`,
       description: firstCommentDescription(code),
       code,
-      previewStart: fileName === "00-love-story.markdy" ? 3.2 : 0,
+      previewStart: previewStart ?? 0,
     };
   }),
 );


### PR DESCRIPTION
## Summary
- restore the newer Full Story Love Story scene as the homepage default
- trim the homepage picker to a smaller curated showcase with clearer labels
- add a repo-level Copilot shipping shortcut so `ship it` can trigger the full workflow

## Validation
- pnpm run build
- pnpm run lint
- pnpm run test