### PR TITLE
chore(seo): reposition metadata for animated diagrams-as-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <strong>Markdy</strong><br>
-  Open-source text-to-animation and animated diagram DSL.<br>
-  Write MarkdyScript → get browser-native technical motion graphics.
+  Open-source DSL for animated architecture & system diagrams.<br>
+  Write MarkdyScript → get browser-native animated diagrams.
 </p>
 
 <p align="center">
@@ -20,14 +20,12 @@
 
 ## What is Markdy?
 
-**Markdy is a framework-agnostic animation DSL for animated developer diagrams.** Write motion graphics like Markdown.
+**Markdy is a framework-agnostic DSL for animated architecture and system diagrams.** Write your diagram as plain text — Markdy handles layout, edge routing, timing, and browser-native rendering with the Web Animations API. No Canvas, no GSAP, no bloated dependencies.
 
-Define actors, architecture nodes, timelines, and interactions in a simple, readable DSL. The engine handles rendering with the Web Animations API. No Canvas, no GSAP, no bloated dependencies.
-
-> Markdy is built for **text-to-animation scenes and animated technical diagrams**.
-> With `@markdy/stdlib-systems`, it can express architecture, cloud, Kubernetes, CI/CD, auth, data, messaging, state-machine, and flow diagrams.
+> Markdy is built for **animated architecture diagrams and system-design explainers**.
+> The built-in vocabulary expresses architecture, cloud, Kubernetes, CI/CD, auth, data, messaging, state-machine, and flow diagrams.
 >
