### PR TITLE
Improve website SEO and promotion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 
 # Build outputs
 dist/

--- a/website/public/icon.svg
+++ b/website/public/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Markdy">
+  <rect width="512" height="512" rx="112" fill="#047857"/>
+  <path d="M112 176h288v184c0 22-18 40-40 40H152c-22 0-40-18-40-40V176Z" fill="#f8fafc"/>
+  <path d="M112 176 160 96h72l-48 80h72l48-80h72l-48 80h72v56H112v-56Z" fill="#0f172a"/>
+  <path d="M112 176h288v56H112v-56Z" fill="#10b981"/>
+  <path d="M202 292c0-10 11-16 20-11l82 48c9 5 9 18 0 23l-82 48c-9 5-20-1-20-11v-97Z" fill="#047857"/>
+</svg>

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,0 +1,42 @@
+# Markdy
+
+> Open-source text-to-motion animation DSL for writing browser-rendered animated scenes like Markdown.
+
+Markdy lets developers define actors, assets, captions, camera movement, and timeline events in MarkdyScript. It is useful for animated docs, explainers, memes, social clips, Astro sites, MDX content, and AI-generated motion sketches.
+
+## Primary Links
+
+- Website and playground: https://markdy.com/
+- Documentation landing page: https://markdy.com/docs/
+- GitHub repository: https://github.com/HoangYell/markdy-com
+- AI agent reference: https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md
+- Syntax reference: https://github.com/HoangYell/markdy-com/blob/main/docs/SYNTAX.md
+- Tutorial: https://github.com/HoangYell/markdy-com/blob/main/docs/TUTORIAL.md
+- npm core package: https://www.npmjs.com/package/@markdy/core
+- npm DOM renderer: https://www.npmjs.com/package/@markdy/renderer-dom
+- npm Astro package: https://www.npmjs.com/package/@markdy/astro
+- npm MDX package: https://www.npmjs.com/package/@markdy/mdx
+- npm CLI package: https://www.npmjs.com/package/@markdy/cli
+
+## Short Description
+
+Markdy is an open-source animation DSL. Write MarkdyScript text files, parse them with @markdy/core, and render animated browser scenes with @markdy/renderer-dom.
+
+## Best AI Context
+
+Use docs/AGENT.md as the complete reference when generating MarkdyScript. It contains the grammar, valid actor types, actions, camera commands, examples, and constraints.
+
+## Install
+
+```sh
+npm i @markdy/core @markdy/renderer-dom
+```
+
+## Minimal Scene
+
+```markdy
+scene width=600 height=300 bg=white
+actor label = text("Hello Markdy") at (180, 130) size 36 opacity 0
+@0.2: label.fade_in(dur=0.5)
+@1.0: label.move(to=(260, 130), dur=0.8, ease=out)
+```

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,5 +1,16 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Allow: /
+Allow: /images/
+Allow: /prompts/
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
 
 Sitemap: https://markdy.com/sitemap-index.xml

