### PR TITLE
feat: add premium playground showcases

### DIFF
--- a/examples/showcase/ascii-parking-garage.markdy
+++ b/examples/showcase/ascii-parking-garage.markdy
@@ -1,0 +1,49 @@
+# ASCII source becomes a polished garage visualization with terminal chrome, mini-map, parser graph, and state sync.
+scene width=1280 height=720 bg=#07111f fps=60
+
+actor title = caption("ASCII parking garage") at top opacity 0
+actor ascii = ascii_map("Text map compiler") at (82, 130) opacity 0 scale 0.94 z 35
+client Terminal "Terminal" at (590, 148) opacity 0
+service Lexer "Lexer" at (825, 148) opacity 0
+service Graph "Graph builder" at (1060, 148) opacity 0
+queue Lane "Lane graph" at (590, 448) opacity 0
+container Bay "Open bay" at (825, 448) opacity 0
+db State "State store" at (1060, 448) opacity 0
+actor diff = text("+ A-03 free    + EV bay reserved") at (442, 628) size 24 opacity 0 z 70
+
+group pipeline = Terminal, Lexer, Graph, Lane, Bay, State
+
+scene "source-text" {
+  @+0.0: title.line_reveal(from=left, dur=0.42)
+  @+0.12: ascii.fade_in(dur=0.45)
+  @+0.0: ascii.mask(from=0, to=120, dur=0.72, ease=smooth)
+  @+0.0: ascii.glow(color=#22c55e, strength=42, dur=0.72)
+  @+0.24: pipeline.enter(from=right, dur=0.46, ease=snappy, stagger=0.06)
+}
+
+scene "parse" {
+  @+0.16: Terminal.request(to=Lexer, label="ASCII rows", dur=0.55)
+  @+0.0: Lexer.pulse(amount=1.1, dur=0.4)
+  @+0.1: Lexer.request(to=Graph, label="tokens", dur=0.55)
+  @+0.0: Graph.glow(color=#38bdf8, strength=32, dur=0.5)
+}
+
+scene "materialize" {
+  @+0.16: Graph.emit(to=Lane, label="lane edges", dur=0.55)
+  @+0.0: Graph.emit(to=Bay, label="bay nodes", dur=0.55)
+  @+0.0: Lane.ripple(color=#38bdf8, size=145, dur=0.55)
+  @+0.0: Bay.ripple(color=#22c55e, size=145, dur=0.55)
+}
+
+scene "sync" {
+  @+0.16: Lane.request(to=State, label="occupancy", dur=0.58)
+  @+0.0: Bay.request(to=State, label="EV reserve", dur=0.58)
+  @+0.16: State.glow(color=#22c55e, strength=38, dur=0.55)
+  @+0.0: diff.line_reveal(from=left, dur=0.45)
+}
+
+scene "focus-terminal" {
+  @+0.22: camera.pan(to=(270, 260), dur=0.78, ease=smooth)
+  @+0.0: camera.zoom(to=1.2, dur=0.78, ease=smooth)
+  @+0.18: ascii.pulse(amount=1.035, dur=0.45)
+}

--- a/examples/showcase/cyber-parking-control.markdy
+++ b/examples/showcase/cyber-parking-control.markdy
@@ -1,0 +1,53 @@
+# Smart-garage video scene: premium HTML/CSS dashboard, routed flows, camera work, and staged emphasis.
+scene width=1280 height=720 bg=#050816 fps=60
+
+actor title = caption("Cyber parking control room") at top opacity 0
+actor dash = parking_map("Vision routing HUD") at (72, 124) opacity 0 scale 0.92 z 35
+client DriverApp "Driver app" at (560, 156) opacity 0
+service GateCam "Gate camera" at (808, 156) opacity 0
+service PlateOCR "Plate OCR" at (1048, 156) opacity 0
+db Occupancy "Occupancy DB" at (560, 442) opacity 0
+service Allocator "Spot allocator" at (808, 442) opacity 0
+container Gate "Gate arm" at (1048, 442) opacity 0
+cloud Garage "Garage A-17" at (1048, 300) opacity 0
+actor status = text("SCAN -> OCR -> ROUTE -> GATE") at (432, 632) size 23 opacity 0 z 70
+
+group nodes = DriverApp, GateCam, PlateOCR, Occupancy, Allocator, Gate, Garage
+
+scene "cold-open" {
+  @+0.0: title.line_reveal(from=left, dur=0.42)
+  @+0.1: dash.mask(from=0, to=120, dur=0.75, ease=smooth)
+  @+0.0: dash.fade_in(dur=0.45)
+  @+0.0: dash.glow(color=#38bdf8, strength=42, dur=0.75)
+  @+0.2: nodes.fade_in(dur=0.42, stagger=0.08)
+}
+
+scene "scan-and-read" {
+  @+0.2: DriverApp.request(to=GateCam, label="arrival", dur=0.55)
+  @+0.0: GateCam.glow(color=#38bdf8, strength=30, dur=0.48)
+  @+0.08: GateCam.request(to=PlateOCR, label="plate frame", dur=0.58)
+  @+0.0: PlateOCR.pulse(amount=1.1, dur=0.42)
+  @+0.0: dash.pulse(amount=1.04, dur=0.46)
+}
+
+scene "decision-loop" {
+  @+0.12: PlateOCR.request(to=Occupancy, label="permit lookup", dur=0.6)
+  @+0.0: Occupancy.glow(color=#22c55e, strength=34, dur=0.5)
+  @+0.14: Occupancy.response(to=Allocator, label="3 free bays", dur=0.58)
+  @+0.0: Allocator.glow(color=#a78bfa, strength=36, dur=0.54)
+  @+0.16: status.fade_in(dur=0.35)
+}
+
+scene "route-car" {
+  @+0.2: Allocator.emit(to=Gate, label="open lane", dur=0.56)
+  @+0.0: Gate.ripple(color=#22c55e, size=160, dur=0.62)
+  @+0.12: Gate.emit(to=Garage, label="reserve A-17", dur=0.58)
+  @+0.0: Garage.ripple(color=#38bdf8, size=190, dur=0.7)
+}
+
+scene "cinematic-push" {
+  @+0.18: camera.pan(to=(270, 260), dur=0.84, ease=smooth)
+  @+0.0: camera.zoom(to=1.22, dur=0.84, ease=smooth)
+  @+0.2: dash.glow(color=#22c55e, strength=48, dur=0.72)
+  @+0.0: status.scale(to=1.06, dur=0.4, ease=overshoot)
+}

--- a/examples/showcase/parking-game-loop.markdy
+++ b/examples/showcase/parking-game-loop.markdy
@@ -1,0 +1,50 @@
+# Arcade-grade parking loop: animated CSS game viewport plus input, physics, collision, scoring, replay, and camera punch-in.
+scene width=1280 height=720 bg=#0b1020 fps=60
+
+actor title = caption("Parking game loop") at top opacity 0
+actor world = game_scene("Parking micro-game") at (80, 128) opacity 0 scale 0.94 z 35
+client Input "Input buffer" at (585, 145) opacity 0
+service Physics "Physics tick" at (820, 145) opacity 0
+service Collision "Collision grid" at (1055, 145) opacity 0
+container CarPose "Car pose" at (585, 450) opacity 0
+service Score "Score HUD" at (820, 450) opacity 0
+db Replay "Replay ghost" at (1055, 450) opacity 0
+actor combo = text("PERFECT PARK +1200") at (462, 628) size 34 opacity 0 scale 0.72 z 80
+
+group engine = Input, Physics, Collision, CarPose, Score, Replay
+
+scene "insert-coin" {
+  @+0.0: title.line_reveal(from=left, dur=0.42)
+  @+0.12: world.fade_in(dur=0.42)
+  @+0.0: world.blur(from=8, to=0, dur=0.52)
+  @+0.0: world.glow(color=#f59e0b, strength=44, dur=0.72)
+  @+0.22: engine.enter(from=right, dur=0.44, ease=snappy, stagger=0.06)
+}
+
+scene "drive" {
+  @+0.16: Input.request(to=Physics, label="steer + brake", dur=0.55)
+  @+0.0: Physics.glow(color=#38bdf8, strength=32, dur=0.45)
+  @+0.08: Physics.request(to=CarPose, label="pose", dur=0.5)
+  @+0.0: world.pulse(amount=1.035, dur=0.46)
+}
+
+scene "collision-pass" {
+  @+0.12: Physics.request(to=Collision, label="sweep", dur=0.52)
+  @+0.0: Collision.response(to=Physics, label="clear", dur=0.46)
+  @+0.08: Collision.emit(to=Score, label="aligned", dur=0.54)
+  @+0.0: Score.ripple(color=#f59e0b, size=160, dur=0.6)
+}
+
+scene "replay-and-score" {
+  @+0.14: Physics.emit(to=Replay, label="ghost", dur=0.55)
+  @+0.0: Replay.glow(color=#a78bfa, strength=34, dur=0.48)
+  @+0.08: combo.fade_in(dur=0.25)
+  @+0.0: combo.scale(to=1.12, dur=0.38, ease=overshoot)
+  @+0.0: world.ripple(color=#22c55e, size=190, dur=0.68)
+}
+
+scene "replay-cam" {
+  @+0.2: camera.pan(to=(270, 260), dur=0.78, ease=smooth)
+  @+0.0: camera.zoom(to=1.24, dur=0.78, ease=smooth)
+  @+0.18: combo.shake(intensity=4, dur=0.24)
+}

--- a/examples/showcase/utf8-byte-visualizer.markdy
+++ b/examples/showcase/utf8-byte-visualizer.markdy
@@ -1,0 +1,49 @@
+# UTF-8 explainer video: rich byte visualizer surface with data-flow choreography and cinematic focus.
+scene width=1280 height=720 bg=#06101f fps=60
+
+actor title = caption("UTF-8 byte visualizer") at top opacity 0
+actor viz = byte_viz("Character pipeline") at (64, 132) opacity 0 scale 0.92 z 35
+client Input "Text input" at (610, 145) opacity 0
+service CodePoint "Code point" at (846, 145) opacity 0
+service Encoder "UTF-8 encoder" at (1082, 145) opacity 0
+queue Bytes "Byte stream" at (610, 450) opacity 0
+container Bits "Bit lanes" at (846, 450) opacity 0
+cloud Screen "Rendered glyph" at (1082, 450) opacity 0
+actor formula = text("A -> U+0041 -> 0x41 -> 01000001") at (428, 628) size 28 opacity 0 z 80
+
+group pipeline = Input, CodePoint, Encoder, Bytes, Bits, Screen
+
+scene "glyph" {
+  @+0.0: title.line_reveal(from=left, dur=0.42)
+  @+0.12: viz.fade_in(dur=0.42)
+  @+0.0: viz.mask(from=0, to=120, dur=0.72, ease=smooth)
+  @+0.0: viz.glow(color=#a78bfa, strength=44, dur=0.72)
+  @+0.22: pipeline.enter(from=right, dur=0.44, ease=snappy, stagger=0.06)
+}
+
+scene "code-point" {
+  @+0.16: Input.request(to=CodePoint, label="character", dur=0.55)
+  @+0.0: CodePoint.glow(color=#38bdf8, strength=34, dur=0.5)
+  @+0.08: CodePoint.request(to=Encoder, label="U+0041", dur=0.56)
+  @+0.0: Encoder.pulse(amount=1.1, dur=0.44)
+}
+
+scene "bytes" {
+  @+0.14: Encoder.emit(to=Bytes, label="0x41", dur=0.55)
+  @+0.0: Bytes.ripple(color=#a78bfa, size=160, dur=0.58)
+  @+0.08: Bytes.emit(to=Bits, label="01000001", dur=0.56)
+  @+0.0: Bits.glow(color=#22c55e, strength=38, dur=0.55)
+}
+
+scene "paint" {
+  @+0.14: Bits.request(to=Screen, label="paint glyph", dur=0.58)
+  @+0.0: Screen.ripple(color=#38bdf8, size=180, dur=0.68)
+  @+0.08: formula.line_reveal(from=left, dur=0.45)
+  @+0.0: viz.pulse(amount=1.035, dur=0.46)
+}
+
+scene "inspect" {
+  @+0.22: camera.pan(to=(282, 260), dur=0.78, ease=smooth)
+  @+0.0: camera.zoom(to=1.2, dur=0.78, ease=smooth)
+  @+0.18: formula.scale(to=1.06, dur=0.38, ease=overshoot)
+}

--- a/packages/renderer-dom/src/actions/context.ts
+++ b/packages/renderer-dom/src/actions/context.ts
@@ -35,7 +35,7 @@ export interface ActionContext {
   states: Map<string, ActorState>;
   /** Root elements for every actor, keyed by actor name. */
   actorEls: Map<string, HTMLElement>;
-  /** The camera/content layer actors are mounted into. */
+  /** The actor/effects layer that actor-relative overlays are mounted into. */
   scene: HTMLElement;
   /** Host-supplied asset URL overrides, keyed by asset name. */
   assetOverrides: Record<string, string>;

--- a/packages/renderer-dom/src/actions/flow.ts
+++ b/packages/renderer-dom/src/actions/flow.ts
@@ -8,7 +8,7 @@
  * busy sequence diagram doesn't accumulate clutter.
  */
 import type { ActionContext, ActionHandler } from "./context.js";
-import { pointAtDistance, polylineLength, round1, routeFlowPath, toPathD } from "../geometry/path.js";
+import { labelPointForPath, polylineLength, round1, routeFlowPath, toPathD } from "../geometry/path.js";
 
 const EDGE_LAYER_ATTR = "data-markdy-edge-layer";
 
@@ -145,7 +145,7 @@ function buildEdge(ctx: ActionContext, targetName: string): void {
 
   const labelText = String(ev.params.label ?? "");
   if (labelText) {
-    const midPoint = pointAtDistance(points, length * 0.5);
+    const midPoint = labelPointForPath(points, lane);
     const label = document.createElementNS("http://www.w3.org/2000/svg", "text");
     label.setAttribute("x", `${round1(midPoint.x)}`);
     label.setAttribute("y", `${round1(midPoint.y - 8)}`);

--- a/packages/renderer-dom/src/actors.ts
+++ b/packages/renderer-dom/src/actors.ts
@@ -19,7 +19,479 @@ const ARCHITECTURE_NODE_TYPES = new Set([
   "cluster",
 ]);
 
+const SHOWCASE_SURFACE_TYPES = new Set(["parking_map", "ascii_map", "game_scene", "byte_viz"]);
+
 const ARCHITECTURE_STYLE_ID = "markdy-architecture-node-styles";
+const SHOWCASE_STYLE_ID = "markdy-showcase-surface-styles";
+
+function ensureShowcaseStyles(doc: Document): void {
+  if (doc.getElementById(SHOWCASE_STYLE_ID)) return;
+
+  const style = doc.createElement("style");
+  style.id = SHOWCASE_STYLE_ID;
+  style.textContent = `
+.markdy-showcase {
+  --surface-a: rgba(15, 23, 42, 0.9);
+  --accent: #38bdf8;
+  --accent-2: #22c55e;
+  position: relative;
+  box-sizing: border-box;
+  width: 390px;
+  height: 250px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.34);
+  border-radius: 24px;
+  color: #e5f3ff;
+  background:
+    radial-gradient(circle at 12% 0%, color-mix(in srgb, var(--accent) 32%, transparent), transparent 34%),
+    radial-gradient(circle at 90% 15%, color-mix(in srgb, var(--accent-2) 26%, transparent), transparent 34%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.13), rgba(255, 255, 255, 0.025) 32%, var(--surface-a));
+  box-shadow:
+    0 26px 70px rgba(2, 6, 23, 0.42),
+    0 0 0 1px rgba(255, 255, 255, 0.06) inset,
+    0 1px 0 rgba(255, 255, 255, 0.18) inset,
+    0 0 44px color-mix(in srgb, var(--accent) 24%, transparent);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  isolation: isolate;
+  contain: layout paint style;
+  backdrop-filter: blur(16px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
+}
+.markdy-showcase::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    linear-gradient(90deg, transparent 0 48%, rgba(255, 255, 255, 0.09) 50%, transparent 52%) 0 0 / 34px 34px,
+    linear-gradient(0deg, transparent 0 48%, rgba(255, 255, 255, 0.055) 50%, transparent 52%) 0 0 / 34px 34px;
+  mask-image: linear-gradient(to bottom, rgba(0,0,0,0.85), transparent 82%);
+  opacity: 0.48;
+  animation: markdyGridDrift 7s linear infinite;
+}
+.markdy-showcase::after {
+  content: "";
+  position: absolute;
+  inset: -40% -20%;
+  z-index: -1;
+  background: conic-gradient(from 90deg, transparent, color-mix(in srgb, var(--accent) 20%, transparent), transparent 32%);
+  opacity: 0.6;
+  animation: markdyAurora 9s linear infinite;
+}
+.markdy-showcase--byte_viz { width: 420px; }
+.markdy-showcase__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px 8px;
+}
+.markdy-showcase__title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 15px;
+  font-weight: 820;
+  letter-spacing: 0.01em;
+  color: #f8fafc;
+}
+.markdy-showcase__pill {
+  flex: 0 0 auto;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, transparent);
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: #bae6fd;
+  background: rgba(8, 47, 73, 0.54);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 0 16px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+.markdy-showcase__body { position: absolute; inset: 48px 14px 14px; }
+.markdy-showcase--parking_map { --accent: #38bdf8; --accent-2: #22c55e; }
+.parking-map__road {
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  top: 78px;
+  height: 50px;
+  border-radius: 999px;
+  background:
+    repeating-linear-gradient(90deg, rgba(226, 232, 240, 0.78) 0 18px, transparent 18px 34px) center / 100% 3px no-repeat,
+    linear-gradient(90deg, rgba(15, 23, 42, 0.96), rgba(30, 41, 59, 0.88));
+  box-shadow: 0 10px 28px rgba(2, 6, 23, 0.28) inset;
+}
+.parking-map__scan {
+  position: absolute;
+  left: 28px;
+  top: 42px;
+  width: 66px;
+  height: 124px;
+  border-radius: 18px;
+  border: 1px solid rgba(56, 189, 248, 0.55);
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.22), transparent);
+  box-shadow: 0 0 24px rgba(56, 189, 248, 0.28);
+  animation: markdyScanPulse 1.8s ease-in-out infinite;
+}
+.parking-map__car {
+  position: absolute;
+  left: 48px;
+  top: 86px;
+  width: 46px;
+  height: 22px;
+  border-radius: 11px 15px 15px 11px;
+  background: linear-gradient(90deg, #22d3ee, #818cf8);
+  box-shadow: 0 0 18px rgba(56, 189, 248, 0.55), 0 8px 18px rgba(2, 6, 23, 0.35);
+  animation: markdyCarGlide 3.8s cubic-bezier(.4,0,.2,1) infinite;
+}
+.parking-map__car::before,
+.parking-map__car::after {
+  content: "";
+  position: absolute;
+  bottom: -4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #020617;
+  border: 2px solid #cbd5e1;
+}
+.parking-map__car::before { left: 7px; }
+.parking-map__car::after { right: 7px; }
+.parking-map__slots {
+  position: absolute;
+  right: 12px;
+  top: 24px;
+  display: grid;
+  grid-template-columns: repeat(4, 44px);
+  gap: 8px;
+}
+.parking-map__slot {
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.34);
+  background: rgba(15, 23, 42, 0.7);
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.035) inset;
+}
+.parking-map__slot:nth-child(3),
+.parking-map__slot:nth-child(6),
+.parking-map__slot:nth-child(8) {
+  border-color: rgba(34, 197, 94, 0.78);
+  background: rgba(20, 83, 45, 0.5);
+  animation: markdySlotGlow 1.7s ease-in-out infinite;
+}
+.parking-map__route {
+  position: absolute;
+  left: 91px;
+  right: 95px;
+  top: 109px;
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, #22c55e, #38bdf8, transparent);
+  filter: drop-shadow(0 0 8px #22c55e);
+  animation: markdyRouteFlow 1.5s linear infinite;
+}
+.parking-map__stats {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 5px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+.parking-map__stat,
+.ascii-map__badge,
+.game-scene__hud,
+.byte-viz__badge {
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 12px;
+  padding: 8px;
+  background: rgba(2, 6, 23, 0.42);
+  color: #cbd5e1;
+  font-size: 10px;
+  font-weight: 760;
+}
+.parking-map__stat strong,
+.byte-viz__badge strong {
+  display: block;
+  margin-top: 2px;
+  color: #f8fafc;
+  font-size: 16px;
+}
+.markdy-showcase--ascii_map { --accent: #22c55e; --accent-2: #38bdf8; }
+.ascii-map__terminal {
+  position: absolute;
+  inset: 0;
+  border-radius: 18px;
+  border: 1px solid rgba(34, 197, 94, 0.34);
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.72), rgba(2, 6, 23, 0.36));
+  box-shadow: 0 0 28px rgba(34, 197, 94, 0.16) inset;
+}
+.ascii-map__chrome {
+  height: 28px;
+  padding-left: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+.ascii-map__chrome span {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #ef4444;
+  box-shadow: 14px 0 #f59e0b, 28px 0 #22c55e;
+}
+.ascii-map__code {
+  position: absolute;
+  left: 16px;
+  top: 46px;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 19px;
+  line-height: 1.55;
+  color: #bbf7d0;
+  text-shadow: 0 0 12px rgba(34, 197, 94, 0.45);
+}
+.ascii-map__code b {
+  color: #67e8f9;
+  animation: markdyBlink 1.2s steps(2, end) infinite;
+}
+.ascii-map__minimap {
+  position: absolute;
+  right: 18px;
+  top: 48px;
+  width: 102px;
+  height: 122px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 7px;
+}
+.ascii-map__mini-slot {
+  border-radius: 7px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.72);
+}
+.ascii-map__mini-slot:nth-child(2),
+.ascii-map__mini-slot:nth-child(6) {
+  border-color: rgba(34, 197, 94, 0.85);
+  background: rgba(20, 83, 45, 0.56);
+}
+.ascii-map__transform {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+.markdy-showcase--game_scene { --accent: #f59e0b; --accent-2: #22c55e; }
+.game-scene__world {
+  position: absolute;
+  inset: 0;
+  border-radius: 18px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 80% 18%, rgba(245, 158, 11, 0.22), transparent 26%),
+    linear-gradient(160deg, #172554, #020617 72%);
+}
+.game-scene__world::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(115deg, transparent 0 22px, rgba(255,255,255,0.06) 22px 24px);
+  animation: markdyRoadMove 4s linear infinite;
+}
+.game-scene__road {
+  position: absolute;
+  left: -35px;
+  right: -35px;
+  top: 94px;
+  height: 76px;
+  transform: rotate(-8deg);
+  background:
+    repeating-linear-gradient(90deg, #e2e8f0 0 24px, transparent 24px 46px) center / 100% 4px no-repeat,
+    linear-gradient(180deg, #334155, #0f172a);
+  box-shadow: 0 18px 32px rgba(2, 6, 23, 0.42);
+}
+.game-scene__car {
+  position: absolute;
+  left: 88px;
+  top: 126px;
+  width: 58px;
+  height: 30px;
+  border-radius: 12px 18px 18px 12px;
+  background: linear-gradient(90deg, #fb7185, #f59e0b);
+  transform: rotate(-8deg);
+  box-shadow: 0 0 24px rgba(245, 158, 11, 0.52);
+  animation: markdyCarPark 3.4s cubic-bezier(.2,1,.3,1) infinite;
+}
+.game-scene__spot {
+  position: absolute;
+  right: 54px;
+  top: 85px;
+  width: 90px;
+  height: 68px;
+  border: 3px solid rgba(34, 197, 94, 0.78);
+  border-left-style: dashed;
+  border-radius: 10px;
+  filter: drop-shadow(0 0 12px rgba(34, 197, 94, 0.48));
+}
+.game-scene__cones {
+  position: absolute;
+  right: 80px;
+  bottom: 34px;
+  display: flex;
+  gap: 14px;
+}
+.game-scene__cone {
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 26px solid #f97316;
+  filter: drop-shadow(0 5px 8px rgba(2, 6, 23, 0.35));
+}
+.game-scene__hud {
+  position: absolute;
+  left: 14px;
+  top: 14px;
+  min-width: 120px;
+  border-color: rgba(245, 158, 11, 0.38);
+}
+.game-scene__hud strong { color: #fed7aa; font-size: 18px; }
+.game-scene__perfect {
+  position: absolute;
+  left: 132px;
+  top: 54px;
+  color: #fef3c7;
+  font-size: 21px;
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  text-shadow: 0 0 18px rgba(245, 158, 11, 0.7);
+  animation: markdyPerfectPop 1.6s ease-in-out infinite;
+}
+.markdy-showcase--byte_viz { --accent: #a78bfa; --accent-2: #38bdf8; }
+.byte-viz__pipeline {
+  position: absolute;
+  inset: 4px;
+  display: grid;
+  grid-template-columns: 98px 1fr 122px;
+  gap: 12px;
+  align-items: stretch;
+}
+.byte-viz__glyph {
+  display: grid;
+  place-items: center;
+  border-radius: 22px;
+  border: 1px solid rgba(167, 139, 250, 0.45);
+  background: radial-gradient(circle at 30% 20%, rgba(167, 139, 250, 0.42), rgba(15, 23, 42, 0.78));
+  color: #fff;
+  font-size: 72px;
+  font-weight: 920;
+  box-shadow: 0 0 34px rgba(167, 139, 250, 0.32) inset;
+}
+.byte-viz__middle { display: grid; gap: 10px; }
+.byte-viz__row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.byte-viz__chip {
+  flex: 1 1 0;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 12px;
+  padding: 8px 10px;
+  background: rgba(2, 6, 23, 0.42);
+  color: #ddd6fe;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 12px;
+  font-weight: 800;
+}
+.byte-viz__arrow {
+  color: #67e8f9;
+  filter: drop-shadow(0 0 8px #38bdf8);
+  animation: markdyArrowPulse 1.1s ease-in-out infinite;
+}
+.byte-viz__bits {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 5px;
+}
+.byte-viz__bit {
+  display: grid;
+  place-items: center;
+  height: 31px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(56, 189, 248, 0.28);
+  color: #bae6fd;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 12px;
+  font-weight: 900;
+  animation: markdyBitFlip 1.9s ease-in-out infinite;
+}
+.byte-viz__bit:nth-child(2n) { animation-delay: 0.12s; }
+.byte-viz__bit:nth-child(3n) { animation-delay: 0.24s; }
+.byte-viz__side { display: grid; gap: 9px; }
+@keyframes markdyGridDrift { to { background-position: 34px 34px, 34px 34px; } }
+@keyframes markdyAurora { to { transform: rotate(1turn); } }
+@keyframes markdyScanPulse { 50% { transform: translateX(18px); opacity: 0.72; } }
+@keyframes markdyCarGlide { 0%, 12% { transform: translateX(0); } 68%, 100% { transform: translateX(198px); } }
+@keyframes markdySlotGlow { 50% { box-shadow: 0 0 20px rgba(34, 197, 94, 0.38); } }
+@keyframes markdyRouteFlow { to { filter: hue-rotate(70deg) drop-shadow(0 0 9px #38bdf8); } }
+@keyframes markdyBlink { 50% { opacity: 0.25; } }
+@keyframes markdyRoadMove { to { background-position: 44px 0; } }
+@keyframes markdyCarPark { 0%, 12% { transform: translateX(0) rotate(-8deg); } 70%, 100% { transform: translateX(164px) translateY(-31px) rotate(-1deg); } }
+@keyframes markdyPerfectPop { 0%, 100% { transform: scale(0.92); opacity: 0.72; } 50% { transform: scale(1.05); opacity: 1; } }
+@keyframes markdyArrowPulse { 50% { transform: translateX(3px); opacity: 0.72; } }
+@keyframes markdyBitFlip { 50% { transform: translateY(-2px); border-color: rgba(167, 139, 250, 0.75); } }
+`;
+  doc.head.appendChild(style);
+}
+
+function createShowcaseSurfaceEl(type: string, def: ActorDef): HTMLElement {
+  ensureShowcaseStyles(document);
+  const label = def.args[0] || type.replace("_", " ");
+  const root = document.createElement("div");
+  root.className = `markdy-showcase markdy-showcase--${type}`;
+  root.setAttribute("role", "img");
+  root.setAttribute("aria-label", label);
+
+  if (type === "parking_map") {
+    root.innerHTML = `
+      <div class="markdy-showcase__top"><div class="markdy-showcase__title"></div><div class="markdy-showcase__pill">live ops</div></div>
+      <div class="markdy-showcase__body">
+        <div class="parking-map__scan"></div><div class="parking-map__road"></div><div class="parking-map__route"></div><div class="parking-map__car"></div>
+        <div class="parking-map__slots"><span class="parking-map__slot"></span><span class="parking-map__slot"></span><span class="parking-map__slot"></span><span class="parking-map__slot"></span><span class="parking-map__slot"></span><span class="parking-map__slot"></span><span class="parking-map__slot"></span><span class="parking-map__slot"></span></div>
+        <div class="parking-map__stats"><div class="parking-map__stat">occupancy<strong>87%</strong></div><div class="parking-map__stat">OCR<strong>18ms</strong></div><div class="parking-map__stat">route<strong>A-17</strong></div></div>
+      </div>`;
+  } else if (type === "ascii_map") {
+    root.innerHTML = `
+      <div class="markdy-showcase__top"><div class="markdy-showcase__title"></div><div class="markdy-showcase__pill">parser</div></div>
+      <div class="markdy-showcase__body">
+        <div class="ascii-map__terminal"><div class="ascii-map__chrome"><span></span></div><div class="ascii-map__code">[P1][P2][<b>  </b>][EV]<br />[IN]===LANE===[OUT]<br />0101 0000 0100 0001</div><div class="ascii-map__minimap"><i class="ascii-map__mini-slot"></i><i class="ascii-map__mini-slot"></i><i class="ascii-map__mini-slot"></i><i class="ascii-map__mini-slot"></i><i class="ascii-map__mini-slot"></i><i class="ascii-map__mini-slot"></i></div><div class="ascii-map__transform"><div class="ascii-map__badge">tokens</div><div class="ascii-map__badge">graph</div><div class="ascii-map__badge">slots</div></div></div>
+      </div>`;
+  } else if (type === "game_scene") {
+    root.innerHTML = `
+      <div class="markdy-showcase__top"><div class="markdy-showcase__title"></div><div class="markdy-showcase__pill">60 fps</div></div>
+      <div class="markdy-showcase__body">
+        <div class="game-scene__world"><div class="game-scene__hud">combo<br /><strong>x4.2</strong></div><div class="game-scene__perfect">PERFECT PARK</div><div class="game-scene__road"></div><div class="game-scene__spot"></div><div class="game-scene__car"></div><div class="game-scene__cones"><i class="game-scene__cone"></i><i class="game-scene__cone"></i><i class="game-scene__cone"></i></div></div>
+      </div>`;
+  } else {
+    root.innerHTML = `
+      <div class="markdy-showcase__top"><div class="markdy-showcase__title"></div><div class="markdy-showcase__pill">UTF-8</div></div>
+      <div class="markdy-showcase__body">
+        <div class="byte-viz__pipeline"><div class="byte-viz__glyph">A</div><div class="byte-viz__middle"><div class="byte-viz__row"><div class="byte-viz__chip">char</div><span class="byte-viz__arrow">-></span><div class="byte-viz__chip">U+0041</div></div><div class="byte-viz__row"><div class="byte-viz__chip">0x41</div><span class="byte-viz__arrow">-></span><div class="byte-viz__chip">01000001</div></div><div class="byte-viz__bits"><span class="byte-viz__bit">0</span><span class="byte-viz__bit">1</span><span class="byte-viz__bit">0</span><span class="byte-viz__bit">0</span><span class="byte-viz__bit">0</span><span class="byte-viz__bit">0</span><span class="byte-viz__bit">0</span><span class="byte-viz__bit">1</span></div></div><div class="byte-viz__side"><div class="byte-viz__badge">bytes<strong>1</strong></div><div class="byte-viz__badge">planes<strong>BMP</strong></div><div class="byte-viz__badge">glyph<strong>paint</strong></div></div></div>
+      </div>`;
+  }
+
+  const title = root.querySelector<HTMLElement>(".markdy-showcase__title");
+  if (title) title.textContent = label;
+  return root;
+}
 
 function ensureArchitectureStyles(doc: Document): void {
   if (doc.getElementById(ARCHITECTURE_STYLE_ID)) return;
@@ -258,6 +730,10 @@ function isArchitectureNodeType(type: string): boolean {
   return ARCHITECTURE_NODE_TYPES.has(type);
 }
 
+function isShowcaseSurfaceType(type: string): boolean {
+  return SHOWCASE_SURFACE_TYPES.has(type);
+}
+
 function architectureTypeLabel(type: string): string {
   if (type === "db") return "database";
   if (type === "api") return "service";
@@ -352,6 +828,14 @@ export function createActorEl(
       break;
     }
 
+    case "parking_map":
+    case "ascii_map":
+    case "game_scene":
+    case "byte_viz": {
+      el = createShowcaseSurfaceEl(def.type, def);
+      break;
+    }
+
     case "service":
     case "api":
     case "microservice":
@@ -413,6 +897,7 @@ export function createActorEl(
   el.style.opacity = String(def.opacity ?? 1);
   if (def.z !== undefined) el.style.zIndex = String(def.z);
   else if (def.type === "caption") el.style.zIndex = "100";
+  else if (isShowcaseSurfaceType(def.type)) el.style.zIndex = "25";
   else if (isArchitectureNodeType(def.type)) el.style.zIndex = "10";
 
   return el;

--- a/packages/renderer-dom/src/animations.ts
+++ b/packages/renderer-dom/src/animations.ts
@@ -40,7 +40,8 @@ const DEFAULT_EASE_BY_ACTION: Record<string, string> = {
 export function buildAnimations(
   ast: SceneAST,
   actorEls: Map<string, HTMLElement>,
-  scene: HTMLElement,
+  actorLayer: HTMLElement,
+  cameraLayer: HTMLElement,
   assetOverrides: Record<string, string>,
   faceSwaps: FaceSwap[],
 ): Animation[] {
@@ -82,7 +83,7 @@ export function buildAnimations(
     // The camera is a reserved actor with no element of its own — it
     // transforms the whole content layer, so it routes separately.
     if (ev.actor === "camera") {
-      buildCameraAction(ev, scene, ast, baseOpts, anims, cameraState);
+      buildCameraAction(ev, cameraLayer, ast, baseOpts, anims, cameraState);
       continue;
     }
 
@@ -101,7 +102,7 @@ export function buildAnimations(
       ast,
       states,
       actorEls,
-      scene,
+      scene: actorLayer,
       assetOverrides,
       faceSwaps,
       anims,

--- a/packages/renderer-dom/src/geometry/path.ts
+++ b/packages/renderer-dom/src/geometry/path.ts
@@ -44,9 +44,71 @@ export function pointAtDistance(points: Point[], dist: number): Point {
       const t = seg <= 0 ? 0 : Math.min(1, remain / seg);
       return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
     }
+
     remain -= seg;
   }
   return points[0];
+}
+
+function segmentLength(a: Point, b: Point): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+export function labelPointForPath(points: Point[], lane: number): Point {
+  if (points.length < 2) return points[0] ?? { x: 0, y: 0 };
+
+  let bestIndex = 0;
+  let bestLength = -1;
+  for (let i = 0; i < points.length - 1; i++) {
+    const len = segmentLength(points[i], points[i + 1]);
+    if (len > bestLength) {
+      bestIndex = i;
+      bestLength = len;
+    }
+  }
+
+  const a = points[bestIndex];
+  const b = points[bestIndex + 1];
+  const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+  const offset = lane * 8;
+  if (Math.abs(a.x - b.x) >= Math.abs(a.y - b.y)) {
+    return { x: mid.x, y: mid.y - 10 - offset };
+  }
+  return { x: mid.x + 10 + offset, y: mid.y };
+}
+
+function clamp(n: number, min: number, max: number): number {
+  if (max < min) return n;
+  return Math.min(max, Math.max(min, n));
+}
+
+function clampPointToScene(point: Point, ast: SceneAST): Point {
+  const pad = 14;
+  return {
+    x: round1(clamp(point.x, pad, ast.meta.width - pad)),
+    y: round1(clamp(point.y, pad, ast.meta.height - pad)),
+  };
+}
+
+function routeLength(points: Point[]): number {
+  let total = 0;
+  for (let i = 0; i < points.length - 1; i++) total += segmentLength(points[i], points[i + 1]);
+  return total;
+}
+
+function routeBends(points: Point[]): number {
+  let bends = 0;
+  for (let i = 1; i < points.length - 1; i++) {
+    const prev = points[i - 1];
+    const cur = points[i];
+    const next = points[i + 1];
+    const dx1 = Math.sign(cur.x - prev.x);
+    const dy1 = Math.sign(cur.y - prev.y);
+    const dx2 = Math.sign(next.x - cur.x);
+    const dy2 = Math.sign(next.y - cur.y);
+    if (dx1 !== dx2 || dy1 !== dy2) bends++;
+  }
+  return bends;
 }
 
 /**
@@ -123,15 +185,28 @@ export function routeFlowPath(
     [source, { x: source.x, y: bottomLane }, { x: target.x, y: bottomLane }, target],
   );
 
+  const minObstacleX = obstacles.length
+    ? Math.min(...obstacles.map((o) => o.x1))
+    : Math.min(source.x, target.x);
+  const maxObstacleX = obstacles.length
+    ? Math.max(...obstacles.map((o) => o.x2))
+    : Math.max(source.x, target.x);
+  const leftLane = Math.max(16, minObstacleX - 24 - lane * 12);
+  const rightLane = Math.min(ast.meta.width - 16, maxObstacleX + 24 + lane * 12);
+  candidates.push(
+    [source, { x: leftLane, y: source.y }, { x: leftLane, y: target.y }, target],
+    [source, { x: rightLane, y: source.y }, { x: rightLane, y: target.y }, target],
+  );
+
   let best = candidates[0];
-  let bestHits = Number.POSITIVE_INFINITY;
+  let bestScore = Number.POSITIVE_INFINITY;
   for (const candidate of candidates) {
     const hits = countPathIntersections(candidate, obstacles);
-    if (hits < bestHits) {
+    const score = hits * 100000 + routeBends(candidate) * 800 + routeLength(candidate);
+    if (score < bestScore) {
       best = candidate;
-      bestHits = hits;
-      if (hits === 0) break;
+      bestScore = score;
     }
   }
-  return best;
+  return best.map((point) => clampPointToScene(point, ast));
 }

--- a/packages/renderer-dom/src/geometry/rect.ts
+++ b/packages/renderer-dom/src/geometry/rect.ts
@@ -27,13 +27,26 @@ export interface Rect {
  * they only feed routing heuristics, never layout.
  */
 const ACTOR_SIZES: Record<string, { width: number; height: number }> = {
-  service: { width: 180, height: 84 },
-  client: { width: 180, height: 84 },
-  db: { width: 180, height: 84 },
-  queue: { width: 180, height: 84 },
+  service: { width: 184, height: 88 },
+  api: { width: 184, height: 88 },
+  microservice: { width: 184, height: 88 },
+  client: { width: 184, height: 88 },
+  user: { width: 184, height: 88 },
+  db: { width: 184, height: 88 },
+  database: { width: 184, height: 88 },
+  queue: { width: 184, height: 88 },
+  cache: { width: 184, height: 88 },
+  cloud: { width: 184, height: 88 },
+  region: { width: 184, height: 88 },
+  container: { width: 184, height: 88 },
+  cluster: { width: 184, height: 88 },
   box: { width: 100, height: 100 },
   caption: { width: 260, height: 56 },
   figure: { width: 120, height: 170 },
+  parking_map: { width: 390, height: 250 },
+  ascii_map: { width: 390, height: 250 },
+  game_scene: { width: 390, height: 250 },
+  byte_viz: { width: 420, height: 250 },
 };
 
 const DEFAULT_ACTOR_SIZE = { width: 140, height: 42 };
@@ -43,13 +56,23 @@ export function actorSizeByType(type: string): { width: number; height: number }
 }
 
 export function actorCenter(state: ActorState, actorType: string): Point {
-  const { width, height } = actorSizeByType(actorType);
-  return { x: state.x + width / 2, y: state.y + height / 2 };
+  const rect = actorRect(state, actorType);
+  return { x: rect.x1 + (rect.x2 - rect.x1) / 2, y: rect.y1 + (rect.y2 - rect.y1) / 2 };
 }
 
 export function actorRect(state: ActorState, actorType: string): Rect {
   const { width, height } = actorSizeByType(actorType);
-  return { x1: state.x, y1: state.y, x2: state.x + width, y2: state.y + height };
+  const scale = Math.max(0.001, state.scale);
+  const scaledWidth = width * scale;
+  const scaledHeight = height * scale;
+  const dx = (scaledWidth - width) / 2;
+  const dy = (scaledHeight - height) / 2;
+  return {
+    x1: state.x - dx,
+    y1: state.y - dy,
+    x2: state.x + width + dx,
+    y2: state.y + height + dy,
+  };
 }
 
 export function inflateRect(rect: Rect, pad: number): Rect {

--- a/packages/renderer-dom/src/player.ts
+++ b/packages/renderer-dom/src/player.ts
@@ -23,10 +23,13 @@
 import { parse } from "@markdy/core";
 import type { Chapter, ParseWarning, SceneAST } from "@markdy/core";
 import type { FaceSwap } from "./types.js";
+import { stateFrom } from "./types.js";
 import { createActorEl } from "./actors.js";
 import { buildAnimations } from "./animations.js";
+import { actorRect, type Rect } from "./geometry/rect.js";
 
 const SCENE_STYLE_ID = "markdy-scene-ambience-styles";
+const SAFE_FRAME_PADDING = 28;
 
 function ensureSceneStyles(doc: Document): void {
   if (doc.getElementById(SCENE_STYLE_ID)) return;
@@ -75,6 +78,13 @@ function ensureSceneStyles(doc: Document): void {
 }
 .markdy-scene-content {
   z-index: 2;
+}
+.markdy-scene-actor-layer {
+  position: absolute;
+  inset: 0;
+  overflow: visible;
+  transform-origin: 0 0;
+  will-change: transform;
 }
 `;
   doc.head.appendChild(style);
@@ -126,6 +136,93 @@ export interface Player {
   /** Seeks to the start of the named chapter. No-op if the name doesn't match a chapter. */
   seekToChapter(name: string): void;
   destroy(): void;
+}
+
+interface SafeFrame {
+  x: number;
+  y: number;
+  scale: number;
+}
+
+function unionRect(a: Rect | null, b: Rect): Rect {
+  if (!a) return b;
+  return {
+    x1: Math.min(a.x1, b.x1),
+    y1: Math.min(a.y1, b.y1),
+    x2: Math.max(a.x2, b.x2),
+    y2: Math.max(a.y2, b.y2),
+  };
+}
+
+function numericPair(value: unknown): [number, number] | null {
+  if (!Array.isArray(value) || value.length < 2) return null;
+  const [x, y] = value;
+  return typeof x === "number" && typeof y === "number" ? [x, y] : null;
+}
+
+function computeContentBounds(ast: SceneAST): Rect | null {
+  let bounds: Rect | null = null;
+  const maxScaleByActor = new Map<string, number>();
+  const positionsByActor = new Map<string, Array<[number, number]>>();
+
+  for (const [name, def] of Object.entries(ast.actors)) {
+    maxScaleByActor.set(name, Math.max(0.001, def.scale ?? 1));
+    positionsByActor.set(name, [[def.x, def.y]]);
+  }
+
+  for (const ev of ast.events) {
+    if (ev.actor === "camera") continue;
+    if (ev.action === "scale" && typeof ev.params.to === "number") {
+      maxScaleByActor.set(ev.actor, Math.max(maxScaleByActor.get(ev.actor) ?? 1, ev.params.to));
+    }
+    if (ev.action === "move" || ev.action === "spring") {
+      const to = numericPair(ev.params.to);
+      if (to) positionsByActor.get(ev.actor)?.push(to);
+    }
+  }
+
+  for (const [name, def] of Object.entries(ast.actors)) {
+    const positions = positionsByActor.get(name) ?? [[def.x, def.y]];
+    const scale = maxScaleByActor.get(name) ?? def.scale ?? 1;
+    for (const [x, y] of positions) {
+      bounds = unionRect(bounds, actorRect({ ...stateFrom(def), x, y, scale }, def.type));
+    }
+  }
+
+  return bounds;
+}
+
+function computeSafeFrame(ast: SceneAST): SafeFrame {
+  const bounds = computeContentBounds(ast);
+  if (!bounds) return { x: 0, y: 0, scale: 1 };
+
+  const boundsWidth = Math.max(1, bounds.x2 - bounds.x1);
+  const boundsHeight = Math.max(1, bounds.y2 - bounds.y1);
+  const availableWidth = Math.max(1, ast.meta.width - SAFE_FRAME_PADDING * 2);
+  const availableHeight = Math.max(1, ast.meta.height - SAFE_FRAME_PADDING * 2);
+  const scale = Math.min(1, availableWidth / boundsWidth, availableHeight / boundsHeight);
+  const scaledWidth = boundsWidth * scale;
+  const scaledHeight = boundsHeight * scale;
+
+  function axisOffset(min: number, max: number, sceneSize: number, scaledSize: number): number {
+    const paddedMin = SAFE_FRAME_PADDING;
+    const paddedMax = sceneSize - SAFE_FRAME_PADDING;
+    const scaledMin = min * scale;
+    const scaledMax = max * scale;
+
+    if (scaledSize > paddedMax - paddedMin) return (sceneSize - scaledSize) / 2 - scaledMin;
+    if (scaledMin < paddedMin) return paddedMin - scaledMin;
+    if (scaledMax > paddedMax) return paddedMax - scaledMax;
+    return 0;
+  }
+
+  const x = axisOffset(bounds.x1, bounds.x2, ast.meta.width, scaledWidth);
+  const y = axisOffset(bounds.y1, bounds.y2, ast.meta.height, scaledHeight);
+  return {
+    x: Math.round(x * 1000) / 1000,
+    y: Math.round(y * 1000) / 1000,
+    scale: Math.round(scale * 1000) / 1000,
+  };
 }
 
 /**
@@ -293,6 +390,13 @@ export function createPlayer(opts: PlayerOptions): Player {
   });
   scene.appendChild(sceneContent);
 
+  const actorLayer = document.createElement("div");
+  actorLayer.className = "markdy-scene-actor-layer";
+  const safeFrame = computeSafeFrame(ast);
+  actorLayer.dataset.markdySafeFrame = `${safeFrame.x},${safeFrame.y},${safeFrame.scale}`;
+  actorLayer.style.transform = `translate(${safeFrame.x}px, ${safeFrame.y}px) scale(${safeFrame.scale})`;
+  sceneContent.appendChild(actorLayer);
+
   function scaleScene(): void {
     const s = viewport.clientWidth / ast.meta.width;
     scene.style.transform = `scale(${s})`;
@@ -305,13 +409,13 @@ export function createPlayer(opts: PlayerOptions): Player {
   const actorEls = new Map<string, HTMLElement>();
   for (const [name, def] of Object.entries(ast.actors)) {
     const el = createActorEl(name, def, ast.assets, assetOverrides);
-    sceneContent.appendChild(el);
+    actorLayer.appendChild(el);
     actorEls.set(name, el);
   }
 
   // ── Build all animations, keep them permanently paused ────────────────────
   const faceSwaps: FaceSwap[] = [];
-  const allAnims = buildAnimations(ast, actorEls, sceneContent, assetOverrides, faceSwaps);
+  const allAnims = buildAnimations(ast, actorEls, actorLayer, sceneContent, assetOverrides, faceSwaps);
   faceSwaps.sort((a, b) => a.timeMs - b.timeMs);
 
   for (const anim of allAnims) {

--- a/packages/renderer-dom/tests/geometry.test.ts
+++ b/packages/renderer-dom/tests/geometry.test.ts
@@ -17,6 +17,7 @@ import {
   segmentIntersectsRect,
 } from "../src/geometry/rect.js";
 import {
+  labelPointForPath,
   pointAtDistance,
   polylineLength,
   round1,
@@ -32,8 +33,8 @@ function stateAt(x: number, y: number): ActorState {
 
 describe("actor bounds", () => {
   it("gives system-diagram node types a shared footprint", () => {
-    for (const type of ["service", "client", "db", "queue"]) {
-      expect(actorSizeByType(type)).toEqual({ width: 180, height: 84 });
+    for (const type of ["service", "api", "microservice", "client", "user", "database", "db", "queue", "cache", "cloud", "region", "container", "cluster"]) {
+      expect(actorSizeByType(type)).toEqual({ width: 184, height: 88 });
     }
   });
 
@@ -44,6 +45,16 @@ describe("actor bounds", () => {
   it("treats an actor's position as its top-left corner", () => {
     expect(actorRect(stateAt(10, 20), "box")).toEqual({ x1: 10, y1: 20, x2: 110, y2: 120 });
     expect(actorCenter(stateAt(10, 20), "box")).toEqual({ x: 60, y: 70 });
+  });
+
+  it("expands bounds around the actor center when scale changes", () => {
+    expect(actorRect({ ...stateAt(10, 20), scale: 2 }, "box")).toEqual({
+      x1: -40,
+      y1: -30,
+      x2: 160,
+      y2: 170,
+    });
+    expect(actorCenter({ ...stateAt(10, 20), scale: 2 }, "box")).toEqual({ x: 60, y: 70 });
   });
 
   it("inflates rectangles symmetrically", () => {
@@ -123,6 +134,11 @@ describe("polyline measurement", () => {
   it("emits compact SVG path data", () => {
     expect(toPathD(path)).toBe("M 0 0 L 30 0 L 30 40");
     expect(round1(12.349)).toBe(12.3);
+  });
+
+  it("places labels on the longest segment with lane-aware offset", () => {
+    expect(labelPointForPath(path, 0)).toEqual({ x: 40, y: 20 });
+    expect(labelPointForPath(path, 2)).toEqual({ x: 56, y: 20 });
   });
 });
 

--- a/packages/renderer-dom/tests/render.extended.test.ts
+++ b/packages/renderer-dom/tests/render.extended.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { parse, registerActorPack } from "@markdy/core";
 import { createActorEl } from "../src/actors.js";
 import { buildAnimations } from "../src/animations.js";
+import { createPlayer } from "../src/player.js";
 import type { FaceSwap } from "../src/types.js";
 
 // ---------------------------------------------------------------------------
@@ -23,6 +24,7 @@ beforeAll(() => {
           removeEventListener() {},
           currentTime: 0,
           playState: "paused",
+          _target: this,
           // Non-standard fields — tests read these to assert on keyframe shape
           // without needing a full WAAPI implementation.
           _keyframes: keyframes,
@@ -30,6 +32,13 @@ beforeAll(() => {
         } as unknown as Animation;
       };
     }
+  }
+  if (typeof (g as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver !== "function") {
+    (g as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
   }
 
   registerActorPack({
@@ -72,7 +81,7 @@ function mount(code: string) {
     actorEls.set(name, el);
   }
   const faceSwaps: FaceSwap[] = [];
-  const anims = buildAnimations(ast, actorEls, sceneContent, {}, faceSwaps);
+  const anims = buildAnimations(ast, actorEls, sceneContent, sceneContent, {}, faceSwaps);
   return { ast, scene, sceneContent, actorEls, anims };
 }
 
@@ -345,6 +354,55 @@ describe("renderer — system flow actions", () => {
     expect(actorEls.get("client")?.textContent).toContain("Browser");
     expect(actorEls.get("auth")?.textContent).toContain("Auth API");
     expect(anims.length).toBeGreaterThan(0);
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe("renderer — safe framing", () => {
+    it("wraps actors in a safe-frame layer when content would otherwise clip", () => {
+      const container = document.createElement("div");
+      const player = createPlayer({
+        container,
+        code: [
+          "scene width=400 height=240 bg=#0f172a",
+          "actor left = box() at (0, 20) scale 2",
+          "actor right = box() at (300, 120) scale 2",
+        ].join("\n"),
+        autoplay: false,
+        copyright: false,
+        progressBar: false,
+      });
+
+      const layer = container.querySelector<HTMLElement>(".markdy-scene-actor-layer");
+      expect(layer).toBeDefined();
+      expect(layer?.dataset.markdySafeFrame).not.toBe("0,0,1");
+      expect(layer?.style.transform).toContain("scale(");
+      player.destroy();
+    });
+
+    it("keeps camera animations off the safe-frame actor layer", () => {
+      const ast = parse(
+        [
+          "scene width=400 height=240 bg=#0f172a",
+          "actor card = box() at (300, 120) scale 2",
+          "@0.0: camera.zoom(to=1.2, dur=0.4)",
+        ].join("\n"),
+      );
+      const actorLayer = document.createElement("div");
+      const cameraLayer = document.createElement("div");
+      const actorEls = new Map<string, HTMLElement>();
+      actorEls.set("card", createActorEl("card", ast.actors["card"], ast.assets, {}));
+
+      const anims = buildAnimations(ast, actorEls, actorLayer, cameraLayer, {}, []);
+      const cameraAnim = anims.find((anim) => {
+        const keyframes = (anim as unknown as { _keyframes?: unknown })._keyframes;
+        return Array.isArray(keyframes) && keyframes.some((frame) => String((frame as Keyframe).transform ?? "").includes("scale(1.2)"));
+      });
+
+      expect(cameraAnim).toBeDefined();
+      expect((cameraAnim as unknown as { _target?: Element })._target).toBe(cameraLayer);
+      expect((cameraAnim as unknown as { _target?: Element })._target).not.toBe(actorLayer);
+    });
   });
 
   it("routes around a blocking middle actor in a 3-actor scene", () => {

--- a/packages/stdlib-systems/README.md
+++ b/packages/stdlib-systems/README.md
@@ -14,6 +14,14 @@ Adds actor types:
 - `db`
 - `queue`
 - `client`
+- `cloud`
+- `region`
+- `container`
+- `cluster`
+- `parking_map`
+- `ascii_map`
+- `game_scene`
+- `byte_viz`
 
 Adds actions:
 - `.request(to=..., label=..., dur=...)`

--- a/packages/stdlib-systems/src/index.ts
+++ b/packages/stdlib-systems/src/index.ts
@@ -14,6 +14,10 @@ export const SYSTEM_ACTOR_TYPES = [
   "region",
   "container",
   "cluster",
+  "parking_map",
+  "ascii_map",
+  "game_scene",
+  "byte_viz",
 ] as const;
 export const SYSTEM_FLOW_ACTIONS = ["request", "response", "emit"] as const;
 

--- a/website/src/data/examples.ts
+++ b/website/src/data/examples.ts
@@ -12,7 +12,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-export type ExampleCategory = "product" | "system" | "chart" | "ui-state" | "reliability";
+export type ExampleCategory = "product" | "system" | "chart" | "ui-state" | "reliability" | "interactive" | "education";
 
 export interface ExampleMeta {
   id: string;
@@ -34,45 +34,37 @@ export interface ExampleEntry extends ExampleMeta {
   code: string;
 }
 
-// Bullet Reveal is first (and has no explicit previewStart override), which
-// makes it the landing-page/playground default — it's the calmest and most
-// immediately legible of the five: no failure states, no camera movement.
+// The first entry is the landing-page/playground default. Keep it high-impact:
+// this curated set should showcase complex animated UI, systems, and education scenes.
 export const EXAMPLE_REGISTRY: ExampleMeta[] = [
   {
-    id: "bullet-reveal",
-    title: "Bullet Reveal",
-    description: "Sequential bullet points animating in with stagger — the PowerPoint-style reveal people actually need.",
-    category: "product",
-    file: "showcase/bullet-reveal.markdy",
+    id: "cyber-parking-control",
+    title: "Cyber Parking Control",
+    description: "A smart-garage control-room video with a custom CSS dashboard, OCR flow, live routing, glow effects, and a cinematic camera push.",
+    category: "system",
+    file: "showcase/cyber-parking-control.markdy",
     playback: { previewStart: 0 },
   },
   {
-    id: "request-lifecycle",
-    title: "Request Lifecycle",
-    description: "Browser to CDN to server to database, with a packet traveling the path and a response returning.",
-    category: "system",
-    file: "showcase/request-lifecycle.markdy",
+    id: "ascii-parking-garage",
+    title: "ASCII Parking Garage",
+    description: "A terminal-style ASCII map compiler that turns text rows into lane graphs, bay nodes, state sync, and a polished animated mini-map.",
+    category: "education",
+    file: "showcase/ascii-parking-garage.markdy",
   },
   {
-    id: "bar-chart-grow-in",
-    title: "Bar Chart Grow-In",
-    description: "Bars rising with staggered easing while axis labels settle into place.",
-    category: "chart",
-    file: "showcase/bar-chart-grow-in.markdy",
+    id: "parking-game-loop",
+    title: "Parking Game Loop",
+    description: "An arcade-grade parking-game viewport with CSS road motion, car parking, HUD, physics/collision flow, replay capture, and score punch-in.",
+    category: "interactive",
+    file: "showcase/parking-game-loop.markdy",
   },
   {
-    id: "retry-with-backoff",
-    title: "Retry with Backoff",
-    description: "A failing request retrying at increasing intervals until it succeeds.",
-    category: "reliability",
-    file: "showcase/retry-with-backoff.markdy",
-  },
-  {
-    id: "component-state-transition",
-    title: "Component State Transition",
-    description: "A card moving through idle, loading, loaded, and error states.",
-    category: "ui-state",
-    file: "showcase/component-state-transition.markdy",
+    id: "utf8-byte-visualizer",
+    title: "UTF-8 Byte Visualizer",
+    description: "A rich byte-visualizer surface where one character becomes code point, hex byte, bit lanes, and a rendered glyph with data-flow choreography.",
+    category: "education",
+    file: "showcase/utf8-byte-visualizer.markdy",
   },
 ];
 

--- a/website/src/editor/markdy-language.ts
+++ b/website/src/editor/markdy-language.ts
@@ -228,12 +228,19 @@ const keywordCompletions: Completion[] = [
   { label: "at",     type: "keyword", detail: "position",          info: "at (x, y)" },
 ];
 
+function systemTypeDetail(label: string): string {
+  if (label === "parking_map" || label === "ascii_map" || label === "game_scene" || label === "byte_viz") {
+    return "premium showcase surface";
+  }
+  return "architecture node";
+}
+
 const typeCompletions: Completion[] = [
   { label: "figure", type: "type", detail: "stick figure",    info: "figure(skin, gender, face)" },
   { label: "text",   type: "type", detail: "text label",      info: 'text("content")' },
   { label: "sprite", type: "type", detail: "image sprite",    info: "sprite(assetName)" },
   { label: "box",    type: "type", detail: "grey box",        info: "box()" },
-  ...SYSTEM_ACTOR_TYPES.map((label): Completion => ({ label, type: "type", detail: "architecture node", info: `${label} Name` })),
+  ...SYSTEM_ACTOR_TYPES.map((label): Completion => ({ label, type: "type", detail: systemTypeDetail(label), info: `${label} Name` })),
   { label: "image",  type: "type", detail: "image asset",     info: 'image("path/to/img.png")' },
   { label: "icon",   type: "type", detail: "icon asset",      info: 'icon("set:name")' },
 ];

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1105,10 +1105,14 @@ scene width=800 height=400 bg=#f8fafc
   import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
 
   import { markdyLanguage, markdyAutocomplete, markdyHighlightLight, markdyHighlightDark } from "../editor/markdy-language";
+  import { registerActorPack } from "@markdy/core";
   import { baseTheme, lightTheme, darkTheme } from "../editor/editor-theme";
   import { createPlayer } from "@markdy/renderer-dom";
+  import { systemsPack } from "@markdy/stdlib-systems";
   import type { Player } from "@markdy/renderer-dom";
   import type { ExampleEntry } from "../data/examples";
+
+  registerActorPack(systemsPack);
 
   const examples: ExampleEntry[]  = (window as any).__MARKDY_EXAMPLES;
   const assets: Record<string, string> = (window as any).__MARKDY_ASSETS;


### PR DESCRIPTION
## Summary
- add four polished playground showcase scenes for cyber parking, ASCII parking, game loop, and UTF-8 visualization
- add premium renderer showcase surfaces with rich HTML/CSS animation details
- add safe framing and improved flow routing so dense scenes stay clean and inside the viewport

## Validation
- pnpm --filter @markdy/renderer-dom run typecheck
- pnpm --filter @markdy/renderer-dom run test
- pnpm --filter @markdy/renderer-dom run build
- pnpm run verify:examples
- pnpm --filter @markdy/website run build
- browser smoke test: playground renders premium parking scene with no console errors