### PR TITLE
fix: prevent flow-edge label overlaps and rework Learn guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.29] — 2026-08-02
+
+### Fixed
+- **Flow-edge labels no longer overlap** — Edges now appear at their scheduled time and persist, assembling the diagram instead of showing every label from the first frame. Labels are placed with collision avoidance so they never sit on top of nodes, the title caption, or one another, and the traveling dot fades on arrival to leave a clean line and arrowhead.
+
+### Changed
+- **Learn MarkdyScript rebuilt around architecture diagrams** — The step-by-step guide now teaches the real production recipe (systems nodes, grouped reveals, chaptered `request`/`response`/`emit` flows, polish, and camera direction) with practical, runnable examples instead of one-off story scenes.
+
 ## [0.7.28] — 2026-08-02
 
 ### Added

--- a/packages/renderer-dom/src/actions/flow.ts
+++ b/packages/renderer-dom/src/actions/flow.ts
@@ -8,7 +8,9 @@
  * busy sequence diagram doesn't accumulate clutter.
  */
 import type { ActionContext, ActionHandler } from "./context.js";
-import { labelPointForPath, polylineLength, round1, routeFlowPath, toPathD } from "../geometry/path.js";
+import type { ActorState } from "../types.js";
+import { placeFlowLabel, polylineLength, routeFlowPath, toPathD } from "../geometry/path.js";
+import { actorRect, inflateRect, type Rect } from "../geometry/rect.js";
 
 const EDGE_LAYER_ATTR = "data-markdy-edge-layer";
 