-> If you are searching for a **Mermaid alternative for animation**, **animated architecture diagrams**, **AI-generated diagrams**, **text-to-diagram**, **architecture as code**, or **docs-as-code motion graphics**, Markdy is designed for that workflow.
+> If you are searching for a **Mermaid alternative with animation**, **animated architecture diagrams**, **diagram as code**, **AI-generated diagrams**, **text-to-diagram**, **architecture as code**, or **docs-as-code motion graphics**, Markdy is designed for that workflow.
 
 ```markdy
 scene "Request path" theme=midnight

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdy",
   "version": "0.8.0",
   "private": true,
-  "description": "An open-source animation DSL engine. Write MarkdyScript, get animated scenes in the browser.",
+  "description": "Open-source DSL for animated architecture & system diagrams. Write MarkdyScript, get browser-native animated diagrams.",
   "license": "MIT",
   "author": "Hoang Yell <hoangyell@gmail.com> (https://hoangyell.com)",
   "repository": {
@@ -18,15 +18,16 @@
     "pnpm": ">=8"
   },
   "keywords": [
-    "animation",
-    "dsl",
     "markdy",
     "markdyscript",
-    "text-to-motion",
-    "framer-motion-alternative",
-    "markdown-animation",
-    "declarative-animation",
-    "astro-animation",
+    "diagram-as-code",
+    "animated-diagram",
+    "architecture-diagram",
+    "mermaid-alternative",
+    "system-design",
+    "sequence-diagram",
+    "docs-as-code",
+    "dsl",
     "web-animations-api"
   ],
   "packageManager": "pnpm@9.15.4",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdy/astro",
   "version": "0.8.0",
-  "description": "Astro island component for MarkdyScript animations.",
+  "description": "Astro island component for animated MarkdyScript architecture diagrams.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -16,12 +16,12 @@
   "keywords": [
     "markdy",
     "astro",
-    "animation",
-    "island",
-    "component",
-    "astro-animation",
     "astro-component",
-    "declarative"
+    "diagram-as-code",
+    "architecture-diagram",
+    "animated-diagram",
+    "island",
+    "component"
   ],
   "author": "Hoang Yell <hoangyell@gmail.com> (https://hoangyell.com)",
   "homepage": "https://markdy.com",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdy/cli",
   "version": "0.8.0",
-  "description": "First-party CLI for MarkdyScript: lint, format, explain, render, and local playground tooling.",
+  "description": "First-party CLI for MarkdyScript diagrams: lint, format, explain, render, and a local playground.",
   "license": "MIT",
   "type": "module",
   "files": [
@@ -23,9 +23,9 @@
   "keywords": [
     "markdy",
     "cli",
-    "animation",
-    "dsl",
-    "text-to-motion"
+    "diagram-as-code",
+    "architecture-diagram",
+    "dsl"
   ],
   "author": "Hoang Yell <hoangyell@gmail.com> (https://hoangyell.com)",
   "homepage": "https://markdy.com",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdy/core",
   "version": "0.8.0",
-  "description": "MarkdyScript parser and AST types — zero runtime dependencies.",
+  "description": "MarkdyScript parser and diagram compiler (auto-layout, edge routing, cue scheduling) — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -21,13 +21,13 @@
   "keywords": [
     "markdy",
     "markdyscript",
-    "animation",
-    "dsl",
+    "diagram-as-code",
+    "architecture-diagram",
+    "mermaid-alternative",
     "parser",
-    "ast",
-    "declarative-animation",
-    "text-to-motion",
-    "markdown-animation"
+    "compiler",
+    "dsl",
+    "system-design"
   ],
   "author": "Hoang Yell <hoangyell@gmail.com> (https://hoangyell.com)",
   "homepage": "https://markdy.com",

--- a/packages/markdy-language-server/package.json
+++ b/packages/markdy-language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdy/language-server",
   "version": "0.8.0",
-  "description": "Language Server Protocol implementation for MarkdyScript.",
+  "description": "Language Server Protocol implementation for MarkdyScript diagrams.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -26,6 +26,7 @@
     "lsp",
     "language-server",
     "markdyscript",
+    "diagram-as-code",
     "editor"
   ],
   "author": "Hoang Yell <hoangyell@gmail.com> (https://hoangyell.com)",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdy/mdx",
   "version": "0.8.0",
-  "description": "MDX integration plugin and lightweight React player for Markdy.",
+  "description": "MDX plugin and lightweight React player for animated Markdy diagrams.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -22,8 +22,9 @@
     "markdy",
     "mdx",
     "remark",
-    "react",
-    "animation"
+    "diagram-as-code",
+    "architecture-diagram",
+    "react"
   ],
   "author": "Hoang Yell <hoangyell@gmail.com> (https://hoangyell.com)",
   "homepage": "https://markdy.com",

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@markdy/renderer-dom",
   "version": "0.8.0",
-  "description": "Web Animations API renderer for MarkdyScript scenes.",
+  "description": "Browser renderer for animated MarkdyScript architecture diagrams, built on the Web Animations API.",
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
@@ -20,14 +20,14 @@
   },
   "keywords": [
     "markdy",
-    "animation",
+    "animated-diagram",
+    "architecture-diagram",
+    "diagram-as-code",
     "web-animations-api",
     "renderer",
-    "dom",
-    "declarative-animation",
-    "motion",
-    "framer-motion-alternative",
-    "gsap-alternative"
+    "mermaid-alternative",
+    "svg",
+    "motion"
   ],
   "author": "Hoang Yell <hoangyell@gmail.com> (https://hoangyell.com)",
   "homepage": "https://markdy.com",

--- a/packages/stdlib-systems/package.json
+++ b/packages/stdlib-systems/package.json
@@ -21,9 +21,10 @@
   "keywords": [
     "markdy",
     "system-diagram",
-    "sequence",
-    "animation",
-    "dsl"
+    "architecture-diagram",
+    "mermaid-alternative",
+    "sequence-diagram",
+    "diagram-as-code"
   ],
   "author": "Hoang Yell <hoangyell@gmail.com> (https://hoangyell.com)",
   "homepage": "https://markdy.com",

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -1,8 +1,8 @@
 # Markdy
 
-> Open-source text-to-animation and animated diagram DSL for writing browser-rendered technical motion graphics like Markdown.
+> Open-source DSL for animated architecture and system diagrams — write plain text, get browser-native animated diagrams. A Mermaid alternative with motion.
 
-Markdy lets developers define actors, architecture nodes, assets, captions, camera movement, and timeline events in MarkdyScript. It is useful for animated documentation, architecture visualization, sequence flows, infrastructure diagrams, product explainers, Astro sites, MDX content, and AI-generated diagrams.
+Markdy lets developers declare nodes, groups, beats, and flow operators (`->`, `<-`, `~>`, `--`) in MarkdyScript. It is useful for animated architecture diagrams, system-design explainers, sequence flows, infrastructure diagrams, CI/CD and Kubernetes diagrams, product walkthroughs, Astro sites, MDX content, and AI-generated diagrams.
 
 ## Primary Links
 

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -13,11 +13,11 @@ export interface Props extends HTMLAttributes<"html"> {
 
 const {
   title,
-  description = "Markdy is an open-source text-to-animation and animated diagram DSL for developer docs, architecture visualization, AI-generated diagrams, and browser-native motion graphics.",
+  description = "Markdy turns plain text into animated architecture and system diagrams in the browser — an open-source, AI-friendly, Mermaid-style diagram-as-code tool with motion.",
   canonicalURL = "https://markdy.com/",
   ogImage = "https://markdy.com/og-image.png",
-  ogImageAlt = "Markdy playground with MarkdyScript code and an animated architecture diagram preview",
-  keywords = "animation dsl, markdown animation, mermaid alternative, mermaid for animation, interactive diagrams, animated diagrams, system architecture diagrams, sequence diagrams, flowchart dsl, infrastructure diagrams, architecture visualization, developer documentation, AI-generated diagrams, LLM-friendly DSL, diagram scripting, text-to-diagram, text-to-animation, architecture as code, docs as code, visual DSL",
+  ogImageAlt = "Markdy playground with MarkdyScript code and an animated architecture diagram",
+  keywords = "animated architecture diagram, diagram as code, animated diagrams, mermaid alternative, animated mermaid, system design diagram, sequence diagram, flowchart, infrastructure diagram, architecture as code, text to diagram, AI diagram generator, docs as code, software architecture visualization, animated system diagram, developer diagrams",
   structuredData = [],
 } = Astro.props;
 
@@ -61,7 +61,7 @@ const baseStructuredData = [
     keywords,
     url: "https://markdy.com/",
     applicationCategory: "DeveloperApplication",
-    applicationSubCategory: "Animation DSL, Diagramming Tool, Developer Documentation Tool",
+    applicationSubCategory: "Diagramming Tool, Architecture Visualization, Developer Documentation Tool",
     operatingSystem: "Web",
     programmingLanguage: "TypeScript",
     codeRepository: "https://github.com/HoangYell/markdy-com",

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -12,7 +12,7 @@ const docStructuredData = [
     "@id": "https://markdy.com/docs/#webpage",
     url: "https://markdy.com/docs/",
     name: "Markdy Documentation",
-    description: "Learn MarkdyScript for text-to-animation, animated diagrams, architecture visualization, docs-as-code workflows, and AI-generated technical explainers.",
+    description: "Learn MarkdyScript for animated architecture and system diagrams as code: nodes, groups, beats, flow operators, docs-as-code workflows, and AI-generated diagrams.",
     isPartOf: { "@id": "https://markdy.com/#website" },
     about: { "@id": "https://markdy.com/#software" },
   },
@@ -40,10 +40,10 @@ const docStructuredData = [
 ---
 
 <Layout
-  title="Markdy Documentation — Learn MarkdyScript"
-  description="Learn MarkdyScript for animated diagrams, architecture visualization, docs-as-code animation, AI-generated diagrams, and browser-native technical motion graphics."
+  title="Markdy Docs — MarkdyScript for Animated Diagrams"
+  description="Learn MarkdyScript: declare nodes, groups, beats, and flow operators to build animated architecture and system diagrams as code — for docs, Astro, MDX, and AI generation."
   canonicalURL="https://markdy.com/docs/"
-  keywords="Markdy documentation, MarkdyScript tutorial, animation DSL docs, text-to-animation syntax, animated diagrams, architecture diagrams, Mermaid alternative, AI-generated diagrams, docs as code, LLM-friendly DSL"
+  keywords="MarkdyScript tutorial, animated architecture diagram, diagram as code, mermaid alternative, system design diagram, sequence diagram, flowchart, architecture as code, AI diagram generator, docs as code"
   structuredData={docStructuredData}
 >
   <main class="docs-page">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -142,8 +142,8 @@ const homepageStructuredData = [
     "@type": "WebPage",
     "@id": "https://markdy.com/#webpage",
     url: "https://markdy.com/",
-    name: "Markdy — Animation DSL for Animated Developer Diagrams",
-    description: "Markdy is a framework-agnostic text-to-animation DSL for animated docs, architecture visualization, system diagrams, Astro sites, MDX content, and AI-generated scenes.",
+    name: "Markdy — Animated Architecture Diagrams as Code",
+    description: "Markdy is a framework-agnostic DSL for animated architecture and system diagrams: write plain text and get browser-native, versionable, AI-friendly motion diagrams for docs, Astro sites, and MDX.",
     isPartOf: { "@id": "https://markdy.com/#website" },
     about: { "@id": "https://markdy.com/#software" },
     primaryImageOfPage: {
@@ -240,10 +240,10 @@ markdy <span class="u-fn">check-all</span> examples`;
 ---
 
 <Layout 
