### PR TITLE
Rework figure() gender rendering + rewrite the love-story showcase

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -169,8 +169,8 @@ The actor name `camera` is **reserved**. Never declare `actor camera = ...` — 
 | Position | Name | Type | Default | Valid values |
 |---|---|---|---|---|
 | 1 | skinColor | CSS colour | `#ffdbac` | Any hex/named colour |
-| 2 | gender | string | `m` | `m`, `f` |
-| 3 | face | emoji | `😶` (m) / `🙂` (f) | Any single emoji |
+| 2 | gender | string | `x` | `f`, `m`, `x` (anything else falls back to `x`) — sets the torso: 👗 (f), 👔 (m), 👕 (x) |
+| 3 | face | emoji | `🙂` | Any single emoji |
 
 **Caption positioning:** captions use anchor keywords (`at top | bottom | center`) instead of numeric coordinates. They're auto-centered horizontally (`x = scene.width / 2`) and placed at `~12%` / `~88%` / `50%` of scene height respectively. Numeric `at (x, y)` is a `ParseError` for captions; anchor syntax on non-captions is a `ParseError` too.
 

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -84,9 +84,9 @@ Actors are the objects visible in the scene. They must be declared before any ev
 Figures are emoji-based stick figures with named body parts that can be individually animated.
 
 ```markdy
-actor guy  = figure(#c68642)           at (100, 200)    # male, default face 😶
-actor gal  = figure(#fad4c0, f)        at (300, 200)    # female variant, default face 🙂
-actor hero = figure(#c68642, m, 😎)   at (500, 200)    # custom starting face
+actor guy  = figure(#c68642)           at (100, 200)    # gender defaults to x, shirt 👕
+actor gal  = figure(#fad4c0, f)        at (300, 200)    # gender = f, dress 👗
+actor hero = figure(#c68642, m, 😎)   at (500, 200)    # gender = m, necktie 👔; custom starting face
 ```
 
 **Arguments** (positional, inside the parentheses):