@@ -21,8 +23,20 @@ const STROKE_BY_ACTION: Record<string, string> = {
 
 const DEFAULT_STROKE = "#38bdf8";
 const LABEL_MAX_CHARS = 28;
-/** How long an edge lingers after its dot arrives, in milliseconds. */
-const EDGE_FADE_MS = 140;
+/** Approximate rendered width of one label character at 12px bold, in px. */
+const LABEL_CHAR_PX = 6.8;
+/** How long the draw-on / fade-in of an edge takes, in milliseconds. */
+const EDGE_REVEAL_MS = 220;
+
+/**
+ * Per-scene registry of placed label rectangles.
+ *
+ * Flow edges are built independently (one call to `buildEdge` each), but their
+ * labels must not collide, so each edge records the box it claimed here and
+ * later edges route their labels around the accumulated set. Keyed by the SVG
+ * overlay element so a rebuilt scene (new overlay) starts from a clean slate.
+ */
+const LABEL_RECTS = new WeakMap<SVGSVGElement, Rect[]>();
 
 /**
  * Lazily creates the shared SVG overlay that all flow edges draw into.
@@ -98,6 +112,22 @@ function isDashed(ctx: ActionContext): boolean {
   return style === "dashed" || style === "fire_and_forget" || ctx.ev.action === "response";
 }
 
+/**
+ * Bounding box an edge label must dodge.
+ *
+ * Normal top-left-anchored actors use their `actorRect`. A `caption` is a
+ * centered overlay ribbon whose real rendered width depends on its text (and
+ * so isn't known here), so we reserve its full-width horizontal band — which
+ * is also what a title/subtitle visually occupies — keeping edge labels out
+ * of the title zone entirely.
+ */
+function nodeObstacleRect(state: ActorState, type: string, sceneWidth: number): Rect {
+  const rect = actorRect(state, type);
+  if (type !== "caption") return rect;
+  const halfH = (rect.y2 - rect.y1) / 2 + 4;
+  return { x1: 0, y1: state.y - halfH, x2: sceneWidth, y2: state.y + halfH };
+}
+
 function buildEdge(ctx: ActionContext, targetName: string): void {
   const { ev, state, states, ast, scene, baseOpts, anims } = ctx;
   const targetState = states.get(targetName);
@@ -115,8 +145,16 @@ function buildEdge(ctx: ActionContext, targetName: string): void {
   const svg = ensureEdgeLayer(scene);
   ensureEdgeDefs(svg);
 
+  const startMs = Number(baseOpts.delay ?? 0);
+  const durationMs = Math.max(1, Number(baseOpts.duration ?? 500));
+  const revealMs = Math.min(EDGE_REVEAL_MS, durationMs);
+
   const group = document.createElementNS("http://www.w3.org/2000/svg", "g");
   group.setAttribute("data-markdy-flow-edge", "1");
+  // Hidden until the edge's scheduled time; `fill: both` on the reveal below
+  // holds this 0 during the delay so future edges don't show early, then the
+  // edge draws on and stays part of the assembled diagram.
+  group.style.opacity = "0";
 
   const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
   path.setAttribute("d", pathD);
@@ -145,22 +183,34 @@ function buildEdge(ctx: ActionContext, targetName: string): void {
 
   const labelText = String(ev.params.label ?? "");
   if (labelText) {
-    const midPoint = labelPointForPath(points, lane);
+    const shown =
+      labelText.length > LABEL_MAX_CHARS ? `${labelText.slice(0, LABEL_MAX_CHARS - 1)}…` : labelText;
+    const textWidth = shown.length * LABEL_CHAR_PX + 12;
+
+    const placed = LABEL_RECTS.get(svg) ?? (LABEL_RECTS.set(svg, []), LABEL_RECTS.get(svg)!);
+    const obstacles: Rect[] = [...placed];
+    for (const [name, nodeState] of states.entries()) {
+      const type = ast.actors[name]?.type ?? "box";
+      obstacles.push(inflateRect(nodeObstacleRect(nodeState, type, ast.meta.width), 2));
+    }
+
+    const spot = placeFlowLabel(points, textWidth, obstacles, ast);
+    placed.push(spot.rect);
+
     const label = document.createElementNS("http://www.w3.org/2000/svg", "text");
-    label.setAttribute("x", `${round1(midPoint.x)}`);
-    label.setAttribute("y", `${round1(midPoint.y - 8)}`);
+    label.setAttribute("x", `${spot.x}`);
+    label.setAttribute("y", `${spot.y}`);
     label.setAttribute("text-anchor", "middle");
+    label.setAttribute("dominant-baseline", "middle");
     label.setAttribute("font-size", "12");
     label.setAttribute("font-weight", "700");
     label.setAttribute("paint-order", "stroke");
-    label.setAttribute("stroke", "rgba(2, 6, 23, 0.88)");
+    label.setAttribute("stroke", "rgba(2, 6, 23, 0.9)");
     label.setAttribute("stroke-width", "5");
     label.setAttribute("stroke-linejoin", "round");
-    label.setAttribute("fill", "#cbd5e1");
-    label.setAttribute("filter", "url(#markdy-flow-glow)");
+    label.setAttribute("fill", "#dbe4f0");
     label.setAttribute("data-full-label", labelText);
-    label.textContent =
-      labelText.length > LABEL_MAX_CHARS ? `${labelText.slice(0, LABEL_MAX_CHARS - 1)}…` : labelText;
+    label.textContent = shown;
     group.appendChild(label);
   }
 
@@ -168,17 +218,22 @@ function buildEdge(ctx: ActionContext, targetName: string): void {
 
   anims.push(
     path.animate([{ strokeDashoffset: length }, { strokeDashoffset: 0 }], baseOpts),
+    // Travel the dot along the edge, then fade it at arrival so the finished
+    // edge is a clean line + arrowhead rather than a dot resting on the tip.
     marker.animate(
       [
-        { offsetDistance: "0%", opacity: 1 },
-        { offsetDistance: "100%", opacity: 1 },
+        { offsetDistance: "0%", opacity: 1, offset: 0 },
+        { offsetDistance: "100%", opacity: 1, offset: 0.82 },
+        { offsetDistance: "100%", opacity: 0, offset: 1 },
       ],
       baseOpts,
     ),
-    group.animate([{ opacity: 1 }, { opacity: 0 }], {
-      delay: Number(baseOpts.delay ?? 0) + Number(baseOpts.duration ?? 0),
-      duration: EDGE_FADE_MS,
-      fill: "forwards",
+    // Reveal the edge at its scheduled time and keep it (persist). `fill: both`
+    // holds opacity 0 during the delay, so nothing appears before its turn.
+    group.animate([{ opacity: 0 }, { opacity: 1 }], {
+      delay: startMs,
+      duration: revealMs,
+      fill: "both",
     }),
   );
 }

--- a/packages/renderer-dom/src/geometry/path.ts
+++ b/packages/renderer-dom/src/geometry/path.ts
@@ -77,6 +77,92 @@ export function labelPointForPath(points: Point[], lane: number): Point {
   return { x: mid.x + 10 + offset, y: mid.y };
 }
 
+function rectsOverlap(a: Rect, b: Rect): boolean {
+  return a.x1 < b.x2 && a.x2 > b.x1 && a.y1 < b.y2 && a.y2 > b.y1;
+}
+
+function overlapCount(rect: Rect, obstacles: Rect[]): number {
+  let hits = 0;
+  for (const o of obstacles) if (rectsOverlap(rect, o)) hits++;
+  return hits;
+}
+
+export interface LabelPlacement {
+  x: number;
+  y: number;
+  rect: Rect;
+}
+
+const LABEL_BOX_HEIGHT = 18;
+
+/**
+ * Chooses a readable anchor for an edge label.
+ *
+ * The label starts centered on the edge's longest segment, then steps
+ * perpendicular to that segment — preferring above (horizontal edges) or to
+ * the right (vertical edges) — until it clears every obstacle it's given
+ * (node boxes plus already-placed labels). The whole box is kept inside the
+ * scene, and the least-crowded candidate wins if nothing is fully clear.
+ */
+export function placeFlowLabel(
+  points: Point[],
+  textWidth: number,
+  obstacles: Rect[],
+  ast: SceneAST,
+): LabelPlacement {
+  let bestIndex = 0;
+  let bestLength = -1;
+  for (let i = 0; i < points.length - 1; i++) {
+    const len = segmentLength(points[i], points[i + 1]);
+    if (len > bestLength) {
+      bestLength = len;
+      bestIndex = i;
+    }
+  }
+
+  const a = points[bestIndex] ?? { x: 0, y: 0 };
+  const b = points[bestIndex + 1] ?? a;
+  const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+  const horizontal = Math.abs(a.x - b.x) >= Math.abs(a.y - b.y);
+
+  const half = textWidth / 2;
+  const halfH = LABEL_BOX_HEIGHT / 2;
+  const pad = 8;
+
+  const base = horizontal ? 15 : half + 12;
+  const step = horizontal ? LABEL_BOX_HEIGHT + 3 : textWidth + 12;
+  const order = horizontal ? [-1, 1] : [1, -1];
+  const offsets: number[] = [];
+  for (let k = 0; k < 7; k++) {
+    for (const sign of order) offsets.push(sign * (base + k * step));
+  }
+
+  let fallback: LabelPlacement | null = null;
+  let fallbackHits = Number.POSITIVE_INFINITY;
+
+  for (const off of offsets) {
+    let cx = horizontal ? mid.x : mid.x + off;
+    let cy = horizontal ? mid.y + off : mid.y;
+    cx = clamp(cx, pad + half, ast.meta.width - pad - half);
+    cy = clamp(cy, pad + halfH, ast.meta.height - pad - halfH);
+    const rect: Rect = { x1: cx - half, y1: cy - halfH, x2: cx + half, y2: cy + halfH };
+    const hits = overlapCount(rect, obstacles);
+    if (hits === 0) return { x: round1(cx), y: round1(cy), rect };
+    if (hits < fallbackHits) {
+      fallbackHits = hits;
+      fallback = { x: round1(cx), y: round1(cy), rect };
+    }
+  }
+
+  return (
+    fallback ?? {
+      x: round1(mid.x),
+      y: round1(mid.y),
+      rect: { x1: mid.x - half, y1: mid.y - halfH, x2: mid.x + half, y2: mid.y + halfH },
+    }
+  );
+}
+
 function clamp(n: number, min: number, max: number): number {
   if (max < min) return n;
   return Math.min(max, Math.max(min, n));

--- a/packages/renderer-dom/tests/geometry.test.ts
+++ b/packages/renderer-dom/tests/geometry.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { parse, TECHNICAL_NODE_TYPES } from "@markdy/core";
+import type { SceneAST } from "@markdy/core";
 import {
   actorCenter,
   actorRect,
@@ -16,8 +17,10 @@ import {
   inflateRect,
   segmentIntersectsRect,
 } from "../src/geometry/rect.js";
+import type { Rect } from "../src/geometry/rect.js";
 import {
   labelPointForPath,
+  placeFlowLabel,
   pointAtDistance,
   polylineLength,
   round1,
@@ -139,6 +142,34 @@ describe("polyline measurement", () => {
   it("places labels on the longest segment with lane-aware offset", () => {
     expect(labelPointForPath(path, 0)).toEqual({ x: 40, y: 20 });
     expect(labelPointForPath(path, 2)).toEqual({ x: 56, y: 20 });
+  });
+});
+
+describe("placeFlowLabel", () => {
+  const ast = { meta: { width: 400, height: 300 } } as unknown as SceneAST;
+  const rectsOverlap = (a: Rect, b: Rect) =>
+    a.x1 < b.x2 && a.x2 > b.x1 && a.y1 < b.y2 && a.y2 > b.y1;
+
+  it("centers on the longest segment when nothing is in the way", () => {
+    const spot = placeFlowLabel([{ x: 40, y: 100 }, { x: 240, y: 100 }], 60, [], ast);
+    expect(spot.x).toBe(140);
+    // A horizontal edge parks its label just above the line.
+    expect(spot.y).toBeLessThan(100);
+  });
+
+  it("nudges the label clear of an obstacle it would otherwise hit", () => {
+    const points = [{ x: 40, y: 100 }, { x: 240, y: 100 }];
+    const blocker: Rect = { x1: 100, y1: 70, x2: 180, y2: 100 };
+    const spot = placeFlowLabel(points, 60, [blocker], ast);
+    expect(rectsOverlap(spot.rect, blocker)).toBe(false);
+  });
+
+  it("keeps the whole label box inside the scene", () => {
+    const spot = placeFlowLabel([{ x: 4, y: 6 }, { x: 4, y: 260 }], 120, [], ast);
+    expect(spot.rect.x1).toBeGreaterThanOrEqual(0);
+    expect(spot.rect.x2).toBeLessThanOrEqual(ast.meta.width);
+    expect(spot.rect.y1).toBeGreaterThanOrEqual(0);
+    expect(spot.rect.y2).toBeLessThanOrEqual(ast.meta.height);
   });
 });
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -454,7 +454,7 @@ markdy <span class="u-fn">check-all</span> examples`;
     <div class="section-header">
       <span class="section-tag">Step-by-Step</span>
       <h2>Learn MarkdyScript</h2>
-      <p>Build cinematic scenes with premium surfaces, routed systems, reusable choreography, and camera direction. Every card is runnable in the playground.</p>
+      <p>Build production architecture diagrams step by step: lay out systems nodes, narrate the flow with labeled <code>request</code>/<code>response</code>/<code>emit</code> edges, group reveals into chapters, then add polish and camera direction. Every card is runnable in the playground.</p>
     </div>
 
     <div class="ref-grid">
@@ -466,32 +466,34 @@ markdy <span class="u-fn">check-all</span> examples`;
           <h3>Cinematic Scene Setup</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Start with a wide video canvas, dark art direction, and 60fps when the scene needs HUD detail, glow, and smooth motion.</p>
+        <p class="ref-intro">Start with a wide 16:9 canvas and dark art direction, then declare systems nodes with the <code>&lt;type&gt; Name "Label" at (x, y)</code> shorthand and reveal them together with a staggered <code>group</code>.</p>
         <div class="ref-code-wrap">
-        <pre><code>scene width=1280 height=720 bg=#050816 fps=60
-actor title = caption("Cyber parking control room") at top opacity 0
-        actor hud = surface("Vision routing HUD", "live ops", cyan) at (56, 124) scale 0.9 opacity 0</code></pre>
+        <pre><code>scene width=1280 height=720 bg=#07111f fps=60
+actor title = caption("Checkout Service") at top opacity 0
+client Web "Web App" at (110, 320) opacity 0
+service Orders "Order Service" at (660, 230) opacity 0</code></pre>
         <script type="text/plain" class="ref-code-data">
-scene width=1280 height=720 bg=#050816 fps=60
-actor title = caption("Cyber parking control room") at top opacity 0
-actor hud = surface("Vision routing HUD", "live ops", cyan) at (56, 124) scale 0.9 opacity 0 z 35
-actor status = text("SCAN -> OCR -> ROUTE -> GATE") at (432, 632) size 23 opacity 0 z 70
+scene width=1280 height=720 bg=#07111f fps=60
+actor title = caption("Checkout Service") at top opacity 0
+client Web "Web App" at (110, 320) opacity 0
+api_gateway Gateway "API Gateway" at (380, 320) opacity 0
+service Orders "Order Service" at (660, 230) opacity 0
+database OrderDB "Orders DB" at (930, 230) opacity 0
+
+group nodes = Web, Gateway, Orders, OrderDB
 
 @0.0: title.line_reveal(from=left, dur=0.42)
-@0.1: hud.fade_in(dur=0.45)
-@0.1: hud.mask(from=0, to=120, dur=0.75, ease=smooth)
-@0.2: hud.glow(color=#38bdf8, strength=42, dur=0.75)
-@0.8: status.line_reveal(from=left, dur=0.45)
+@0.2: nodes.fade_in(dur=0.5, stagger=0.08)
         </script>
         </div>
         <table>
           <thead><tr><th>Property</th><th>Default</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>width</code></td><td><code>800</code></td><td>Canvas width in pixels</td></tr>
-            <tr><td><code>height</code></td><td><code>400</code></td><td>Canvas height in pixels</td></tr>
-            <tr><td><code>fps</code></td><td><code>30</code></td><td>Frame rate for the rendering engine</td></tr>
-            <tr><td><code>bg</code></td><td><code>white</code></td><td>Use art-directed CSS colors; dark scenes make neon surfaces pop</td></tr>
-            <tr><td><code>duration</code></td><td><i>auto</i></td><td>Override total length in seconds</td></tr>
+            <tr><td><code>width</code></td><td><code>800</code></td><td>Canvas width — use <code>1280</code> for presentation diagrams</td></tr>
+            <tr><td><code>height</code></td><td><code>400</code></td><td>Canvas height — <code>720</code> keeps a clean 16:9 frame</td></tr>
+            <tr><td><code>fps</code></td><td><code>30</code></td><td>Frame rate; <code>60</code> for smooth glow and camera moves</td></tr>
+            <tr><td><code>bg</code></td><td><code>white</code></td><td>Dark backgrounds (<code>#07111f</code>) make node accents pop</td></tr>
+            <tr><td><code>group</code></td><td><i>—</i></td><td>Name a set of nodes to reveal or animate together with <code>stagger</code></td></tr>
           </tbody>
         </table>
       </article>
@@ -503,40 +505,40 @@ actor status = text("SCAN -> OCR -> ROUTE -> GATE") at (432, 632) size 23 opacit
           <h3>Visual Primitives</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Compose reusable visual primitives instead of relying on one-off story actors.</p>
+        <p class="ref-intro">Beyond diagram nodes, compose reusable visual primitives — <code>surface</code>, <code>terminal</code>, <code>matrix</code>, <code>stat</code>, <code>chips</code>, <code>glyph</code> — for dashboards, code panels, and annotations. Each takes a label first and a colour tone last.</p>
         <div class="ref-code-wrap">
-        <pre><code>actor shell = terminal("Compiler", "[IN]===LANE===[OUT]", "tokens -> graph", "slots -> state", green) at (58, 130)
-actor cells = matrix("Cells", "4x2", "3 6 8", green) at (236, 154)
-actor stat = stat("latency", "18ms", cyan) at (196, 322)</code></pre>
+        <pre><code>actor shell = terminal("Build log", "npm run build", "✓ 42 modules", "done in 1.2s", green) at (58, 130)
+actor cells = matrix("Cache", "4x2", "3 6 8", green) at (236, 154)
+actor kpi = stat("p99 latency", "18ms", cyan) at (196, 322)</code></pre>
         <script type="text/plain" class="ref-code-data">
 scene width=1280 height=720 bg=#07111f fps=60
 
-actor title = caption("ASCII parking garage") at top opacity 0
-actor ascii = terminal("Text map compiler", "[P1][P2][  ][EV]", "[IN]===LANE===[OUT]", "0101 0000 0100 0001", green) at (58, 130) scale 0.9 opacity 0 z 35
-actor mini = matrix("mini map", "3x2", "2 6", green) at (282, 192) opacity 0 scale 0.72 z 50
-actor stages = chips("tokens|graph|slots", green) at (88, 324) opacity 0 scale 0.84 z 55
-client Terminal "Terminal" at (600, 150) opacity 0
-service Lexer "Lexer" at (832, 150) opacity 0
-service Graph "Graph builder" at (1064, 150) opacity 0
+actor title = caption("Build Pipeline") at top opacity 0
+actor shell = terminal("Build log", "npm run build", "✓ 42 modules bundled", "done in 1.2s", green) at (58, 130) scale 0.9 opacity 0 z 35
+actor cache = matrix("cache hits", "3x2", "2 6", green) at (282, 192) opacity 0 scale 0.72 z 50
+actor stages = chips("lint|test|build|deploy", green) at (88, 324) opacity 0 scale 0.84 z 55
+repo Repo "Git repo" at (600, 150) opacity 0
+runner CI "CI Runner" at (832, 150) opacity 0
+artifact Image "Image" at (1064, 150) opacity 0
 
 @0.0: title.line_reveal(from=left, dur=0.42)
-@0.1: ascii.fade_in(dur=0.45)
-@0.1: mini.fade_in(dur=0.45)
+@0.1: shell.fade_in(dur=0.45)
+@0.1: cache.fade_in(dur=0.45)
 @0.1: stages.fade_in(dur=0.45)
-@0.1: ascii.mask(from=0, to=120, dur=0.72, ease=smooth)
-@0.2: Terminal.enter(from=right, dur=0.44, ease=snappy)
-@0.28: Lexer.enter(from=right, dur=0.44, ease=snappy)
-@0.36: Graph.enter(from=right, dur=0.44, ease=snappy)
+@0.1: shell.mask(from=0, to=120, dur=0.72, ease=smooth)
+@0.2: Repo.enter(from=right, dur=0.44, ease=snappy)
+@0.28: CI.enter(from=right, dur=0.44, ease=snappy)
+@0.36: Image.enter(from=right, dur=0.44, ease=snappy)
         </script>
         </div>
         <table>
           <thead><tr><th>Type</th><th>Arguments</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>panel</code></td><td>title, tag, tone</td><td>Generic cinematic dashboard shell</td></tr>
-            <tr><td><code>terminal</code></td><td>title, line1, line2, line3, tone</td><td>Reusable terminal/code surface</td></tr>
-            <tr><td><code>grid</code></td><td>label, colsxrows, active cells, tone</td><td>Any matrix: slots, bits, tokens, health, inventory</td></tr>
-            <tr><td><code>metric</code></td><td>label, value, tone</td><td>Compact HUD counters and stats</td></tr>
-            <tr><td><code>lane</code>, <code>marker</code>, <code>token_strip</code>, <code>glyph_card</code></td><td>generic args</td><td>Composable motion/detail primitives</td></tr>
+            <tr><td><code>surface</code></td><td>label, tag, tone</td><td>Dashboard / card shell with a scanline and cells</td></tr>
+            <tr><td><code>terminal</code></td><td>label, line1, line2, line3, tone</td><td>Terminal / code surface with up to 3 output lines</td></tr>
+            <tr><td><code>matrix</code></td><td>label, colsxrows, active cells, tone</td><td>Cell grid: slots, bits, health, inventory</td></tr>
+            <tr><td><code>stat</code></td><td>label, value, tone</td><td>Big-number KPI tile</td></tr>
+            <tr><td><code>chips</code>, <code>track</code>, <code>dot</code>, <code>glyph</code></td><td>generic args</td><td>Token rows, lanes, markers, badge cards</td></tr>
           </tbody>
         </table>
         <p><strong>Modifiers:</strong> <code>opacity</code> (0–1), <code>scale</code>, <code>rotate</code>, <code>size</code> (text only), <code>z</code> (layer order).</p>
@@ -549,42 +551,54 @@ service Graph "Graph builder" at (1064, 150) opacity 0
           <h3>Routed Systems</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Pair premium visuals with architecture nodes and flow actions so handoffs draw accurate, readable routes.</p>
+        <p class="ref-intro">Narrate the data flow with <code>request</code> (call), <code>response</code> (return), and <code>emit</code> (async event). Give every edge a short <code>label</code>, and group beats into <code>scene "…" { }</code> chapters so the story reads phase by phase.</p>
         <div class="ref-code-wrap">
-        <pre><code>@0.6: DriverApp.request(to=GateCam, label="arrival", dur=0.55)
-@1.2: GateCam.request(to=PlateOCR, label="plate frame", dur=0.58)
-@1.8: PlateOCR.request(to=Occupancy, label="permit lookup", dur=0.6)</code></pre>
+        <pre><code>@+0.2: Web.request(to=Gateway, label="POST /checkout", dur=0.5)
+@+0.1: Orders.emit(to=Events, label="order.created", dur=0.5)
+@+0.1: Orders.response(to=Web, label="201 created", dur=0.55)</code></pre>
         <script type="text/plain" class="ref-code-data">
-scene width=1280 height=720 bg=#050816 fps=60
-actor dash = surface("Vision routing HUD", "live ops", cyan) at (56, 124) scale 0.9 opacity 0 z 35
-actor route = track("route", cyan) at (82, 250) scale 0.9 opacity 0 z 45
-actor vehicle = dot("vehicle", cyan) at (244, 260) scale 0.9 opacity 0 z 55
-client DriverApp "Driver app" at (600, 150) opacity 0
-service GateCam "Gate camera" at (832, 150) opacity 0
-service PlateOCR "Plate OCR" at (1064, 150) opacity 0
-db Occupancy "Occupancy DB" at (600, 454) opacity 0
+scene width=1280 height=720 bg=#07111f fps=60
+actor title = caption("Checkout Flow") at top opacity 0
+client Web "Web App" at (90, 320) opacity 0
+api_gateway Gateway "API Gateway" at (350, 320) opacity 0
+service Orders "Order Service" at (630, 210) opacity 0
+cache Cart "Cart Cache" at (900, 110) opacity 0
+database OrderDB "Orders DB" at (900, 330) opacity 0
+queue Events "order.events" at (630, 470) opacity 0
 
-group nodes = DriverApp, GateCam, PlateOCR, Occupancy
+group nodes = Web, Gateway, Orders, Cart, OrderDB, Events
 
-@0.0: dash.fade_in(dur=0.35)
-@0.05: route.fade_in(dur=0.35)
-@0.1: vehicle.fade_in(dur=0.35)
-@0.2: nodes.fade_in(dur=0.42, stagger=0.08)
-@0.8: DriverApp.request(to=GateCam, label="arrival", dur=0.55)
-@1.4: GateCam.request(to=PlateOCR, label="plate frame", dur=0.58)
-@2.0: PlateOCR.request(to=Occupancy, label="permit lookup", dur=0.6)
+scene "layout" {
+  @+0.0: title.line_reveal(from=left, dur=0.42)
+  @+0.2: nodes.fade_in(dur=0.45, stagger=0.06)
+}
+
+scene "checkout" {
+  @+0.2: Web.request(to=Gateway, label="POST /checkout", dur=0.5)
+  @+0.1: Gateway.request(to=Orders, label="create order", dur=0.5)
+  @+0.1: Orders.request(to=Cart, label="read cart", dur=0.5)
+  @+0.1: Cart.response(to=Orders, label="items", dur=0.5)
+  @+0.1: Orders.request(to=OrderDB, label="persist", dur=0.5)
+  @+0.1: Orders.emit(to=Events, label="order.created", dur=0.5)
+  @+0.1: Orders.response(to=Web, label="201 created", dur=0.55)
+}
+
+scene "takeaway" {
+  @+0.2: Orders.glow(color=#22c55e, strength=32, dur=0.55)
+  @+0.0: camera.zoom(to=1.03, dur=0.6, ease=smooth)
+}
         </script>
         </div>
         <table>
           <thead><tr><th>Action</th><th>Parameters</th><th>What it does</th></tr></thead>
           <tbody>
-            <tr><td><code>request</code></td><td>to, label, dur</td><td>Draws a directed handoff between nodes</td></tr>
-            <tr><td><code>response</code></td><td>to, label, dur</td><td>Shows return paths without manually positioning lines</td></tr>
-            <tr><td><code>emit</code></td><td>to, label, dur</td><td>Broadcasts events or state updates through the scene</td></tr>
-            <tr><td><code>group</code></td><td>actor list</td><td>Lets a whole system fade, enter, or stagger together</td></tr>
+            <tr><td><code>request</code></td><td>to, label, dur</td><td>Solid directed call from one node to another</td></tr>
+            <tr><td><code>response</code></td><td>to, label, dur</td><td>Dashed return path (keep <code>label</code> ≤ 28 chars)</td></tr>
+            <tr><td><code>emit</code></td><td>to, label, dur</td><td>Async event / publish edge for queues and topics</td></tr>
+            <tr><td><code>scene "…" { }</code></td><td>—</td><td>Chapter block; <code>@+N</code> times are relative to the chapter</td></tr>
           </tbody>
         </table>
-        <p>Routes avoid actor boxes and use lane-aware labels, so dense scenes stay clean instead of becoming spaghetti.</p>
+        <p>Edges appear at their scheduled time and stay, assembling the full diagram. Routes dodge node boxes and labels auto-place clear of nodes and each other, so dense scenes stay readable instead of turning into spaghetti.</p>
       </article>
 
       <!-- Step 4: Visual Polish -->
@@ -594,29 +608,29 @@ group nodes = DriverApp, GateCam, PlateOCR, Occupancy
           <h3>Visual Polish</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Layer masks, glow, blur, ripple, and text reveals to make the scene feel designed rather than assembled.</p>
+        <p class="ref-intro">Layer <code>mask</code>, <code>glow</code>, <code>blur</code>, <code>ripple</code>, <code>pulse</code>, and text reveals to make a scene feel designed rather than assembled — great for highlighting a healthy service or a successful deploy.</p>
         <div class="ref-code-wrap">
-        <pre><code>@0.1: world.blur(from=8, to=0, dur=0.52)
-@0.2: world.glow(color=#f59e0b, strength=44, dur=0.72)
-@1.7: combo.scale(to=1.12, dur=0.38, ease=overshoot)</code></pre>
+        <pre><code>@0.1: panel.blur(from=8, to=0, dur=0.52)
+@0.2: panel.glow(color=#22c55e, strength=44, dur=0.72)
+@1.7: badge.scale(to=1.12, dur=0.38, ease=overshoot)</code></pre>
         <script type="text/plain" class="ref-code-data">
 scene width=1280 height=720 bg=#0b1020 fps=60
-actor title = caption("Parking game loop") at top opacity 0
-actor world = surface("Parking micro-game", "60 fps", amber) at (58, 128) scale 0.9 opacity 0 z 35
-actor track = track("drive line", amber) at (82, 260) scale 0.9 opacity 0 z 45
-actor car = dot("car", rose) at (174, 270) scale 1.05 opacity 0 z 55
-actor combo = text("PERFECT PARK +1200") at (438, 632) size 32 opacity 0 scale 0.72 z 80
+actor title = caption("Deploy Succeeded") at top opacity 0
+actor panel = surface("Release dashboard", "healthy", green) at (58, 128) scale 0.9 opacity 0 z 35
+actor bar = track("rollout", green) at (82, 260) scale 0.9 opacity 0 z 45
+actor tip = dot("canary", cyan) at (174, 270) scale 1.05 opacity 0 z 55
+actor badge = text("DEPLOY OK · 0 errors") at (438, 632) size 32 opacity 0 scale 0.72 z 80
 
 @0.0: title.line_reveal(from=left, dur=0.42)
-@0.1: world.fade_in(dur=0.42)
-@0.15: track.fade_in(dur=0.42)
-@0.2: car.fade_in(dur=0.42)
-@0.1: world.blur(from=8, to=0, dur=0.52)
-@0.2: world.glow(color=#f59e0b, strength=44, dur=0.72)
-@1.0: world.pulse(amount=1.035, dur=0.46)
-@1.35: world.ripple(color=#22c55e, size=190, dur=0.68)
-@1.55: combo.fade_in(dur=0.25)
-@1.55: combo.scale(to=1.12, dur=0.38, ease=overshoot)
+@0.1: panel.fade_in(dur=0.42)
+@0.15: bar.fade_in(dur=0.42)
+@0.2: tip.fade_in(dur=0.42)
+@0.1: panel.blur(from=8, to=0, dur=0.52)
+@0.2: panel.glow(color=#22c55e, strength=44, dur=0.72)
+@1.0: panel.pulse(amount=1.035, dur=0.46)
+@1.35: panel.ripple(color=#22c55e, size=190, dur=0.68)
+@1.55: badge.fade_in(dur=0.25)
+@1.55: badge.scale(to=1.12, dur=0.38, ease=overshoot)
         </script>
         </div>
         <table>
@@ -636,40 +650,45 @@ actor combo = text("PERFECT PARK +1200") at (438, 632) size 32 opacity 0 scale 0
           <h3>Dense Layouts</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Put rich detail on the left and the explanation graph on the right, then let safe framing keep everything in view.</p>
+        <p class="ref-intro">Put a rich detail panel on the left and the explanation graph on the right. Safe framing scales oversized content back into view, so you can pack in stats and still keep everything on screen.</p>
         <div class="ref-code-wrap">
-        <pre><code>        actor viz = surface("Character pipeline", "UTF-8", purple) at (48, 132) scale 0.88
-        client Input "Text input" at (600, 150)
-        service Encoder "UTF-8 encoder" at (1064, 150)</code></pre>
+        <pre><code>actor kpi = stat("throughput", "1.2M/s", cyan) at (70, 300)
+producer Ingest "Ingest API" at (300, 200)
+warehouse Store "Warehouse" at (1020, 200)</code></pre>
         <script type="text/plain" class="ref-code-data">
 scene width=1280 height=720 bg=#06101f fps=60
-actor title = caption("UTF-8 byte visualizer") at top opacity 0
-actor viz = surface("Character pipeline", "UTF-8", purple) at (48, 132) scale 0.88 opacity 0 z 35
-actor glyph = glyph("A", "glyph", purple) at (74, 174) scale 0.9 opacity 0 z 45
-actor tokens = chips("char|U+0041|0x41|01000001", purple) at (188, 190) scale 0.78 opacity 0 z 50
-client Input "Text input" at (600, 150) opacity 0
-service CodePoint "Code point" at (832, 150) opacity 0
-service Encoder "UTF-8 encoder" at (1064, 150) opacity 0
-queue Bytes "Byte stream" at (600, 454) opacity 0
-container Bits "Bit lanes" at (832, 454) opacity 0
-cloud Screen "Rendered glyph" at (1064, 454) opacity 0
+actor title = caption("Streaming Pipeline") at top opacity 0
+actor panel = surface("Pipeline health", "live", cyan) at (48, 150) scale 0.88 opacity 0 z 35
+actor kpi = stat("throughput", "1.2M/s", cyan) at (96, 372) opacity 0 scale 0.9 z 45
+actor stages = chips("ingest|stream|store|serve", cyan) at (86, 470) scale 0.8 opacity 0 z 50
+producer Ingest "Ingest API" at (470, 180) opacity 0
+queue Kafka "Kafka" at (720, 180) opacity 0
+worker Flink "Stream Workers" at (970, 180) opacity 0
+warehouse Store "Warehouse" at (970, 430) opacity 0
+dashboard BI "BI Dashboard" at (720, 430) opacity 0
 
-group pipeline = Input, CodePoint, Encoder, Bytes, Bits, Screen
+group pipeline = Ingest, Kafka, Flink, Store, BI
 
-@0.0: title.line_reveal(from=left, dur=0.42)
-@0.1: viz.fade_in(dur=0.42)
-@0.14: glyph.fade_in(dur=0.42)
-@0.18: tokens.fade_in(dur=0.42)
-@0.2: pipeline.enter(from=right, dur=0.44, ease=snappy, stagger=0.06)
-@1.0: Input.request(to=CodePoint, label="character", dur=0.55)
-@1.55: CodePoint.request(to=Encoder, label="U+0041", dur=0.56)
-@2.15: Encoder.emit(to=Bytes, label="0x41", dur=0.55)
+scene "layout" {
+  @+0.0: title.line_reveal(from=left, dur=0.42)
+  @+0.1: panel.fade_in(dur=0.42)
+  @+0.05: kpi.fade_in(dur=0.42)
+  @+0.05: stages.fade_in(dur=0.42)
+  @+0.1: pipeline.enter(from=right, dur=0.44, ease=snappy, stagger=0.06)
+}
+
+scene "stream" {
+  @+0.2: Ingest.request(to=Kafka, label="events", dur=0.5)
+  @+0.1: Kafka.request(to=Flink, label="consume", dur=0.5)
+  @+0.1: Flink.emit(to=Store, label="aggregates", dur=0.5)
+  @+0.1: Store.response(to=BI, label="query", dur=0.5)
+}
         </script>
         </div>
         <table>
           <thead><tr><th>Technique</th><th>Why it helps</th></tr></thead>
           <tbody>
-            <tr><td>Hero surface + graph</td><td>Separates visual detail from explanatory structure</td></tr>
+            <tr><td>Detail panel + graph</td><td>Separates visual detail from explanatory structure</td></tr>
             <tr><td>Scale-aware bounds</td><td>Flows route around what the viewer actually sees</td></tr>
             <tr><td>Safe framing</td><td>Oversized content is kept inside the viewport</td></tr>
           </tbody>
@@ -690,15 +709,15 @@ group pipeline = Input, CodePoint, Encoder, Bytes, Bits, Screen
 @2.0: guide.wave(side=left, dur=0.8)</code></pre>
         <script type="text/plain" class="ref-code-data">
 scene width=1280 height=720 bg=#050816 fps=60
-actor dash = surface("Vision routing HUD", "live ops", cyan) at (56, 124) scale 0.9 opacity 0 z 35
-service Allocator "Spot allocator" at (832, 454) opacity 0
-container Gate "Gate arm" at (1064, 454) opacity 0
+actor dash = surface("Service dashboard", "live", cyan) at (56, 124) scale 0.9 opacity 0 z 35
+service Orders "Order Service" at (832, 454) opacity 0
+queue Events "order.events" at (1064, 454) opacity 0
 actor guide = figure(#c68642, m, 😎) at (1040, 584) scale 1.15 opacity 0 z 80
 
 @0.0: dash.fade_in(dur=0.4)
-@0.2: Allocator.fade_in(dur=0.35)
-@0.35: Gate.fade_in(dur=0.35)
-@0.7: Allocator.emit(to=Gate, label="open lane", dur=0.56)
+@0.2: Orders.fade_in(dur=0.35)
+@0.35: Events.fade_in(dur=0.35)
+@0.7: Orders.emit(to=Events, label="order.created", dur=0.56)
 @0.9: guide.fade_in(dur=0.35)
 @1.25: guide.say("Flow labels stay out of the mess.", dur=1.25)
 @2.0: guide.wave(side=left, dur=0.8)
@@ -737,7 +756,7 @@ scene width=1280 height=720 bg=#0b1020 fps=60
 asset badge = icon("lucide:badge-check")
 asset zap = icon("lucide:zap")
 
-actor world = surface("Parking micro-game", "60 fps", amber) at (58, 128) scale 0.9 opacity 0 z 35
+actor world = surface("Release dashboard", "healthy", green) at (58, 128) scale 0.9 opacity 0 z 35
 actor boost = sprite(zap) at (360, 520) scale 1.8 opacity 0 z 70
 actor clear = sprite(badge) at (930, 610) scale 2.2 opacity 0 z 80
 
@@ -851,30 +870,30 @@ seq inspect(color) {
         </div>
         <p class="ref-intro">Use anchored captions for context, then direct attention with camera movement while safe framing protects the shot.</p>
         <div class="ref-code-wrap">
-        <pre><code>actor title = caption("Replay camera") at top
-actor takeaway = caption("Focus the perfect park") at bottom
+        <pre><code>actor title = caption("Deploy Replay") at top
+actor takeaway = caption("Focus the hot path") at bottom
 
 @1.2: camera.pan(to=(640, 340), dur=0.78, ease=smooth)
 @1.2: camera.zoom(to=1.02, dur=0.78, ease=smooth)</code></pre>
         <script type="text/plain" class="ref-code-data">
 scene width=1280 height=720 bg=#0b1020 fps=60
-actor title = caption("Replay camera") at top opacity 0
-actor world = surface("Parking micro-game", "60 fps", amber) at (58, 128) scale 0.9 opacity 0 z 35
-actor track = track("drive line", amber) at (82, 260) scale 0.9 opacity 0 z 45
-actor car = dot("car", rose) at (174, 270) scale 1.05 opacity 0 z 55
-actor combo = text("PERFECT PARK +1200") at (438, 632) size 32 opacity 0 scale 0.72 z 80
-actor takeaway = caption("Focus the perfect park") at bottom opacity 0
+actor title = caption("Deploy Replay") at top opacity 0
+actor world = surface("Release dashboard", "healthy", green) at (58, 128) scale 0.9 opacity 0 z 35
+actor bar = track("rollout", green) at (82, 260) scale 0.9 opacity 0 z 45
+actor tip = dot("canary", cyan) at (174, 270) scale 1.05 opacity 0 z 55
+actor badge = text("DEPLOY OK · 0 errors") at (438, 632) size 32 opacity 0 scale 0.72 z 80
+actor takeaway = caption("Focus the hot path") at bottom opacity 0
 
 @0.3: title.fade_in(dur=0.3)
 @0.4: world.fade_in(dur=0.42)
-@0.45: track.fade_in(dur=0.42)
-@0.5: car.fade_in(dur=0.42)
-@0.9: combo.fade_in(dur=0.25)
-@0.9: combo.scale(to=1.12, dur=0.38, ease=overshoot)
+@0.45: bar.fade_in(dur=0.42)
+@0.5: tip.fade_in(dur=0.42)
+@0.9: badge.fade_in(dur=0.25)
+@0.9: badge.scale(to=1.12, dur=0.38, ease=overshoot)
 @1.25: camera.pan(to=(640, 340), dur=0.78, ease=smooth)
 @1.25: camera.zoom(to=1.02, dur=0.78, ease=smooth)
 @1.6: takeaway.fade_in(dur=0.3)
-@2.2: combo.shake(intensity=4, dur=0.24)
+@2.2: badge.shake(intensity=4, dur=0.24)
 @2.7: camera.zoom(to=1.0, dur=0.55, ease=inout)
         </script>
         </div>


### PR DESCRIPTION
## Problem

In the architecture diagrams, flow-edge **labels overlapped node text and each other** (see the URL Shortener report). Root cause: only the edge path and traveling dot were time-gated — the label/group defaulted to `opacity: 1` for the whole scene, so every chapter's labels were on screen from the first frame and piled up.

## Fix

- **Time-gate the whole edge.** Each edge is hidden until its scheduled time (`fill: both`), then draws on and **persists**, assembling the complete diagram. The traveling dot fades on arrival, leaving a clean line + arrowhead.
- **Collision-aware label placement.** Labels step perpendicular to the edge until clear of node boxes, the title caption band, and every previously-placed label, and are clamped inside the scene. Added `placeFlowLabel` with unit tests.
- **Caption band fix.** A title `caption` is a centered ribbon whose real width isn't known at geometry time, so its full-width top band is reserved — edge labels never land in the title zone.

## Verification

Audited all five gallery diagrams at the fully-assembled frame — **0 label-label overlaps, 0 label-node overlaps, 0 clipped labels**:

| Diagram | Labels | Overlaps |
|---|---|---|
| URL Shortener | 12 | 0 |
| Twitter Timeline | 12 | 0 |
| YouTube Pipeline | 12 | 0 |
| OAuth / OIDC | 11 | 0 |
| Kubernetes | 14 | 0 |

## Learn MarkdyScript

Reworked the step-by-step guide to teach the real production recipe — systems nodes, grouped reveals, chaptered `request`/`response`/`emit` flows, polish, and camera — with practical runnable examples (all 10 cards parse clean).

## Validation
- `pnpm run typecheck` / `lint` / `test` (228) / `gate` (15) / `verify:examples` (50) / `build` — all pass
- Browser: all 5 diagrams + applied Learn examples render clean with no console errors