### PR TITLE
fix(renderer): stop flow-label overlap

### DIFF
--- a/packages/renderer-dom/src/edges.ts
+++ b/packages/renderer-dom/src/edges.ts
@@ -1,5 +1,5 @@
 import type { EdgeKind, PositionedNode, ThemeTokens, TimedCue } from "@markdy/core";
-import { labelPointForPath, polylineLength, routeOrthogonal, toPathD } from "./geometry/path.js";
+import { placeFlowLabel, polylineLength, routeOrthogonal, toPathD } from "./geometry/path.js";
 import { boxRect, type Point, type Rect } from "./geometry/rect.js";
 
 const EDGE_LAYER_ATTR = "data-markdy-edge-layer";
@@ -70,6 +70,7 @@ export interface EdgeRuntime {
   dot: SVGCircleElement;
   pathLen: number;
   points: Point[];
+  labelRect?: Rect;
 }
 
 export function createEdgeRuntime(
@@ -80,13 +81,15 @@ export function createEdgeRuntime(
   label: string | undefined,
   theme: ThemeTokens,
   sceneId: string,
-  obstacles: Rect[],
+  routeObstacles: Rect[],
+  labelObstacles: Rect[],
   bounds: { width: number; height: number },
+  lane: number,
 ): EdgeRuntime {
   ensureDefs(svg, theme, sceneId);
   const color = theme.edges[kind];
   const style = EDGE_STYLES[kind];
-  const points = dedupePoints(routeOrthogonal(boxRect(from), boxRect(to), obstacles, bounds));
+  const points = dedupePoints(routeOrthogonal(boxRect(from), boxRect(to), routeObstacles, bounds, lane));
   const d = toPathD(points);
   const len = polylineLength(points);
 
@@ -116,22 +119,31 @@ export function createEdgeRuntime(
   group.append(path, dot);
 
   let labelEl: SVGTextElement | undefined;
+  let labelRect: Rect | undefined;
   if (label) {
-    const mid = labelPointForPath(points, 0);
+    const textWidth = label.length * 6.6 + 10;
+    const placement = placeFlowLabel(points, textWidth, labelObstacles, bounds);
+    labelRect = placement.rect;
     labelEl = document.createElementNS("http://www.w3.org/2000/svg", "text");
-    labelEl.setAttribute("x", String(mid.x));
-    labelEl.setAttribute("y", String(mid.y));
+    labelEl.setAttribute("x", String(placement.x));
+    labelEl.setAttribute("y", String(placement.y));
     labelEl.setAttribute("text-anchor", "middle");
+    labelEl.setAttribute("dominant-baseline", "middle");
     labelEl.setAttribute("font-size", "11");
     labelEl.setAttribute("font-family", "ui-monospace, SFMono-Regular, Menlo, monospace");
     labelEl.setAttribute("fill", theme.textMuted);
+    // Halo so labels stay readable over grid lines and edges.
+    labelEl.setAttribute("stroke", theme.canvas);
+    labelEl.setAttribute("stroke-width", "3");
+    labelEl.setAttribute("paint-order", "stroke");
+    labelEl.setAttribute("stroke-linejoin", "round");
     labelEl.textContent = label;
     labelEl.style.opacity = "0";
     group.appendChild(labelEl);
   }
 
   svg.appendChild(group);
-  return { group, path, label: labelEl, dot, pathLen: len, points };
+  return { group, path, label: labelEl, dot, pathLen: len, points, labelRect };
 }
 
 /** Keyframes that walk the dot along the polyline at constant speed. */
@@ -198,6 +210,9 @@ export function buildCueAnimations(
   const anims: Animation[] = [];
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
   const rectById = new Map(nodes.map((n) => [n.id, boxRect(n)]));
+  const allNodeRects = [...rectById.values()];
+  const placedLabels: Rect[] = [];
+  const laneByPair = new Map<string, number>();
   const svg = ensureEdgeLayer(scene);
   const sceneId = `md-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -273,11 +288,16 @@ export function buildCueAnimations(
       const from = nodeById.get(seg.from);
       const to = nodeById.get(seg.to);
       if (!from || !to) continue;
-      const obstacles: Rect[] = [];
+      const routeObstacles: Rect[] = [];
       for (const [id, rect] of rectById) {
-        if (id !== seg.from && id !== seg.to) obstacles.push(rect);
+        if (id !== seg.from && id !== seg.to) routeObstacles.push(rect);
       }
-      const runtime = createEdgeRuntime(svg, from, to, seg.op, seg.label, theme, sceneId, obstacles, bounds);
+      const pairKey = [seg.from, seg.to].sort().join("|");
+      const lane = laneByPair.get(pairKey) ?? 0;
+      laneByPair.set(pairKey, lane + 1);
+      const labelObstacles = [...allNodeRects, ...placedLabels];
+      const runtime = createEdgeRuntime(svg, from, to, seg.op, seg.label, theme, sceneId, routeObstacles, labelObstacles, bounds, lane);
+      if (runtime.labelRect) placedLabels.push(runtime.labelRect);
       anims.push(...animateEdgeReveal(runtime, startMs, durMs));
     }
   }

--- a/packages/renderer-dom/src/geometry/path.ts
+++ b/packages/renderer-dom/src/geometry/path.ts
@@ -72,6 +72,87 @@ export function labelPointForPath(points: Point[], lane: number): Point {
   return { x: round1(mid.x + 10 + offset), y: round1(mid.y) };
 }
 
+export interface LabelPlacement {
+  x: number;
+  y: number;
+  rect: Rect;
+}
+
+const LABEL_BOX_HEIGHT = 16;
+
+function rectsOverlap(a: Rect, b: Rect): boolean {
+  return a.x1 < b.x2 && a.x2 > b.x1 && a.y1 < b.y2 && a.y2 > b.y1;
+}
+
+function overlapCount(rect: Rect, obstacles: Rect[]): number {
+  let hits = 0;
+  for (const o of obstacles) if (rectsOverlap(rect, o)) hits++;
+  return hits;
+}
+
+/**
+ * Chooses a readable anchor for an edge label: it steps perpendicular to the
+ * edge's longest segment until the label box clears every obstacle (node boxes
+ * and already-placed labels), staying inside the scene. The least-crowded
+ * candidate wins if nothing is fully clear.
+ */
+export function placeFlowLabel(
+  points: Point[],
+  textWidth: number,
+  obstacles: Rect[],
+  bounds: { width: number; height: number },
+): LabelPlacement {
+  let bestIndex = 0;
+  let bestLength = -1;
+  for (let i = 0; i < points.length - 1; i++) {
+    const len = segmentLength(points[i], points[i + 1]);
+    if (len > bestLength) {
+      bestLength = len;
+      bestIndex = i;
+    }
+  }
+
+  const a = points[bestIndex] ?? { x: 0, y: 0 };
+  const b = points[bestIndex + 1] ?? a;
+  const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+  const horizontal = Math.abs(a.x - b.x) >= Math.abs(a.y - b.y);
+
+  const half = textWidth / 2;
+  const halfH = LABEL_BOX_HEIGHT / 2;
+  const pad = 8;
+
+  const base = horizontal ? 14 : half + 12;
+  const step = horizontal ? LABEL_BOX_HEIGHT + 4 : textWidth + 12;
+  const order = horizontal ? [-1, 1] : [1, -1];
+  const offsets: number[] = [];
+  for (let k = 0; k < 8; k++) {
+    for (const sign of order) offsets.push(sign * (base + k * step));
+  }
+
+  let fallback: LabelPlacement | null = null;
+  let fallbackHits = Number.POSITIVE_INFINITY;
+
+  for (const off of offsets) {
+    const cx = clamp(horizontal ? mid.x : mid.x + off, pad + half, bounds.width - pad - half);
+    const cy = clamp(horizontal ? mid.y + off : mid.y, pad + halfH, bounds.height - pad - halfH);
+    const rect: Rect = { x1: cx - half, y1: cy - halfH, x2: cx + half, y2: cy + halfH };
+    const hits = overlapCount(rect, obstacles);
+    if (hits === 0) return { x: round1(cx), y: round1(cy), rect };
+    if (hits < fallbackHits) {
+      fallbackHits = hits;
+      fallback = { x: round1(cx), y: round1(cy), rect };
+    }
+  }
+
+  return (
+    fallback ?? {
+      x: round1(mid.x),
+      y: round1(mid.y),
+      rect: { x1: mid.x - half, y1: mid.y - halfH, x2: mid.x + half, y2: mid.y + halfH },
+    }
+  );
+}
+
 function clamp(n: number, min: number, max: number): number {
   if (max < min) return n;
   return Math.min(max, Math.max(min, n));

--- a/packages/renderer-dom/tests/geometry.test.ts
+++ b/packages/renderer-dom/tests/geometry.test.ts
@@ -17,6 +17,7 @@ import {
 import type { Rect } from "../src/geometry/rect.js";
 import {
   labelPointForPath,
+  placeFlowLabel,
   pointAtDistance,
   polylineLength,
   round1,
@@ -25,6 +26,36 @@ import {
 } from "../src/geometry/path.js";
 
 const BOUNDS = { width: 1280, height: 720 };
+
+const rectsOverlap = (a: Rect, b: Rect) => a.x1 < b.x2 && a.x2 > b.x1 && a.y1 < b.y2 && a.y2 > b.y1;
+
+describe("placeFlowLabel", () => {
+  const horizontalEdge = [{ x: 300, y: 200 }, { x: 700, y: 200 }];
+
+  it("parks a label clear of the edge line", () => {
+    const p = placeFlowLabel(horizontalEdge, 80, [], BOUNDS);
+    expect(p.y).not.toBe(200);
+    expect(Math.abs(p.x - 500)).toBeLessThan(1);
+  });
+
+  it("separates a second label from the first (no overlap)", () => {
+    const first = placeFlowLabel(horizontalEdge, 80, [], BOUNDS);
+    const second = placeFlowLabel(horizontalEdge, 80, [first.rect], BOUNDS);
+    expect(rectsOverlap(first.rect, second.rect)).toBe(false);
+  });
+
+  it("avoids a node box under the edge midpoint", () => {
+    const blocker: Rect = { x1: 460, y1: 180, x2: 540, y2: 240 };
+    const p = placeFlowLabel(horizontalEdge, 80, [blocker], BOUNDS);
+    expect(rectsOverlap(p.rect, blocker)).toBe(false);
+  });
+
+  it("keeps the label box inside the scene bounds", () => {
+    const p = placeFlowLabel([{ x: 10, y: 8 }, { x: 10, y: 700 }], 200, [], BOUNDS);
+    expect(p.rect.x1).toBeGreaterThanOrEqual(0);
+    expect(p.rect.x2).toBeLessThanOrEqual(BOUNDS.width);
+  });
+});
 
 describe("rect helpers", () => {
   it("builds a rect from a positioned node's top-left corner and size", () => {


### PR DESCRIPTION
## Problem
On dense scenes, flow-edge labels stacked on the same edge midpoint — e.g. `POST /shorten` and `GET /a7` on Browser→Gateway rendered as garbled overlapping text.

## Fix
- **Lane separation**: parallel edges between the same node pair now offset into distinct lanes.
- **Collision-aware labels**: each label is placed to avoid node boxes and already-placed labels, stepping perpendicular to the edge until clear (staying inside the scene).
- **Halo**: labels get a canvas-colored stroke halo so they stay readable over grid lines and edges.

Adds `placeFlowLabel` unit tests. `pnpm run ci` + website build green.