-  title="Markdy — Animation DSL for Animated Developer Diagrams"
-  description="Markdy is an open-source text-to-animation DSL for animated diagrams, Mermaid-style motion, architecture visualization, docs-as-code, and AI-generated developer explainers."
-  keywords="animation DSL, Markdown animation, Mermaid alternative, Mermaid for animation, interactive diagrams, animated diagrams, system architecture diagrams, sequence diagrams, flowchart DSL, infrastructure diagrams, architecture visualization, developer documentation, AI-generated diagrams, LLM-friendly DSL, diagram scripting, text-to-diagram, text-to-animation, architecture as code, docs as code, visual DSL"
-  ogImageAlt="Markdy playground showing text-to-animation code and a rendered scene preview"
+  title="Markdy — Animated Architecture Diagrams as Code"
+  description="Markdy turns plain text into animated architecture and system diagrams in the browser — an open-source, AI-friendly, Mermaid-style diagram-as-code tool with motion."
+  keywords="animated architecture diagram, diagram as code, animated diagrams, mermaid alternative, animated mermaid, system design diagram, sequence diagram, flowchart, infrastructure diagram, architecture as code, text to diagram, AI diagram generator, docs as code, software architecture visualization, animated system diagram, developer diagrams"
+  ogImageAlt="Markdy playground showing MarkdyScript code and an animated architecture diagram"
   structuredData={homepageStructuredData}
 >
 
