### PR TITLE
Fix Charlie expression in love-story example

### DIFF
--- a/examples/00-love-story.markdy
+++ b/examples/00-love-story.markdy
@@ -73,7 +73,7 @@ scene "rejection" {
   @+0.3: alice.face("🥰")
   @+0.0: alice.move(to=(520, 180), dur=0.6, ease=out)
   @+0.5: alice.say("You're the prize 🏆", dur=1.1)
-  @+0.3: charlie.face("🙅")
+  @+0.3: charlie.face("😤")
   @+0.2: charlie.say("Hard pass.", dur=1.1)
   @+0.0: charlie.shake(intensity=5, dur=0.4)
   @+0.4: act3.fade_out(dur=0.3)


### PR DESCRIPTION
## Summary

- Replace Charlie's full-body refusal emoji with a face-only expression in the love-story rejection scene
- Keeps Charlie's visual role consistent while the dialogue and shake animation still communicate the refusal

## Test plan

- [x] pnpm run verify:examples