--- a/website/public/site.webmanifest
+++ b/website/public/site.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Markdy",
+  "short_name": "Markdy",
+  "description": "Open-source text-to-motion animation DSL for browser-rendered animated scenes.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#fafafa",
+  "theme_color": "#047857",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -6,7 +6,9 @@ export interface Props extends HTMLAttributes<"html"> {
   description?: string;
   canonicalURL?: string;
   ogImage?: string;
+  ogImageAlt?: string;
   keywords?: string;
+  structuredData?: Record<string, unknown> | Record<string, unknown>[];
 }
 
 const {
@@ -14,8 +16,69 @@ const {
   description = "Markdy is an open-source text-to-motion animation DSL. Write animated scenes in a simple text language with no keyframes and no drag-and-drop.",
   canonicalURL = "https://markdy.com",
   ogImage = "https://markdy.com/og-image.png",
+  ogImageAlt = "Markdy open-source animation DSL preview",
   keywords = "animation dsl, text-to-motion, declarative animation, markdown animation, framer motion alternative, gsap alternative, astro animation, web animations api",
+  structuredData = [],
 } = Astro.props;
+
+const sameAs = [
+  "https://github.com/HoangYell/markdy-com",
+  "https://www.npmjs.com/package/@markdy/core",
+  "https://www.npmjs.com/package/@markdy/renderer-dom",
+  "https://hoangyell.com",
+];
+
+const baseStructuredData = [
+  {
+    "@type": "WebSite",
+    "@id": "https://markdy.com/#website",
+    name: "Markdy",
+    url: "https://markdy.com/",
+    description,
+    inLanguage: "en",
+    publisher: { "@id": "https://markdy.com/#organization" },
+  },
+  {
+    "@type": "Organization",
+    "@id": "https://markdy.com/#organization",
+    name: "Markdy",
+    url: "https://markdy.com/",
+    logo: "https://markdy.com/icon.svg",
+    sameAs,
+  },
+  {
+    "@type": "Person",
+    "@id": "https://markdy.com/#hoang-yell",
+    name: "Hoang Yell",
+    url: "https://hoangyell.com",
+    sameAs: ["https://github.com/HoangYell", "https://hoangyell.com"],
+  },
+  {
+    "@type": "SoftwareApplication",
+    "@id": "https://markdy.com/#software",
+    name: "Markdy",
+    description,
+    keywords,
+    url: "https://markdy.com/",
+    applicationCategory: "DeveloperApplication",
+    applicationSubCategory: "Animation DSL",
+    operatingSystem: "Web",
+    programmingLanguage: "TypeScript",
+    codeRepository: "https://github.com/HoangYell/markdy-com",
+    license: "https://github.com/HoangYell/markdy-com/blob/main/LICENSE",
+    isAccessibleForFree: true,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    sameAs,
+  },
+];
+
+const pageStructuredData = Array.isArray(structuredData) ? structuredData : [structuredData];
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [...baseStructuredData, ...pageStructuredData],
+};
 ---
 
 <!doctype html>
@@ -27,6 +90,8 @@ const {
     <meta name="keywords" content={keywords} />
     <meta name="author" content="Hoang Yell" />
     <meta name="robots" content="index, follow" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+    <meta name="format-detection" content="telephone=no" />
     <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)" />
     <title>{title}</title>
@@ -38,15 +103,22 @@ const {
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonicalURL} />
     <meta property="og:image" content={ogImage} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content={ogImageAlt} />