@@ -289,8 +289,8 @@ markdy <span class="u-fn">check-all</span> examples`;
 
   <!-- ─── Hero ─────────────────────────────────────────────────────────── -->
   <header class="hero">
-    <div class="hero-badge">Open-source animation DSL · Mermaid-style diagrams with motion</div>
-    <h1>Animated developer diagrams from <span class="gradient-text">plain text</span>.</h1>
+    <div class="hero-badge">Open-source diagrams as code · Mermaid-style, with motion</div>
+    <h1>Animated architecture diagrams from <span class="gradient-text">plain text</span>.</h1>
     <p class="hero-sub">
       Write architecture flows, sequence diagrams, infrastructure explainers, and product walkthroughs in MarkdyScript.
       Markdy renders browser-native motion graphics that stay reviewable, versioned, and AI-friendly.
@@ -885,7 +885,7 @@ beat main:
   <section id="faq" class="faq-section" aria-label="Frequently asked questions">
     <div class="section-header">
       <span class="section-tag">FAQ</span>
-      <h2>Animation DSL, Diagramming, and AI Questions</h2>
+      <h2>Diagramming, Animation, and AI Questions</h2>
       <p>Direct answers for developers comparing Markdy with Mermaid, PlantUML, D2, Graphviz, JavaScript animation libraries, Canvas renderers, and AI-generated code.</p>
     </div>
     <div class="faq-list">
@@ -915,7 +915,7 @@ beat main:
     </div>
     <div class="share-copy" aria-label="Short project description">
       <span>Short description</span>
-      <code>Markdy is an open-source text-to-animation DSL for browser-rendered docs, explainers, and animated diagrams.</code>
+      <code>Markdy is an open-source DSL for animated architecture & system diagrams — write plain text, get browser-native animated diagrams.</code>
     </div>
   </section>
 
@@ -958,7 +958,7 @@ beat main:
       <div class="footer-top">
         <div class="footer-brand-col">
           <span class="footer-brand">🎬 markdy</span>
-          <p class="footer-tagline">Open-source text-to-animation DSL.<br />Built for animated docs and diagrams.</p>
+          <p class="footer-tagline">Open-source diagrams-as-code, with motion.<br />Built for animated architecture &amp; system diagrams.</p>
         </div>
         <div class="footer-cols">
           <h2 class="sr-only">Footer Links</h2>


### PR DESCRIPTION
## Why
The 0.8 redesign moved Markdy from a text-to-animation DSL to **animated architecture & system diagrams as code** — a Mermaid alternative with motion. The SEO metadata still led with 'animation DSL / text-to-animation', so the project didn't surface for how people actually search.

## What
- **Site meta** (Layout.astro, index.astro, docs.astro): new title, description, keywords, OG alt, and structured-data descriptions leading with animated architecture/system diagrams, diagram-as-code, and 'Mermaid alternative'.
- **Hero + footer + FAQ + share copy** repositioned.
- **llms.txt** (AI discovery) repositioned.
- **README** tagline + 'What is Markdy?' repositioned.
- **All package.json** descriptions + keywords updated for npm search (diagram-as-code, architecture-diagram, mermaid-alternative, system-design, sequence-diagram, ...).

Website builds green. npm metadata applies on the next release.