### PR TITLE
chore: release v0.7.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdy",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "private": true,
   "description": "An open-source animation DSL engine. Write MarkdyScript, get animated scenes in the browser.",
   "license": "MIT",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/astro",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "Astro island component for MarkdyScript animations.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/cli",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "First-party CLI for MarkdyScript: lint, format, explain, render, and local playground tooling.",
   "license": "MIT",
   "type": "module",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/compat",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "private": true,
   "description": "Backwards-compatibility gate for MarkdyScript. Snapshots every fixture in packages/compat/fixtures with the current parser and diffs ASTs on every CI run.",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/core",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "MarkdyScript parser and AST types — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/markdy-language-server/package.json
+++ b/packages/markdy-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/language-server",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "Language Server Protocol implementation for MarkdyScript.",
   "license": "MIT",
   "type": "module",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/mdx",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "MDX integration plugin and lightweight React player for Markdy.",
   "license": "MIT",
   "type": "module",

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/renderer-dom",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "Web Animations API renderer for MarkdyScript scenes.",
   "license": "MIT",
   "type": "module",

--- a/packages/stdlib-systems/package.json
+++ b/packages/stdlib-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/stdlib-systems",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "System diagram actor/action pack for Markdy.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump workspace/package versions to 0.7.24
- include favicon fallback release notes
- run full release validation before merge

## Validation
- pnpm run build
- pnpm run lint
- pnpm run test