@@ -94,8 +94,8 @@ actor hero = figure(#c68642, m, 😎)   at (500, 200)    # custom starting face
 | Position | Name | Default | Description |
 |---|---|---|---|
 | 1 | `skinColor` | `#ffdbac` | CSS colour for skin (neck, arm sticks) |
-| 2 | `gender` | `m` | `m` = male (👕🤜👟), `f` = female (👗💅👠) |
-| 3 | `face` | `😶` (m) / `🙂` (f) | Starting emoji expression |
+| 2 | `gender` | `x` | `f` \| `m` \| `x` (any other value falls back to `x`). Sets the torso: 👗 (f), 👔 (m), 👕 (x) |
+| 3 | `face` | `🙂` | Starting emoji expression |
 
 **Named body parts** (used by `rotate_part`, `punch`, `kick`):
 
@@ -103,7 +103,7 @@ actor hero = figure(#c68642, m, 😎)   at (500, 200)    # custom starting face
 |---|---|---|
 | `head` | `data-fig-head` | The emoji face span |
 | `face` | `data-fig-face` | Same element (alias) |
-| `body` | `data-fig-body` | Torso emoji (👕 or 👗) |
+| `body` | `data-fig-body` | Torso emoji (👗/👔/👕, by gender) |
 | `arm_left` | `data-fig-arm-l` | Left arm (pivot: shoulder) |
 | `arm_right` | `data-fig-arm-r` | Right arm (pivot: shoulder) |
 | `leg_left` | `data-fig-leg-l` | Left leg (pivot: hip) |

--- a/examples/00-love-story.markdy
+++ b/examples/00-love-story.markdy
@@ -3,14 +3,10 @@ scene width=800 height=400 fps=30 bg=#fafafa
 
 var skin_a = #c68642
 var skin_b = #8d5524
-var skin_g = #fad4c0
+var skin_c = #fad4c0
 
-def fighter(skin, face) {
-  figure(${skin}, m, ${face})
-}
-
-def girl(skin, face) {
-  figure(${skin}, f, ${face})
+def person(skin, gender, face) {
+  figure(${skin}, ${gender}, ${face})
 }
 
 seq hit(side, power) {
@@ -18,89 +14,96 @@ seq hit(side, power) {
   @+0.05: $.shake(intensity=${power}, dur=0.3)
 }
 
-actor act1 = caption("I. Boys See Girl") at top opacity 0
-actor act2 = caption("II. Boys Fight") at top opacity 0
-actor act3 = caption("III. Girl Says No") at top opacity 0
-actor act4 = caption("IV. Girl Picks the Loser") at top opacity 0
+actor act1 = caption("I. Alice and Bob See Charlie") at top opacity 0
+actor act2 = caption("II. Alice and Bob Fight") at top opacity 0
+actor act3 = caption("III. Charlie Says No") at top opacity 0
+actor act4 = caption("IV. Charlie Picks Themself") at top opacity 0
 
-actor chad = fighter(${skin_a}, 😏) at (640, 180)
-actor kevin = fighter(${skin_b}, 😤) at (100, 180)
-actor mia = girl(${skin_g}, 👧) at (370, 180) opacity 0
+actor alice = person(${skin_a}, f, 😏) at (640, 180)
+actor bob = person(${skin_b}, m, 😤) at (100, 180)
+actor charlie = person(${skin_c}, x, 🙂) at (370, 180) opacity 0
 actor bush = text("🪨") at (50, 285) size 80 opacity 0
 
 scene "rivals" {
   @+0.0: act1.fade_in(dur=0.3)
-  @+0.1: mia.fade_in(dur=0.5)
-  @+0.0: chad.enter(from=right, dur=0.6)
-  @+0.0: kevin.enter(from=left, dur=0.6)
-  @+0.2: chad.wave(side=left, dur=0.5)
-  @+0.0: kevin.wave(side=right, dur=0.5)
-  @+0.2: chad.face("😍")
-  @+0.0: kevin.face("😍")
-  @+0.2: chad.say("Hey gorgeous 😘", dur=1.3)
-  @+0.3: kevin.say("Back off, she's mine!", dur=1.3)
+  @+0.1: charlie.fade_in(dur=0.5)
+  @+0.0: alice.enter(from=right, dur=0.6)
+  @+0.0: bob.enter(from=left, dur=0.6)
+  @+0.2: alice.wave(side=left, dur=0.5)
+  @+0.0: bob.wave(side=right, dur=0.5)
+  @+0.2: alice.face("😍")
+  @+0.0: bob.face("😍")
+  @+0.2: alice.say("Hey gorgeous 😘", dur=1.3)
+  @+0.3: bob.say("Back off, they're mine!", dur=1.3)
   @+0.6: act1.fade_out(dur=0.3)
-  @+0.1: mia.face("😳")
-  @+0.2: mia.say("…do I get a say?", dur=1.2)
-  @+0.4: mia.move(to=(600, 180), dur=0.5, ease=out)
+  @+0.1: charlie.face("😳")
+  @+0.2: charlie.say("…do I get a say?", dur=1.2)
+  @+0.4: charlie.move(to=(600, 180), dur=0.5, ease=out)
 }
 
 scene "duel" {
   @+0.0: act2.fade_in(dur=0.3)
-  @+0.3: chad.face("😠")
-  @+0.0: kevin.face("😠")
-  @+0.1: chad.move(to=(400, 180), dur=0.5, ease=in)
-  @+0.0: kevin.move(to=(320, 180), dur=0.5, ease=in)
+  @+0.3: alice.face("😠")
+  @+0.0: bob.face("😠")
+  @+0.1: alice.move(to=(400, 180), dur=0.5, ease=in)
+  @+0.0: bob.move(to=(320, 180), dur=0.5, ease=in)
   @+0.3: act2.fade_out(dur=0.3)
-  @+0.2: kevin.say("En garde, bro!", dur=1.0)
-  @+0.3: chad.play(hit, side=left, power=7)
+  @+0.2: bob.say("En garde!", dur=1.0)
+  @+0.3: alice.play(hit, side=left, power=7)
   @+0.0: camera.shake(intensity=6, dur=0.3)
-  @+0.1: kevin.play(hit, side=right, power=7)
-  @+0.2: kevin.kick(side=right, dur=0.3)
-  @+0.0: chad.shake(intensity=9, dur=0.3)
-  @+0.2: chad.say("Is that all?", dur=0.9)
-  @+0.9: chad.punch(side=left, dur=0.25)
+  @+0.1: bob.play(hit, side=right, power=7)
+  @+0.2: bob.kick(side=right, dur=0.3)
+  @+0.0: alice.shake(intensity=9, dur=0.3)
+  @+0.2: alice.say("Is that all?", dur=0.9)
+  @+0.9: alice.punch(side=left, dur=0.25)
   @+0.0: camera.shake(intensity=16, dur=0.5)
-  @+0.0: kevin.face("😵")
+  @+0.0: bob.face("😵")
   @+0.0: bush.fade_in(dur=0.2)
-  @+0.1: kevin.move(to=(110, 275), dur=0.55, ease=out)
-  @+0.0: kevin.rotate(to=-80, dur=0.55, ease=out)
+  @+0.1: bob.move(to=(110, 275), dur=0.55, ease=out)
+  @+0.0: bob.rotate(to=-80, dur=0.55, ease=out)
   @+0.4: bush.shake(intensity=7, dur=0.4)
   @+0.0: bush.fade_out(dur=0.3)
-  @+0.0: kevin.face("🤕")
-  @+0.3: chad.face("😎")
-  @+0.2: chad.say("Too easy. She's mine!", dur=1.4)
+  @+0.0: bob.face("🤕")
+  @+0.3: alice.face("😎")
+  @+0.2: alice.say("Too easy. They're mine!", dur=1.4)
 }
 
 scene "rejection" {
   @+0.0: act3.fade_in(dur=0.3)
-  @+0.3: chad.face("🥰")
-  @+0.0: chad.move(to=(520, 180), dur=0.6, ease=out)
-  @+0.5: chad.say("My queen 👑", dur=1.1)
-  @+0.3: mia.face("🙅")
-  @+0.2: mia.say("Hard pass.", dur=1.1)
-  @+0.0: mia.shake(intensity=5, dur=0.4)
+  @+0.3: alice.face("🥰")
+  @+0.0: alice.move(to=(520, 180), dur=0.6, ease=out)
+  @+0.5: alice.say("You're the prize 🏆", dur=1.1)
+  @+0.3: charlie.face("🙅")
+  @+0.2: charlie.say("Hard pass.", dur=1.1)
+  @+0.0: charlie.shake(intensity=5, dur=0.4)
   @+0.4: act3.fade_out(dur=0.3)
-  @+0.1: chad.face("😨")
-  @+0.2: chad.say("But… I WON??", dur=1.3)
-  @+0.4: mia.face("😒")
-  @+0.2: mia.say("That's the problem.", dur=1.4)
-  @+0.6: chad.face("😭")
-  @+0.4: chad.exit(to=right, dur=0.8)
+  @+0.1: alice.face("😨")
+  @+0.2: alice.say("But… I WON??", dur=1.3)
+  @+0.4: charlie.face("😒")
+  @+0.2: charlie.say("I'm not a trophy, Alice.", dur=1.4)
+  @+0.6: alice.face("😭")
+  @+0.4: alice.exit(to=right, dur=0.8)
 }
 
 scene "aftermath" {
   @+0.0: act4.fade_in(dur=0.3)
-  @+0.2: mia.face("🥺")
-  @+0.1: mia.move(to=(230, 210), dur=1.2, ease=out)
+  @+0.2: charlie.face("🥺")
+  @+0.1: charlie.move(to=(230, 210), dur=1.2, ease=out)
   @+0.0: camera.pan(to=(100, 345), dur=1.2, ease=out)
   @+0.0: camera.zoom(to=1.3, dur=1.2, ease=out)
   @+0.6: act4.fade_out(dur=0.3)
-  @+0.3: mia.face("😊")
-  @+0.2: mia.say("You okay down there?", dur=1.6)
-  @+0.2: kevin.face("🥲")
-  @+0.2: kevin.face("🥹")
-  @+0.2: kevin.say("Mission failed…", dur=1.3)
-  @+0.2: kevin.say("…successfully. 💖", dur=1.6)
-  @+0.2: mia.face("😘")
+  @+0.3: charlie.face("😊")
+  @+0.2: charlie.say("You okay down there?", dur=1.6)
+  @+0.2: bob.face("🥲")
+  @+0.2: bob.say("Mission failed. But I'm okay.", dur=1.6)
+  @+0.2: charlie.face("🙂")
+  @+0.2: charlie.say("Glad to hear.", dur=1.2)
+  @+0.3: bob.rotate(to=0, dur=0.6, ease=out)
+  @+0.0: bob.move(to=(160, 275), dur=0.6, ease=out)
+  @+0.1: bob.face("🙂")
+  @+0.3: bob.exit(to=left, dur=0.6)
+  @+0.0: camera.pan(to=(230, 210), dur=1.0, ease=out)
+  @+0.2: charlie.say("Turns out…", dur=1.0)
+  @+0.2: charlie.say("I'm my own ending. 💛", dur=1.4)
+  @+0.2: charlie.face("😌")
 }

--- a/examples/01-caption-basic.markdy
+++ b/examples/01-caption-basic.markdy
@@ -2,7 +2,7 @@
 scene width=800 height=400 bg=#111
 
 actor header = caption("hello, markdy") at top
-actor hero   = figure(#c68642, m, 😎) at (400, 280)
+actor hero   = figure(#c68642, f, 😎) at (400, 280)
 
 @0.0: header.fade_in(dur=0.4)
 @0.4: hero.enter(from=bottom, dur=0.6)

--- a/examples/02-at-plus-shorthand.markdy
+++ b/examples/02-at-plus-shorthand.markdy
@@ -1,7 +1,7 @@
 # @+N: shorthand — "N seconds after the previous event's end"
 scene width=800 height=400
 
-actor hero = figure(#c68642, m, 🙂) at (200, 240)
+actor hero = figure(#c68642, x, 🙂) at (200, 240)
 
 @0.0:  hero.enter(from=left, dur=0.5)
 @+0.0: hero.say("look ma", dur=0.8)

--- a/examples/04-camera-pan.markdy
+++ b/examples/04-camera-pan.markdy
@@ -4,8 +4,8 @@
 scene width=1200 height=400 bg=#0d1117
 
 actor a = caption("left side") at top
-actor lf = figure(#c68642, m, 🙂) at (200, 260)
-actor rf = figure(#8d5524, m, 😎) at (1000, 260)
+actor lf = figure(#c68642, f, 🙂) at (200, 260)
+actor rf = figure(#8d5524, x, 😎) at (1000, 260)
 
 @0.0:  a.fade_in(dur=0.3)
 @0.3:  lf.enter(from=left, dur=0.5)

--- a/examples/05-camera-zoom.markdy
+++ b/examples/05-camera-zoom.markdy
@@ -3,7 +3,7 @@
 scene width=800 height=450 bg=#0d1117
 
 actor punchline = caption("wait for it") at center
-actor hero      = figure(#c68642, m, 🙂) at (400, 320)
+actor hero      = figure(#c68642, x, 🙂) at (400, 320)
 
 @0.0:  hero.enter(from=bottom, dur=0.5)
 @0.8:  punchline.fade_in(dur=0.4)

--- a/examples/06-camera-shake.markdy
+++ b/examples/06-camera-shake.markdy
@@ -1,8 +1,8 @@
 # camera.shake(intensity=N) — full-scene shake for impacts.
 scene width=800 height=400 bg=#111
 
-actor lf = figure(#c68642, m, 😤) at (260, 240)
-actor rf = figure(#8d5524, m, 😬) at (540, 240)
+actor lf = figure(#c68642, x, 😤) at (260, 240)
+actor rf = figure(#8d5524, f, 😬) at (540, 240)
 
 @0.0:  lf.enter(from=left, dur=0.4)
 @0.0:  rf.enter(from=right, dur=0.4)

--- a/examples/07-caption-bottom.markdy
+++ b/examples/07-caption-bottom.markdy
@@ -2,7 +2,7 @@
 scene width=720 height=720 bg=#111
 
 actor topline = caption("when the compat gate") at top
-actor hero    = figure(#c68642, m, 😎) at (360, 430)
+actor hero    = figure(#c68642, f, 😎) at (360, 430)
 actor botline = caption("stays green on every PR") at bottom
 
 @0.0: topline.fade_in(dur=0.3)

--- a/examples/09-exit-action.markdy
+++ b/examples/09-exit-action.markdy
@@ -1,7 +1,7 @@
 # exit(to=left|right|top|bottom) — mirror of enter: slides off-screen + fades.
 scene width=800 height=400
 
-actor hero = figure(#c68642, m, 🙂) at (400, 240)
+actor hero = figure(#c68642, x, 🙂) at (400, 240)
 actor bye  = caption("goodbye!") at top
 
 @0.0:  hero.enter(from=left, dur=0.5)

--- a/examples/11-soft-warn-unknown.markdy
+++ b/examples/11-soft-warn-unknown.markdy
@@ -4,7 +4,7 @@
 scene width=800 height=400
 
 # unknown-modifier: `fizzbuzz` is not a known modifier key.
-actor hero = figure(#c68642, m, 🙂) at (400, 240) with scale=1.0, fizzbuzz=true
+actor hero = figure(#c68642, f, 🙂) at (400, 240) with scale=1.0, fizzbuzz=true
 
 @0.0: hero.enter(from=left, dur=0.5)
 # unknown-action: `breakdance` is not a known action. The renderer no-ops it,

--- a/examples/12-figure-type-check.markdy
+++ b/examples/12-figure-type-check.markdy
@@ -4,7 +4,7 @@
 # parser hard-fail with a helpful message.
 scene width=800 height=400
 
-actor fighter = figure(#c68642, m, 😎) at (400, 240)
+actor fighter = figure(#c68642, x, 😎) at (400, 240)
 actor label   = text("legal") at (360, 80)
 
 @0.0:  fighter.enter(from=left, dur=0.4)

--- a/examples/15-must-understand.markdy
+++ b/examples/15-must-understand.markdy
@@ -3,7 +3,7 @@
 # Add the ! when you'd rather fail the build than ship a silent no-op.
 scene width=800 height=400
 
-actor hero = figure(#c68642, m, 🙂) at (400, 240)
+actor hero = figure(#c68642, x, 🙂) at (400, 240)
 
 @0.0:  hero.enter(from=left, dur=0.4)
 # Known action with !: no-op, always safe.

--- a/packages/renderer-dom/src/figure.ts
+++ b/packages/renderer-dom/src/figure.ts
@@ -20,21 +20,25 @@ import type { ActorDef } from "@markdy/core";
 //   data-fig-hip-r    — right hip joint
 //
 // DSL syntax:
-//   actor a = figure(#c68642)           at (x,y)   — male, default face 😶
-//   actor b = figure(#fad4c0, f)        at (x,y)   — female (skirt + bun)
-//   actor c = figure(#c68642, m, 😎)   at (x,y)   — custom starting face
+//   actor a = figure(#c68642)           at (x,y)   — gender defaults to x, shirt 👕
+//   actor b = figure(#fad4c0, f)        at (x,y)   — gender = f, dress 👗
+//   actor c = figure(#c68642, m, 😎)   at (x,y)   — gender = m, necktie 👔; custom starting face
+//   actor d = figure(#8d5524, x, 🙂)   at (x,y)   — gender = x (also the default), shirt 👕
+
+const TORSO_EMOJI: Record<"f" | "m" | "x", string> = { f: "👗", m: "👔", x: "👕" };
 
 export function createFigureEl(def: ActorDef): HTMLElement {
   const skinColor = def.args[0] || "#ffdbac";
-  const isFemale  = def.args[1] === "f";
-  const startFace = def.args[2] || (isFemale ? "🙂" : "😶");
+  const genderArg = def.args[1];
+  const gender: "f" | "m" | "x" = genderArg === "f" || genderArg === "m" ? genderArg : "x";
+  const startFace = def.args[2] || "🙂";
   // Use currentColor so leg sticks inherit the scene's text color
   // (dark on light backgrounds, light on dark backgrounds)
   const ink = "currentColor";
 
   const WRAP_W   = 80;
   const FACE_FS  = 40;
-  const SHIRT_FS = isFemale ? 48 : 44;
+  const SHIRT_FS = gender === "f" ? 48 : 44;
   // Estimated visual shirt width ≈ 90% of font-size on most platforms
   const vShirtW  = SHIRT_FS * 0.9;
   // Shoulder x within the shirt row div (centred at WRAP_W/2)
@@ -99,7 +103,7 @@ export function createFigureEl(def: ActorDef): HTMLElement {
 
   const torso = document.createElement("span");
   (torso.dataset as Record<string, string>).figBody = "";
-  torso.textContent = isFemale ? "👗" : "👕";
+  torso.textContent = TORSO_EMOJI[gender];
   Object.assign(torso.style, {
     fontSize:      `${SHIRT_FS}px`,
     lineHeight:    "1",
@@ -117,7 +121,7 @@ export function createFigureEl(def: ActorDef): HTMLElement {
   shirtRow.appendChild(shoulderR);
 
   // ── Arms ──────────────────────────────────────────────────────────────────
-  const armHandEmoji = isFemale ? "💅" : "🤜";
+  const armHandEmoji = "🤜";
 
   shirtRow.appendChild(
     buildArm("left", armHandEmoji, skinColor, {
@@ -125,7 +129,7 @@ export function createFigureEl(def: ActorDef): HTMLElement {
       anchorX: WRAP_W - shLx,
       anchorY: shY,
       restDeg: 20,
-      flipFist: !isFemale,
+      flipFist: true,
     }),
   );
   shirtRow.appendChild(
@@ -172,11 +176,12 @@ export function createFigureEl(def: ActorDef): HTMLElement {
     position:       "relative",
   });
 
-  const legL = buildLeg(true, isFemale, ink, skinColor, LEG_H, LEG_STICK_H, JOINT_SIZE);
-  const legR = buildLeg(false, isFemale, ink, skinColor, LEG_H, LEG_STICK_H, JOINT_SIZE);
+  const legL = buildLeg(true, ink, skinColor, LEG_H, LEG_STICK_H, JOINT_SIZE);
+  const legR = buildLeg(false, ink, skinColor, LEG_H, LEG_STICK_H, JOINT_SIZE);
   legsRow.append(legL, legR);
   hipRow.appendChild(legsRow);
 
+  wrap.dataset.figGender = gender;
   wrap.append(faceEl, neck, shirtRow, hipRow);
   return wrap;
 }
@@ -288,7 +293,6 @@ function buildArm(
 
 function buildLeg(
   isLeft: boolean,
-  isFemale: boolean,
   ink: string,
   skinColor: string,
   legH: number,
@@ -353,7 +357,7 @@ function buildLeg(
   });
 
   const shoe = document.createElement("span");
-  shoe.textContent = isFemale ? "👠" : "👟";
+  shoe.textContent = "👟";
   Object.assign(shoe.style, {
     position:      "absolute",
     fontSize:      "17px",


### PR DESCRIPTION
## Summary

Follow-up on the feedback that `examples/00-love-story.markdy` leaned on visual stereotyping (dress/heels/nails hardcoded onto every "female" figure) and possessive language ("she's mine") that the animation never pushed back on, ending with the girl pairing off with "the loser" regardless.

- **`figure()` gender rendering** (`packages/renderer-dom/src/figure.ts`): gender is now `f | m | x` (default `x`). It only picks the torso costume — 👗 (f), 👔 (m), 👕 (x) — skin color and face are fully independent params, and shoes/hands are shared across all genders. Gender is also exposed as `data-fig-gender` on the DOM. Docs (`docs/SYNTAX.md`, `docs/AGENT.md`) updated to match.
- **`examples/00-love-story.markdy` rewritten**: Alice and Bob (a woman and a man) competing over Charlie (nonbinary) instead of two men over a woman. The possessive dialogue stays as a setup ("Back off, they're mine!") but gets called out on-screen ("I'm not a trophy, Alice."). The story ends with Charlie standing on their own after checking in on Bob, rather than pairing off with whoever "won" the fight.
- Diversified the `gender` arg across the other example files instead of defaulting every figure to `m`.

## Test plan

- [x] `pnpm --filter @markdy/renderer-dom typecheck` / `test` (18/18 passing)
- [x] `pnpm --filter @markdy/core test` (122/122 passing)
- [x] `pnpm --filter @markdy/compat run gate` (15 fixtures, 0 regressions — compat gate only snapshots the AST, unaffected by renderer changes)
- [x] `markdy check-all examples --strict` (no new warnings/failures vs. main)
- [x] Manually verified in a local preview build that `f`/`m`/`x` render the intended costumes and that unknown gender values fall back to `x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)