### PR TITLE
fix(website): playground empty due to missing editor-theme import

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1161,6 +1161,7 @@ beat main:
   import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
 
   import { markdyLanguage, markdyAutocomplete, markdyHighlightLight, markdyHighlightDark } from "../editor/markdy-language";
+  import { baseTheme, lightTheme, darkTheme } from "../editor/editor-theme";
   import { createPlayer } from "@markdy/renderer-dom";
   import type { Player } from "@markdy/renderer-dom";
   import type { ExampleEntry } from "../data/examples";


### PR DESCRIPTION
## Problem
The homepage "Animated Architecture Playground" was empty on markdy.com:

```
Uncaught ReferenceError: baseTheme is not defined
```

The client script referenced `baseTheme`/`lightTheme`/`darkTheme` but never imported them, so `createEditor()` threw and neither the editor nor the player initialized.

## Fix
Import `{ baseTheme, lightTheme, darkTheme }` from `../editor/editor-theme` in the playground client script. Website build passes.