+    <meta property="og:locale" content="en_US" />
     <meta property="og:site_name" content="Markdy" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:creator" content="@HoangYell" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+    <meta name="twitter:image:alt" content={ogImageAlt} />
 
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎬</text></svg>" />
+    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+    <link rel="manifest" href="/site.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" />
@@ -57,18 +129,7 @@ const {
     <script src="https://code.iconify.design/3/3.1.0/iconify.min.js" defer></script>
 
     <!-- JSON-LD Structured Data -->
-    <script type="application/ld+json" set:html={JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Markdy",
-      "description": description,
-      "keywords": keywords,
-      "url": canonicalURL,
-      "applicationCategory": "DeveloperApplication",
-      "operatingSystem": "Web",
-      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
-      "author": { "@type": "Person", "name": "Hoang Yell", "url": "https://hoangyell.com" }
-    })} />
+    <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 
     <!-- Prevent FOUC: set theme before render -->
     <script is:inline>

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -1,0 +1,212 @@
+---
+import Layout from "../layouts/Layout.astro";
+
+const docStructuredData = [
+  {
+    "@type": "WebPage",
+    "@id": "https://markdy.com/docs/#webpage",
+    url: "https://markdy.com/docs/",
+    name: "Markdy Documentation",
+    description: "Start learning MarkdyScript, the open-source text-to-motion animation DSL for browser-rendered scenes.",
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+  },
+  {
+    "@type": "BreadcrumbList",
+    "@id": "https://markdy.com/docs/#breadcrumb",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://markdy.com/" },
+      { "@type": "ListItem", position: 2, name: "Docs", item: "https://markdy.com/docs/" },
+    ],
+  },
+  {
+    "@type": "ItemList",
+    "@id": "https://markdy.com/docs/#resources",
+    name: "Markdy documentation resources",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "MarkdyScript Tutorial", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/TUTORIAL.md" },
+      { "@type": "ListItem", position: 2, name: "MarkdyScript Syntax", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/SYNTAX.md" },
+      { "@type": "ListItem", position: 3, name: "AI Agent Reference", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" },
+    ],
+  },
+];
+---
+
+<Layout
+  title="Markdy Documentation — Learn MarkdyScript"
+  description="Learn MarkdyScript with the tutorial, syntax reference, AI agent guide, examples, and package docs for the open-source text-to-motion animation DSL."
+  canonicalURL="https://markdy.com/docs/"
+  keywords="Markdy documentation, MarkdyScript tutorial, animation DSL docs, text-to-motion syntax, AI animation DSL"
+  structuredData={docStructuredData}
+>
+  <main class="docs-page">
+    <a href="/" class="back-link">Back to Markdy</a>
+    <header class="docs-hero">
+      <span class="docs-kicker">Documentation</span>
+      <h1>Learn MarkdyScript</h1>
+      <p>Start with a scene, add actors, schedule timeline events, and render browser-native animations from plain text.</p>
+    </header>
+
+    <section class="docs-grid" aria-label="Documentation resources">
+      <a class="doc-card" href="https://github.com/HoangYell/markdy-com/blob/main/docs/TUTORIAL.md" target="_blank" rel="noopener noreferrer">
+        <span>Tutorial</span>
+        <h2>Build Your First Scene</h2>
+        <p>A step-by-step guide from text labels and movement to variables, templates, sequences, stick figures, speech, and interaction.</p>
+      </a>
+      <a class="doc-card" href="https://github.com/HoangYell/markdy-com/blob/main/docs/SYNTAX.md" target="_blank" rel="noopener noreferrer">
+        <span>Reference</span>
+        <h2>MarkdyScript Syntax</h2>
+        <p>The language reference for scene declarations, assets, actor types, modifiers, timeline events, camera actions, and presets.</p>
+      </a>
+      <a class="doc-card" href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">
+        <span>AI Agents</span>
+        <h2>Agent Generation Guide</h2>
+        <p>A machine-readable reference optimized for Claude, ChatGPT, GitHub Copilot, Cursor, Windsurf, and other LLM coding agents.</p>
+      </a>
+      <a class="doc-card" href="https://github.com/HoangYell/markdy-com/tree/main/examples" target="_blank" rel="noopener noreferrer">
+        <span>Examples</span>
+        <h2>Shipped Scenes</h2>
+        <p>Browse real .markdy examples for captions, camera movement, gestures, templates, imports, and combined feature demos.</p>
+      </a>
+    </section>
+
+    <section class="quickstart" aria-label="Markdy quickstart">
+      <div>
+        <span class="docs-kicker">Quickstart</span>
+        <h2>Install the parser and DOM renderer</h2>
+        <p>Use <code>@markdy/core</code> for parsing and <code>@markdy/renderer-dom</code> for browser playback with the Web Animations API.</p>
+      </div>
+      <pre><code>npm i @markdy/core @markdy/renderer-dom</code></pre>
+    </section>
+  </main>
+</Layout>
+
+<style>
+  .docs-page {
+    min-height: 100vh;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 5rem 1.5rem;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-bottom: 2rem;
+    color: var(--accent, #047857);
+    font-size: 0.9rem;
+    font-weight: 600;
+  }
+
+  .docs-hero {
+    max-width: 720px;
+    margin-bottom: 2rem;
+  }
+
+  .docs-kicker {
+    display: inline-block;
+    margin-bottom: 0.6rem;
+    color: var(--accent, #047857);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    color: var(--text-primary, #0f172a);
+    font-size: clamp(2.4rem, 7vw, 4.5rem);
+    line-height: 0.98;
+    letter-spacing: -0.05em;
+    margin-bottom: 1rem;
+  }
+
+  .docs-hero p,
+  .quickstart p {
+    color: var(--text-secondary, #64748b);
+    font-size: 1rem;
+    line-height: 1.7;
+  }
+
+  .docs-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  .doc-card,
+  .quickstart {
+    border: 1px solid var(--border, #e2e8f0);
+    border-radius: 12px;
+    background: var(--bg-secondary, #ffffff);
+    box-shadow: 0 1px 4px var(--shadow-sm, rgba(0, 0, 0, 0.04));
+  }
+
+  .doc-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    padding: 1.25rem;
+    transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .doc-card:hover {
+    border-color: var(--accent, #047857);
+    box-shadow: 0 4px 16px var(--shadow-md, rgba(0, 0, 0, 0.06));
+    transform: translateY(-2px);
+  }
+
+  .doc-card span {
+    color: var(--accent, #047857);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .doc-card h2 {
+    color: var(--text-primary, #0f172a);
+    font-size: 1rem;
+    line-height: 1.35;
+  }
+
+  .doc-card p {
+    color: var(--text-secondary, #64748b);
+    font-size: 0.84rem;
+    line-height: 1.6;
+  }
+
+  .quickstart {
+    display: grid;
+    grid-template-columns: 1.2fr 1fr;
+    gap: 1.5rem;
+    align-items: center;
+    margin-top: 1rem;
+    padding: 1.5rem;
+  }
+
+  .quickstart h2 {
+    color: var(--text-primary, #0f172a);
+    font-size: 1.3rem;
+    margin-bottom: 0.4rem;
+  }
+
+  .quickstart pre {
+    overflow-x: auto;
+    margin: 0;
+    padding: 0.9rem 1rem;
+    border-radius: 8px;
+    background: var(--ref-code-bg, #f6f8fa);
+    color: var(--ref-code-text, #24292f);
+    font-size: 0.82rem;
+  }
+
+  @media (max-width: 900px) {
+    .docs-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .quickstart { grid-template-columns: 1fr; }
+  }
+
+  @media (max-width: 560px) {
+    .docs-page { padding: 3rem 1rem; }
+    .docs-grid { grid-template-columns: 1fr; }
+  }
+</style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -132,6 +132,91 @@ const PACKAGES = [
   },
 ] as const;
 
+const USE_CASES = [
+  {
+    title: "Animated docs and tutorials",
+    desc: "Turn walkthroughs, feature explanations, and onboarding steps into small timeline scenes that stay readable in source control.",
+  },
+  {
+    title: "AI-generated motion sketches",
+    desc: "Give an AI agent a plain-English scene brief and get deterministic MarkdyScript back instead of brittle generated JavaScript.",
+  },
+  {
+    title: "Astro and MDX content sites",
+    desc: "Embed animations in documentation, launch posts, and technical articles without shipping a full creative suite to every page.",
+  },
+  {
+    title: "Explainers, memes, and social clips",
+    desc: "Prototype short visual stories with actors, captions, camera movement, and speech bubbles using text-only files.",
+  },
+] as const;
+
+const FAQS = [
+  {
+    question: "What is Markdy?",
+    answer: "Markdy is an open-source animation DSL for writing text-to-motion scenes. You define actors, assets, captions, and timeline events in MarkdyScript, then render the result in the browser.",
+  },
+  {
+    question: "Is Markdy an alternative to GSAP or Framer Motion?",
+    answer: "Markdy is not a general animation framework replacement. It is focused on declarative, scriptable 2D scenes for docs, explainers, demos, memes, and AI-generated animation snippets.",
+  },
+  {
+    question: "Does Markdy require Canvas or a video renderer?",
+    answer: "No. The DOM renderer uses web-native elements, CSS transforms, and the Web Animations API. Scenes can be embedded in normal web pages and Astro projects.",
+  },
+  {
+    question: "Can AI tools generate MarkdyScript?",
+    answer: "Yes. MarkdyScript is intentionally line-based and constrained so tools like Claude, ChatGPT, GitHub Copilot, Cursor, and Windsurf can generate, validate, and revise scenes from natural-language prompts.",
+  },
+  {
+    question: "Which packages do I need to render a scene?",
+    answer: "Use @markdy/core to parse MarkdyScript and @markdy/renderer-dom to render scenes in a browser. Optional packages add Astro, MDX, CLI, language server, and actor-pack support.",
+  },
+] as const;
+
+const PROMOTION_LINKS = [
+  { label: "Star on GitHub", href: "https://github.com/HoangYell/markdy-com", desc: "Follow releases, open issues, and contribute examples." },
+  { label: "Install from npm", href: "https://www.npmjs.com/package/@markdy/core", desc: "Use the parser and renderer packages in your app." },
+  { label: "Read the agent guide", href: "https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md", desc: "Give AI tools the complete grammar and action reference." },
+] as const;
+
+const homepageStructuredData = [
+  {
+    "@type": "WebPage",
+    "@id": "https://markdy.com/#webpage",
+    url: "https://markdy.com/",
+    name: "Markdy — Open-Source Animation DSL Engine",
+    description: "Markdy is a framework-agnostic text-to-motion animation DSL for animated scenes, docs, Astro sites, MDX content, and AI-generated motion sketches.",
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    primaryImageOfPage: {
+      "@type": "ImageObject",
+      url: "https://markdy.com/og-image.png",
+      width: 1200,
+      height: 630,
+    },
+  },
+  {
+    "@type": "BreadcrumbList",
+    "@id": "https://markdy.com/#breadcrumb",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://markdy.com/" },
+    ],
+  },
+  {
+    "@type": "FAQPage",
+    "@id": "https://markdy.com/#faq",
+    mainEntity: FAQS.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
+  },
+];
+
 /* ── Usage code snippets (pre-formatted HTML to avoid Astro expression parsing) ── */
 const USAGE_VANILLA = `<span class="u-kw">import</span> { createPlayer } <span class="u-kw">from</span> <span class="u-str">"@markdy/renderer-dom"</span>;
 
@@ -182,6 +267,8 @@ markdy <span class="u-fn">check-all</span> examples`;
   title="Markdy — Open-Source Animation DSL Engine"
   description="Markdy is a framework-agnostic text-to-motion animation DSL. Write animated scenes like Markdown. No Canvas, no GSAP, no bloated dependencies."
   keywords="open-source animation dsl, text-to-motion, declarative animation, framer motion alternative, gsap alternative, markdown animation, web animations api, stick figure animation"
+  ogImageAlt="Markdy playground showing text-to-motion animation code and a rendered scene preview"
+  structuredData={homepageStructuredData}
 >
 
   <!-- ─── Nav ──────────────────────────────────────────────────────────── -->
@@ -197,7 +284,9 @@ markdy <span class="u-fn">check-all</span> examples`;
       <a href="#features">Features</a>
       <a href="#playground">Playground</a>
       <a href="#learn">Learn</a>
+      <a href="/docs/">Docs</a>
       <a href="#ai-gen">AI</a>
+      <a href="#faq">FAQ</a>
       <a href="https://github.com/HoangYell/markdy-com" target="_blank" rel="noopener noreferrer" class="nav-github">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
         <span>Star</span>
@@ -796,6 +885,60 @@ actor target = box() at (560, 220) scale 0.8
     </div>
   </section>
 
+  <!-- ─── Search Intent: Use Cases + FAQ ──────────────────────────────── -->
+  <section id="use-cases" class="intent-section" aria-label="Markdy use cases">
+    <div class="section-header">
+      <span class="section-tag">Use Cases</span>
+      <h2>Where Markdy Fits</h2>
+      <p>Markdy is built for lightweight animation workflows where text, version control, and AI generation matter more than timeline-heavy creative tools.</p>
+    </div>
+    <div class="intent-grid">
+      {USE_CASES.map((item) => (
+        <article class="intent-card">
+          <h3>{item.title}</h3>
+          <p>{item.desc}</p>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section id="faq" class="faq-section" aria-label="Frequently asked questions">
+    <div class="section-header">
+      <span class="section-tag">FAQ</span>
+      <h2>Animation DSL Questions</h2>
+      <p>Direct answers for developers comparing Markdy with JavaScript animation libraries, Canvas renderers, and AI-generated code.</p>
+    </div>
+    <div class="faq-list">
+      {FAQS.map((item) => (
+        <details class="faq-item">
+          <summary>{item.question}</summary>
+          <p>{item.answer}</p>
+        </details>
+      ))}
+    </div>
+  </section>
+
+  <!-- ─── Promotion Kit ──────────────────────────────────────────────── -->
+  <section id="share" class="share-section" aria-label="Share Markdy">
+    <div class="section-header">
+      <span class="section-tag">Promotion</span>
+      <h2>Share the Project</h2>
+      <p>Consistent links and descriptions help developers, search engines, and AI tools understand what Markdy is.</p>
+    </div>
+    <div class="share-grid">
+      {PROMOTION_LINKS.map((item) => (
+        <a class="share-card" href={item.href} target="_blank" rel="noopener noreferrer">
+          <strong>{item.label}</strong>
+          <span>{item.desc}</span>
+        </a>
+      ))}
+    </div>
+    <div class="share-copy" aria-label="Short project description">
+      <span>Short description</span>
+      <code>Markdy is an open-source text-to-motion animation DSL for writing browser-rendered animated scenes like Markdown.</code>
+    </div>
+  </section>
+
   <!-- ─── Showcase ─────────────────────────────────────────────────────── -->
   <section id="showcase" class="showcase-section" aria-label="Built with Markdy">
     <div class="section-header">
@@ -845,19 +988,22 @@ actor target = box() at (560, 220) scale 0.8
             <a href="#learn">Syntax Reference</a>
             <a href="#packages">Packages</a>
             <a href="#ai-gen">AI Generation</a>
+            <a href="#faq">FAQ</a>
             <a href="#showcase">Showcase</a>
           </div>
           <div class="footer-col">
             <h3>Resources</h3>
+            <a href="/docs/">Documentation</a>
             <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/TUTORIAL.md" target="_blank" rel="noopener noreferrer">Tutorial</a>
-            <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/SYNTAX.md" target="_blank" rel="noopener noreferrer">Syntax Docs</a>
-            <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">Agent Guide</a>
+            <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/SYNTAX.md" target="_blank" rel="noopener noreferrer">Syntax Reference</a>
+            <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">AI Agent Guide</a>
             <a href="https://github.com/HoangYell/markdy-com/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">Contributing</a>
           </div>
           <div class="footer-col">
             <h3>Community</h3>
             <a href="https://github.com/HoangYell/markdy-com" target="_blank" rel="noopener noreferrer">GitHub</a>
             <a href="https://www.npmjs.com/package/@markdy/core" target="_blank" rel="noopener noreferrer">npm</a>
+            <a href="/llms.txt">llms.txt</a>
             <a href="https://github.com/HoangYell/markdy-com/issues" target="_blank" rel="noopener noreferrer">Report a Bug</a>
           </div>
         </div>
@@ -2558,6 +2704,122 @@ actor target = box() at (560, 220) scale 0.8
     background: var(--bg-secondary);
   }
 
+  /* ── Intent + FAQ + Promotion ────────────────────────────────────── */
+  .intent-section,
+  .faq-section,
+  .share-section {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 3.5rem;
+    border-top: 1px solid var(--border-subtle);
+  }
+
+  .intent-grid,
+  .share-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  .intent-card,
+  .share-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    min-height: 100%;
+    padding: 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--bg-secondary);
+    box-shadow: 0 1px 4px var(--shadow-sm);
+    transition: all 0.2s ease;
+  }
+
+  .intent-card h3,
+  .share-card strong {
+    font-size: 0.9rem;
+    font-weight: 700;
+    line-height: 1.35;
+    color: var(--text-primary);
+  }
+
+  .intent-card p,
+  .share-card span {
+    font-size: 0.8rem;
+    line-height: 1.55;
+    color: var(--text-secondary);
+  }
+
+  .share-card:hover {
+    border-color: var(--accent);
+    box-shadow: 0 4px 16px var(--shadow-md);
+    transform: translateY(-2px);
+  }
+
+  .faq-list {
+    display: grid;
+    gap: 0.8rem;
+    max-width: 820px;
+    margin: 0 auto;
+  }
+
+  .faq-item {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--bg-secondary);
+    box-shadow: 0 1px 4px var(--shadow-sm);
+  }
+
+  .faq-item summary {
+    cursor: pointer;
+    padding: 1rem 1.25rem;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+
+  .faq-item summary::marker {
+    color: var(--accent);
+  }
+
+  .faq-item p {
+    padding: 0 1.25rem 1rem;
+    color: var(--text-secondary);
+    font-size: 0.88rem;
+    line-height: 1.65;
+  }
+
+  .share-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  .share-copy {
+    display: grid;
+    gap: 0.45rem;
+    max-width: 900px;
+    margin: 1rem auto 0;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--bg-tertiary);
+  }
+
+  .share-copy span {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+
+  .share-copy code {
+    color: var(--text-primary);
+    font-size: 0.82rem;
+    line-height: 1.6;
+    white-space: normal;
+  }
+
   /* ── Footer ──────────────────────────────────────────────────────── */
   .footer {
     padding: 2.5rem 1.5rem 1.5rem;
@@ -2734,6 +2996,8 @@ actor target = box() at (560, 220) scale 0.8
 
     .ref-grid { grid-template-columns: 1fr; }
     .ai-grid { grid-template-columns: 1fr; }
+    .intent-grid,
+    .share-grid { grid-template-columns: 1fr; }
     .ref-card { overflow: hidden; }
     .ref-card pre { white-space: pre; }
 

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -2,7 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="Privacy Policy — Markdy" description="Privacy policy and tracking disclosures for Markdy.com" canonicalURL="https://markdy.com/privacy">
+<Layout title="Privacy Policy — Markdy" description="Privacy policy and local storage disclosures for Markdy.com" canonicalURL="https://markdy.com/privacy">
   <div class="legal-container">
     <div class="legal-content">
       <a href="/" class="back-link">← Back to Markdy</a>
@@ -15,13 +15,8 @@ import Layout from '../layouts/Layout.astro';
       </section>
 
       <section>
-        <h2>2. Data Collection and Google Analytics</h2>
-        <p>We use <strong>Google Analytics</strong> to measure traffic, understand how developers interact with the documentation, and improve the project. Google Analytics may set cookies on your browser or read cookies that are already there. We only collect aggregated, non-personally identifiable information, such as:</p>
-        <ul>
-          <li>Browser type and operating system</li>
-          <li>Pages visited and time spent on the site</li>
-          <li>General location (Country/City level)</li>
-        </ul>
+        <h2>2. Data Collection</h2>
+        <p>Markdy.com does not currently run analytics scripts, advertising pixels, or behavioral tracking. Static hosting infrastructure may still create standard server logs such as request URL, timestamp, user agent, and IP address for security and reliability.</p>
       </section>
 
       <section>
@@ -36,7 +31,7 @@ import Layout from '../layouts/Layout.astro';
 
       <section>
         <h2>5. Your Rights</h2>
-        <p>You can opt out of Google Analytics tracking at any time by installing the <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">Google Analytics Opt-out Browser Add-on</a>.</p>
+        <p>Because the site does not currently run analytics scripts or account systems, there is no analytics profile to opt out of on Markdy.com. You can clear the saved theme preference at any time by clearing this site's local storage in your browser.</p>
       </section>
 
       <section>


### PR DESCRIPTION
## Summary
- expand site-wide SEO metadata, social preview tags, and JSON-LD structured data
- add indexable homepage FAQ/use-case/promotion sections and a /docs/ landing page
- add llms.txt, web manifest, square site icon, crawler hints, and correct privacy tracking language

## Validation
- pnpm --filter @markdy/website build
- pnpm run ci
- pnpm run build