### PR TITLE
feat(website): SEO satellite article cluster for core features

### DIFF
--- a/website/src/layouts/ArticleLayout.astro
+++ b/website/src/layouts/ArticleLayout.astro
@@ -1,0 +1,231 @@
+---
+/**
+ * Shared shell for Markdy satellite/SEO articles.
+ * Wraps the SEO Layout, adds a breadcrumb, article header, and a shared CTA.
+ */
+import Layout from "./Layout.astro";
+
+export interface Props {
+  title: string;
+  description: string;
+  keywords: string;
+  canonicalURL: string;
+  headline: string;
+  dek: string;
+  updated?: string;
+  structuredData?: Record<string, unknown> | Record<string, unknown>[];
+}
+
+const {
+  title,
+  description,
+  keywords,
+  canonicalURL,
+  headline,
+  dek,
+  updated = "August 2026",
+  structuredData,
+} = Astro.props;
+---
+
+<Layout
+  title={title}
+  description={description}
+  keywords={keywords}
+  canonicalURL={canonicalURL}
+  structuredData={structuredData}
+>
+  <article class="article">
+    <nav class="article-crumbs" aria-label="Breadcrumb">
+      <a href="/">Markdy</a>
+      <span aria-hidden="true">/</span>
+      <a href="/blog/">Articles</a>
+    </nav>
+
+    <header class="article-head">
+      <h1>{headline}</h1>
+      <p class="article-dek">{dek}</p>
+      <p class="article-updated">Updated {updated} · <a href="/blog/">All articles</a></p>
+    </header>
+
+    <div class="article-body">
+      <slot />
+    </div>
+
+    <aside class="article-cta" aria-label="Call to action">
+      <h2>See it animate in your browser</h2>
+      <p>Write a diagram in plain text and watch Markdy lay it out, route the edges, and play it back — no signup, no install.</p>
+      <div class="article-cta-actions">
+        <a class="art-btn art-btn-primary" href="/#playground">Open the Playground</a>
+        <a class="art-btn art-btn-secondary" href="/docs/">Read the Docs</a>
+        <a class="art-btn art-btn-ghost" href="https://github.com/HoangYell/markdy-com" target="_blank" rel="noopener noreferrer">Star on GitHub</a>
+      </div>
+    </aside>
+  </article>
+</Layout>
+
+<style>
+  .article {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 5rem 1.25rem 4rem;
+  }
+  .article-crumbs {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #64748b);
+    margin-bottom: 1.5rem;
+  }
+  .article-crumbs a {
+    color: var(--accent, #38bdf8);
+    text-decoration: none;
+  }
+  .article-crumbs span {
+    margin: 0 0.4rem;
+    opacity: 0.6;
+  }
+  .article-head h1 {
+    font-size: clamp(2rem, 5vw, 2.9rem);
+    line-height: 1.12;
+    letter-spacing: -0.03em;
+    margin: 0 0 1rem;
+  }
+  .article-dek {
+    font-size: 1.15rem;
+    line-height: 1.6;
+    color: var(--text-secondary, #475569);
+    margin: 0 0 0.75rem;
+  }
+  .article-updated {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #94a3b8);
+    margin: 0 0 2.5rem;
+  }
+  .article-updated a {
+    color: var(--accent, #38bdf8);
+  }
+
+  .article-body :global(h2) {
+    font-size: 1.6rem;
+    letter-spacing: -0.02em;
+    margin: 2.75rem 0 0.9rem;
+    line-height: 1.2;
+  }
+  .article-body :global(h3) {
+    font-size: 1.2rem;
+    margin: 1.8rem 0 0.6rem;
+  }
+  .article-body :global(p),
+  .article-body :global(li) {
+    font-size: 1.02rem;
+    line-height: 1.75;
+    color: var(--text-primary, #1e293b);
+  }
+  .article-body :global(ul),
+  .article-body :global(ol) {
+    padding-left: 1.3rem;
+    margin: 1rem 0;
+  }
+  .article-body :global(li) {
+    margin: 0.4rem 0;
+  }
+  .article-body :global(a) {
+    color: var(--accent, #0ea5e9);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .article-body :global(strong) {
+    color: var(--text-primary, #0f172a);
+  }
+  .article-body :global(pre) {
+    background: var(--bg-code, #0f1b2d);
+    color: #e6edf7;
+    border: 1px solid var(--border-color, #1f2b3d);
+    border-radius: 12px;
+    padding: 1rem 1.15rem;
+    overflow-x: auto;
+    font-size: 0.86rem;
+    line-height: 1.6;
+    margin: 1.2rem 0;
+  }
+  .article-body :global(code) {
+    font-family: "SF Mono", "Fira Code", "Cascadia Code", Consolas, monospace;
+  }
+  .article-body :global(:not(pre) > code) {
+    background: var(--bg-secondary, rgba(148, 163, 184, 0.16));
+    padding: 0.12em 0.4em;
+    border-radius: 5px;
+    font-size: 0.9em;
+  }
+  .article-body :global(blockquote) {
+    border-left: 3px solid var(--accent, #38bdf8);
+    margin: 1.4rem 0;
+    padding: 0.4rem 0 0.4rem 1.1rem;
+    color: var(--text-secondary, #475569);
+  }
+  .article-body :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.4rem 0;
+    font-size: 0.95rem;
+  }
+  .article-body :global(th),
+  .article-body :global(td) {
+    border: 1px solid var(--border-color, #e2e8f0);
+    padding: 0.55rem 0.75rem;
+    text-align: left;
+  }
+  .article-body :global(th) {
+    background: var(--bg-secondary, rgba(148, 163, 184, 0.12));
+  }
+
+  .article-cta {
+    margin-top: 3.5rem;
+    padding: 2rem;
+    border-radius: 16px;
+    border: 1px solid var(--border-color, #e2e8f0);
+    background: var(--bg-secondary, rgba(56, 189, 248, 0.06));
+    text-align: center;
+  }
+  .article-cta h2 {
+    font-size: 1.5rem;
+    margin: 0 0 0.6rem;
+  }
+  .article-cta p {
+    color: var(--text-secondary, #475569);
+    margin: 0 auto 1.4rem;
+    max-width: 46ch;
+    line-height: 1.6;
+  }
+  .article-cta-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+    justify-content: center;
+  }
+  .art-btn {
+    display: inline-block;
+    padding: 0.7rem 1.3rem;
+    border-radius: 10px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    text-decoration: none;
+    transition: transform 0.15s ease, opacity 0.15s ease;
+  }
+  .art-btn:hover {
+    transform: translateY(-1px);
+  }
+  .art-btn-primary {
+    background: var(--accent, #38bdf8);
+    color: #04121f;
+  }
+  .art-btn-secondary {
+    background: transparent;
+    border: 1px solid var(--border-color, #cbd5e1);
+    color: var(--text-primary, #0f172a);
+  }
+  .art-btn-ghost {
+    background: transparent;
+    color: var(--text-secondary, #64748b);
+    border: 1px solid transparent;
+  }
+</style>

--- a/website/src/pages/blog/ai-generated-architecture-diagrams.astro
+++ b/website/src/pages/blog/ai-generated-architecture-diagrams.astro
@@ -1,0 +1,106 @@
+---
+/*
+  SEO BRIEF — satellite article for feature: "AI-agent friendly"
+  Target keywords: ai generated architecture diagram, ai diagram generator, llm
+    diagram, chatgpt architecture diagram, copilot diagram, text to diagram AI
+  Search intent: commercial-investigation / how-to — developers who want an AI to
+    generate maintainable architecture diagrams from a plain-English brief.
+  Meta title: AI-Generated Architecture Diagrams: Let LLMs Write Diagrams | Markdy
+  Meta description: Give Claude, ChatGPT, or Copilot a plain-English brief and get a
+    valid, animated architecture diagram back. A constrained, AI-friendly diagram DSL.
+  Primary CTA: Open the Playground. Secondary: Read the agent guide / Star on GitHub.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/ai-generated-architecture-diagrams/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "AI-Generated Architecture Diagrams: Let LLMs Write Your Diagrams as Code",
+    description:
+      "Why a constrained text DSL beats generated JavaScript for AI diagramming, and how to prompt Claude, ChatGPT, or Copilot for a runnable animated architecture diagram.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords: "ai generated architecture diagram, ai diagram generator, llm diagram, chatgpt architecture diagram, copilot diagram",
+  },
+];
+---
+
+<ArticleLayout
+  title="AI-Generated Architecture Diagrams: Let LLMs Write Diagrams | Markdy"
+  description="Give Claude, ChatGPT, or Copilot a plain-English brief and get a valid, animated architecture diagram back. MarkdyScript is a constrained, AI-friendly diagram DSL."
+  keywords="ai generated architecture diagram, ai diagram generator, llm diagram, chatgpt architecture diagram, copilot diagram, text to diagram, AI diagramming"
+  canonicalURL={canonicalURL}
+  headline="AI-Generated Architecture Diagrams: Let LLMs Write Your Diagrams as Code"
+  dek="Why a constrained text DSL beats generated JavaScript for AI diagramming — and how to prompt Claude, ChatGPT, or Copilot to produce runnable Markdy scenes."
+  structuredData={structuredData}
+>
+  <p>
+    Ask an LLM to "draw our architecture" and you usually get one of two disappointing results: an ASCII sketch, or a
+    wall of brittle Canvas/JavaScript that half-runs. The problem isn't the model — it's the target format.
+    <strong>MarkdyScript</strong> is a small, line-based, strictly-validated DSL, which makes it a great compile
+    target for AI: easy to generate, easy to validate, and easy to revise.
+  </p>
+
+  <h2>Why constrained text is the right AI target</h2>
+  <ul>
+    <li><strong>Small grammar.</strong> Nodes, groups, beats, and four flow operators — a model can learn it from one reference page.</li>
+    <li><strong>Deterministic.</strong> The same text always renders the same diagram, so results are reproducible and diffable.</li>
+    <li><strong>Line-numbered errors.</strong> When the model gets something wrong, the parser points at the exact line, so the agent can self-correct.</li>
+    <li><strong>No runtime to hallucinate.</strong> There's no imperative API surface to invent — just declarative statements.</li>
+  </ul>
+
+  <h2>How to prompt for a Markdy diagram</h2>
+  <p>
+    Point the model at the <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">Markdy agent guide</a>
+    (grammar, node kinds, examples) and describe the system in plain English:
+  </p>
+  <blockquote>
+    Use the Markdy agent guide. Create a 1280×720 animated architecture diagram for a URL shortener. Use semantic
+    node kinds, beats, labeled flow edges (<code>-&gt;</code>, <code>&lt;-</code>, <code>~&gt;</code>), short labels,
+    and a final <code>glow</code> on the hot path.
+  </blockquote>
+  <p>You get back a complete, runnable scene:</p>
+  <pre><code>scene "URL Shortener" theme=midnight
+layout LR
+
+browser Browser
+gateway Gateway "API Gateway"
+service Shortener "URL Shortener"
+cache Redis "Hot URL Cache"
+database UrlDB "URL Store"
+
+group storage: Redis UrlDB
+
+beat create:
+  Browser -&gt; Gateway "POST /shorten" -&gt; Shortener
+  Shortener -&gt; UrlDB "store slug" &amp; Shortener ~&gt; Redis "warm cache"
+  Browser &lt;- Shortener "short.ly/a7"
+
+beat finish:
+  glow storage color=#22c55e</code></pre>
+  <p>
+    Paste it straight into the <a href="/#playground">playground</a> to verify it. If it doesn't parse, hand the
+    line-numbered error back to the model and ask it to fix that line — the loop is fast and reliable.
+  </p>
+
+  <h2>Works with the tools you already use</h2>
+  <p>
+    MarkdyScript is plain text, so it works with any assistant that accepts a URL as context — Claude, ChatGPT,
+    GitHub Copilot, Cursor, and Windsurf. Keep the diagram in your repo and the same agent can update it whenever the
+    system changes, exactly like <a href="/blog/animated-diagrams-as-code/">diagrams as code</a>.
+  </p>
+
+  <h2>Validate what the AI produced</h2>
+  <p>
+    Trust, but verify. Run <code>markdy lint scene.markdy</code> in CI, or render the scene in
+    <a href="/blog/animated-diagrams-astro-mdx/">Astro or MDX</a> docs so a broken diagram fails your build instead of
+    shipping. Deterministic output means AI-generated diagrams stay reviewable — not magic you can't audit.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/blog/animated-diagrams-as-code.astro
+++ b/website/src/pages/blog/animated-diagrams-as-code.astro
@@ -1,0 +1,112 @@
+---
+/*
+  SEO BRIEF — satellite article for feature: "Animated diagrams as code"
+  Target keywords: animated diagrams as code, diagram as code, architecture as code,
+    version controlled diagrams, animated architecture diagram
+  Search intent: commercial-investigation / informational — developers who want
+    architecture diagrams that live in version control and animate, evaluating
+    "diagram as code" tools vs. Figma/Lucidchart screenshots.
+  Meta title: Animated Diagrams as Code — Version Architecture in Git | Markdy
+  Meta description: Write architecture and system diagrams as plain text and get
+    browser-native animation you can review in pull requests. Free & open source.
+  Primary CTA: Open the Playground. Secondary: Read the Docs / Star on GitHub.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/animated-diagrams-as-code/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "Animated Diagrams as Code: Version Your Architecture in Git",
+    description:
+      "Write architecture and system diagrams as plain text and get browser-native animation you can review in pull requests.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords:
+      "animated diagrams as code, diagram as code, architecture as code, version controlled diagrams",
+  },
+];
+---
+
+<ArticleLayout
+  title="Animated Diagrams as Code — Version Architecture in Git | Markdy"
+  description="Write architecture and system diagrams as plain text and get browser-native animation you can review in pull requests. Free and open source diagram-as-code."
+  keywords="animated diagrams as code, diagram as code, architecture as code, version controlled diagrams, animated architecture diagram, text to diagram"
+  canonicalURL={canonicalURL}
+  headline="Animated Diagrams as Code: Version Your Architecture in Git"
+  dek="Stop pasting stale screenshots into your docs. Describe your system in plain text, review it in pull requests, and let Markdy lay it out and animate it in the browser."
+  structuredData={structuredData}
+>
+  <p>
+    Architecture diagrams rot. Someone draws the system in a whiteboard tool, exports a PNG, drops it in the
+    wiki — and six deploys later it's fiction. <strong>Diagram as code</strong> fixes the staleness by keeping the
+    diagram in the same repository as the code it describes. <strong>Markdy</strong> takes that one step further:
+    your diagram isn't just versioned text, it's an <strong>animated architecture diagram</strong> that renders in
+    any browser.
+  </p>
+
+  <h2>What "animated diagrams as code" actually means</h2>
+  <p>
+    In Markdy you declare nodes and connect them with flow operators. There are no coordinates to maintain — the
+    engine handles layout, edge routing, and timing. Here's a complete, runnable scene:
+  </p>
+  <pre><code>scene "Checkout" theme=midnight
+layout LR
+
+browser Web
+service API "Checkout API"
+database DB "Orders DB"
+
+beat main:
+  show $nodes stagger=80ms
+  Web -&gt; API "POST /order" -&gt; DB "persist"
+  Web &lt;- API "201 Created"</code></pre>
+  <p>
+    That's the whole diagram. Paste it into the <a href="/#playground">interactive playground</a> and it lays out
+    left-to-right, routes the arrows around the boxes, and animates the request/response flow. Because it's plain
+    text, a teammate can review the change in a pull request — a one-line diff instead of a re-exported image.
+  </p>
+
+  <h2>Why version-controlled diagrams win</h2>
+  <ul>
+    <li><strong>Reviewable in PRs.</strong> Diagram changes show up as readable diffs next to the code change that caused them.</li>
+    <li><strong>Always current.</strong> The diagram lives in the repo, so it's updated in the same commit as the system.</li>
+    <li><strong>Copy-paste friendly.</strong> No binary assets, no design-tool licenses, no export step.</li>
+    <li><strong>AI-friendly.</strong> A constrained text DSL is easy for LLMs to generate and revise — see <a href="/blog/ai-generated-architecture-diagrams/">AI-generated architecture diagrams</a>.</li>
+  </ul>
+
+  <h2>How it compares to static diagram-as-code tools</h2>
+  <p>
+    Tools like Mermaid, PlantUML, D2, and Graphviz pioneered text-to-diagram. They're excellent for static charts.
+    Markdy is built for the moment when a <em>static</em> picture isn't enough — when you need to walk a viewer
+    through a request path, a cache-miss fallback, or a deploy pipeline step by step.
+  </p>
+  <table>
+    <thead><tr><th>Need</th><th>Reach for</th></tr></thead>
+    <tbody>
+      <tr><td>Static UML / flowchart in a README</td><td>Mermaid, PlantUML</td></tr>
+      <tr><td>Animated, narrated architecture &amp; system flows</td><td>Markdy</td></tr>
+      <tr><td>Freeform whiteboard sketch</td><td>Excalidraw, draw.io</td></tr>
+    </tbody>
+  </table>
+  <p>
+    Prefer a lighter runtime story too? Markdy renders with the Web Animations API and CSS — no Canvas or GSAP.
+    Read <a href="/blog/browser-native-diagram-animation/">browser-native diagram animation</a> for the details.
+  </p>
+
+  <h2>Get started in two minutes</h2>
+  <ol>
+    <li>Open the <a href="/#playground">playground</a> and edit the sample scene.</li>
+    <li>Copy the syntax you need from the <a href="/docs/">docs</a> or the <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">agent guide</a>.</li>
+    <li>Drop the <code>.markdy</code> file in your repo and render it with <code>@markdy/renderer-dom</code>, Astro, or MDX.</li>
+  </ol>
+  <p>
+    Animated diagrams as code mean your architecture picture is finally as maintainable as the architecture itself.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/blog/animated-diagrams-astro-mdx.astro
+++ b/website/src/pages/blog/animated-diagrams-astro-mdx.astro
@@ -1,0 +1,110 @@
+---
+/*
+  SEO BRIEF — satellite article for feature: "Docs-first integrations"
+  Target keywords: astro diagrams, mdx diagrams, docs as code animation, animated
+    documentation, astro architecture diagram, mdx architecture diagram
+  Search intent: how-to / implementation — docs authors on Astro or MDX who want
+    to embed animated architecture diagrams that stay in version control.
+  Meta title: Animated Diagrams in Astro & MDX — Docs-as-Code with Motion | Markdy
+  Meta description: Embed animated architecture diagrams in Astro and MDX docs.
+    Markdy hydrates on scroll, ships tiny, and keeps diagrams in version control.
+  Primary CTA: Open the Playground. Secondary: Read the Docs / Star on GitHub.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/animated-diagrams-astro-mdx/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "Animated Diagrams in Astro & MDX: Docs-as-Code, With Motion",
+    description:
+      "Add lazy-loaded, animated architecture diagrams to your Astro site or MDX content with one component — versioned in git next to your docs.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords: "astro diagrams, mdx diagrams, docs as code animation, animated documentation, astro architecture diagram",
+  },
+];
+
+const astroExample = `---
+import { Markdy } from "@markdy/astro";
+
+const code = \`
+  scene "Request" theme=midnight width=800 height=400
+  browser Web
+  service API
+  beat main:
+    show $nodes
+    Web -> API "GET /users"
+\`;
+---
+
+<Markdy code={code} width={800} height={400} bg="#07111f" autoplay />`;
+---
+
+<ArticleLayout
+  title="Animated Diagrams in Astro & MDX — Docs-as-Code with Motion | Markdy"
+  description="Embed animated architecture diagrams in Astro and MDX docs. Markdy hydrates on scroll, ships tiny, and keeps your diagrams in version control alongside content."
+  keywords="astro diagrams, mdx diagrams, docs as code animation, animated documentation, astro architecture diagram, mdx architecture diagram"
+  canonicalURL={canonicalURL}
+  headline="Animated Diagrams in Astro & MDX: Docs-as-Code, With Motion"
+  dek="Add lazy-loaded, animated architecture diagrams to your Astro site or MDX content with a single component — and keep them in git next to your docs."
+  structuredData={structuredData}
+>
+  <p>
+    Docs-as-code teams already keep prose in version control. The missing piece is usually the diagrams — still
+    exported as PNGs from a design tool and perpetually out of date. <strong>Markdy</strong> closes that gap: drop an
+    <strong>animated architecture diagram</strong> straight into your <strong>Astro</strong> or <strong>MDX</strong>
+    content as text, and it renders in the browser, versioned alongside the page.
+  </p>
+
+  <h2>Astro: one island component</h2>
+  <p>
+    Install <code>@markdy/astro</code> and pass your scene as a <code>code</code> prop. The island hydrates only when
+    it scrolls into view, so it never blocks your critical render path:
+  </p>
+  <pre><code>{astroExample}</code></pre>
+
+  <h2>MDX: fenced code blocks</h2>
+  <p>
+    With <code>@markdy/mdx</code> you write a <code>markdy</code> fenced block right in Markdown — no per-file
+    component imports:
+  </p>
+  <pre><code>```markdy
+scene "Request" theme=midnight
+browser Web
+service API
+beat main:
+  show $nodes
+  Web -&gt; API "GET /users"
+```</code></pre>
+  <p>
+    The remark plugin turns that block into a lazy-loaded player. Your authors keep writing Markdown; the diagrams
+    come along for free.
+  </p>
+
+  <h2>Why this beats a screenshot</h2>
+  <ul>
+    <li><strong>Never stale.</strong> The diagram updates in the same commit as the doc — true <a href="/blog/animated-diagrams-as-code/">diagrams as code</a>.</li>
+    <li><strong>SEO- and crawler-friendly.</strong> Real text and elements, plus an SSR placeholder and <code>&lt;noscript&gt;</code> fallback for indexing.</li>
+    <li><strong>No layout shift.</strong> The placeholder reserves the exact aspect ratio before hydration.</li>
+    <li><strong>Lightweight.</strong> It's <a href="/blog/browser-native-diagram-animation/">browser-native motion</a> — no Canvas, no GSAP, no video embed.</li>
+  </ul>
+
+  <h2>A tidy docs workflow</h2>
+  <ol>
+    <li>Draft the scene in the <a href="/#playground">playground</a> until it looks right.</li>
+    <li>Commit the <code>.markdy</code> source (or inline it) next to the doc.</li>
+    <li>Lint diagrams in CI with <code>markdy lint</code> so a broken diagram fails the build.</li>
+    <li>Let an <a href="/blog/ai-generated-architecture-diagrams/">AI agent</a> keep them updated as the system changes.</li>
+  </ol>
+  <p>
+    Read the <a href="/docs/">documentation</a> for the full component API, then ship docs where the diagrams move
+    with your system instead of drifting away from it.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/blog/browser-native-diagram-animation.astro
+++ b/website/src/pages/blog/browser-native-diagram-animation.astro
@@ -1,0 +1,102 @@
+---
+/*
+  SEO BRIEF — satellite article for feature: "Browser-native motion"
+  Target keywords: web animations api diagrams, gsap alternative, browser native
+    animation, css transform diagram, lightweight diagram animation
+  Search intent: technical evaluation — developers who want animated diagrams
+    without shipping Canvas, a video pipeline, or a heavy animation library.
+  Meta title: Browser-Native Diagram Animation — No Canvas, No GSAP | Markdy
+  Meta description: Markdy animates diagrams with the Web Animations API and CSS —
+    no Canvas, no GSAP, no video export. Lightweight, seekable, embeddable motion.
+  Primary CTA: Open the Playground. Secondary: Read the Docs / Star on GitHub.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/browser-native-diagram-animation/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "Browser-Native Diagram Animation: No Canvas, No GSAP, No Video Export",
+    description:
+      "How Markdy animates architecture diagrams with the Web Animations API and CSS transforms — a lightweight, seekable, embeddable alternative to Canvas and GSAP.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords: "web animations api, gsap alternative, browser native animation, lightweight diagram animation",
+  },
+];
+
+const playerExample = `import { createPlayer } from "@markdy/renderer-dom";
+
+const player = createPlayer({
+  container: document.getElementById("scene"),
+  code: \`
+    scene "Request" theme=midnight
+    browser Web
+    service API
+    beat main:
+      show $nodes
+      Web -> API "GET /users"
+  \`,
+});
+
+player.seek(1.2); // scrubbing just works`;
+---
+
+<ArticleLayout
+  title="Browser-Native Diagram Animation — No Canvas, No GSAP | Markdy"
+  description="Markdy animates architecture diagrams with the Web Animations API and CSS transforms — no Canvas, no GSAP, no video export. Lightweight, seekable, embeddable motion for docs."
+  keywords="web animations api diagrams, gsap alternative, browser native animation, css transform diagram, lightweight diagram animation, framer motion alternative"
+  canonicalURL={canonicalURL}
+  headline="Browser-Native Diagram Animation: No Canvas, No GSAP, No Video Export"
+  dek="How Markdy renders animated architecture diagrams with the Web Animations API and CSS — a tiny bundle, seekable playback, and zero heavy dependencies."
+  structuredData={structuredData}
+>
+  <p>
+    Most "animated diagram" solutions reach for a big hammer: a Canvas engine, a full animation library like GSAP,
+    or an offline render that spits out an MP4. All three add weight, break text selection and accessibility, and
+    turn your diagram into an opaque blob. <strong>Markdy</strong> takes the opposite approach — it animates real
+    DOM and SVG with the <strong>Web Animations API (WAAPI)</strong> and CSS transforms.
+  </p>
+
+  <h2>What "browser-native" buys you</h2>
+  <ul>
+    <li><strong>Tiny footprint.</strong> The parser and renderer are small and dependency-light — no Canvas runtime, no GSAP core.</li>
+    <li><strong>Seekable and scrubbable.</strong> Every animation is driven by a single timeline, so <code>play()</code>, <code>pause()</code>, and <code>seek()</code> work in any direction.</li>
+    <li><strong>Accessible and inspectable.</strong> Nodes are real elements with real text — selectable, translatable, and visible to crawlers.</li>
+    <li><strong>Embeddable anywhere.</strong> It's just a DOM subtree, so it drops into any web page, Astro island, or MDX block.</li>
+  </ul>
+
+  <h2>How the renderer works</h2>
+  <p>
+    Markdy splits parsing from rendering. <code>@markdy/core</code> compiles your text into a render plan: positioned
+    nodes, routed edges, and a schedule of timed cues. <code>@markdy/renderer-dom</code> then builds DOM nodes and an
+    SVG edge layer and drives them with WAAPI:
+  </p>
+  <pre><code>{playerExample}</code></pre>
+  <p>
+    Because playback is a controlled timeline rather than fire-and-forget CSS keyframes, you get reliable seeking and
+    a progress bar for free — the same machinery that powers the <a href="/#playground">playground</a> scrubber.
+  </p>
+
+  <h2>A GSAP or Framer Motion alternative?</h2>
+  <p>
+    Not exactly — GSAP and Framer Motion are general-purpose UI animation frameworks. Markdy is narrower and higher
+    level: it's for <strong>animated architecture and system diagrams</strong> specifically. If your goal is a
+    labeled, narrated diagram of a request path or a deploy pipeline (not a bespoke UI interaction), Markdy gets you
+    there in a few lines of text instead of imperative animation code. See
+    <a href="/blog/animated-diagrams-as-code/">animated diagrams as code</a> for the authoring model.
+  </p>
+
+  <h2>Where it shines</h2>
+  <p>
+    Docs sites, launch posts, onboarding flows, and architecture reviews — anywhere a lightweight, in-page animation
+    beats a heavy video embed. Pair it with <a href="/blog/animated-diagrams-astro-mdx/">Astro and MDX</a> to lazy-load
+    scenes only when they scroll into view.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -1,0 +1,176 @@
+---
+import Layout from "../../layouts/Layout.astro";
+
+const ARTICLES = [
+  {
+    slug: "animated-diagrams-as-code",
+    title: "Animated Diagrams as Code: Version Your Architecture in Git",
+    dek: "Describe your system in plain text, review it in pull requests, and let Markdy animate it in the browser.",
+    tag: "Diagram as code",
+  },
+  {
+    slug: "browser-native-diagram-animation",
+    title: "Browser-Native Diagram Animation: No Canvas, No GSAP",
+    dek: "How Markdy animates architecture diagrams with the Web Animations API and CSS — tiny, seekable, embeddable.",
+    tag: "Performance",
+  },
+  {
+    slug: "ai-generated-architecture-diagrams",
+    title: "AI-Generated Architecture Diagrams: Let LLMs Write Your Diagrams",
+    dek: "Prompt Claude, ChatGPT, or Copilot for a valid, animated architecture diagram instead of brittle JavaScript.",
+    tag: "AI authoring",
+  },
+  {
+    slug: "animated-diagrams-astro-mdx",
+    title: "Animated Diagrams in Astro & MDX: Docs-as-Code, With Motion",
+    dek: "Embed lazy-loaded animated diagrams in Astro and MDX docs, versioned in git next to your content.",
+    tag: "Docs as code",
+  },
+];
+
+const blogStructuredData = [
+  {
+    "@type": "CollectionPage",
+    "@id": "https://markdy.com/blog/#collection",
+    url: "https://markdy.com/blog/",
+    name: "Markdy Articles — Animated Diagrams as Code",
+    description:
+      "Guides on animated architecture diagrams as code: diagram-as-code, browser-native motion, AI-generated diagrams, and Astro/MDX docs.",
+    isPartOf: { "@id": "https://markdy.com/#website" },
+  },
+  {
+    "@type": "ItemList",
+    "@id": "https://markdy.com/blog/#list",
+    itemListElement: ARTICLES.map((a, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: `https://markdy.com/blog/${a.slug}/`,
+      name: a.title,
+    })),
+  },
+];
+---
+
+<Layout
+  title="Markdy Articles — Animated Diagrams as Code"
+  description="Guides on animated architecture and system diagrams as code: diagram-as-code, browser-native motion, AI-generated diagrams, and Astro/MDX docs-as-code."
+  canonicalURL="https://markdy.com/blog/"
+  keywords="animated diagrams as code, diagram as code, architecture diagram guide, mermaid alternative, ai generated architecture diagram, astro diagrams, mdx diagrams"
+  structuredData={blogStructuredData}
+>
+  <main class="hub">
+    <nav class="hub-crumbs" aria-label="Breadcrumb">
+      <a href="/">Markdy</a>
+      <span aria-hidden="true">/</span>
+      <span>Articles</span>
+    </nav>
+
+    <header class="hub-head">
+      <h1>Animated diagrams as code — guides &amp; deep dives</h1>
+      <p class="hub-dek">
+        Short, practical articles on turning plain text into animated architecture and system diagrams.
+        Start with the <a href="/#playground">interactive playground</a> or the
+        <a href="/docs/">documentation</a>, then dig into a topic below.
+      </p>
+    </header>
+
+    <ul class="hub-list">
+      {ARTICLES.map((a) => (
+        <li class="hub-card">
+          <a href={`/blog/${a.slug}/`}>
+            <span class="hub-tag">{a.tag}</span>
+            <h2>{a.title}</h2>
+            <p>{a.dek}</p>
+            <span class="hub-more">Read the guide →</span>
+          </a>
+        </li>
+      ))}
+    </ul>
+
+    <aside class="hub-cta">
+      <p>New to Markdy? The fastest way in is the <a href="/#playground">live playground</a> — edit a real architecture scene and watch it animate.</p>
+    </aside>
+  </main>
+</Layout>
+
+<style>
+  .hub {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 5rem 1.25rem 4rem;
+  }
+  .hub-crumbs {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #64748b);
+    margin-bottom: 1.5rem;
+  }
+  .hub-crumbs a { color: var(--accent, #38bdf8); text-decoration: none; }
+  .hub-crumbs span { margin: 0 0.4rem; }
+  .hub-head h1 {
+    font-size: clamp(2rem, 5vw, 2.8rem);
+    letter-spacing: -0.03em;
+    line-height: 1.15;
+    margin: 0 0 1rem;
+  }
+  .hub-dek {
+    font-size: 1.12rem;
+    line-height: 1.65;
+    color: var(--text-secondary, #475569);
+    margin: 0 0 2.5rem;
+  }
+  .hub-dek a, .hub-cta a { color: var(--accent, #0ea5e9); }
+  .hub-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+  }
+  .hub-card a {
+    display: block;
+    padding: 1.5rem;
+    border-radius: 14px;
+    border: 1px solid var(--border-color, #e2e8f0);
+    background: var(--bg-secondary, #ffffff);
+    text-decoration: none;
+    transition: transform 0.15s ease, border-color 0.15s ease;
+  }
+  .hub-card a:hover {
+    transform: translateY(-2px);
+    border-color: var(--accent, #38bdf8);
+  }
+  .hub-tag {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent, #0ea5e9);
+    margin-bottom: 0.5rem;
+  }
+  .hub-card h2 {
+    font-size: 1.3rem;
+    line-height: 1.25;
+    margin: 0 0 0.5rem;
+    color: var(--text-primary, #0f172a);
+  }
+  .hub-card p {
+    color: var(--text-secondary, #475569);
+    line-height: 1.6;
+    margin: 0 0 0.9rem;
+  }
+  .hub-more {
+    font-weight: 600;
+    color: var(--accent, #0ea5e9);
+    font-size: 0.95rem;
+  }
+  .hub-cta {
+    margin-top: 2.5rem;
+    padding: 1.4rem 1.6rem;
+    border-radius: 14px;
+    background: var(--bg-secondary, rgba(56, 189, 248, 0.06));
+    border: 1px solid var(--border-color, #e2e8f0);
+    line-height: 1.6;
+    color: var(--text-secondary, #475569);
+  }
+</style>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -974,6 +974,7 @@ beat main:
           <div class="footer-col">
             <h3>Resources</h3>
             <a href="/docs/">Documentation</a>
+            <a href="/blog/">Articles</a>
             <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/TUTORIAL.md" target="_blank" rel="noopener noreferrer">Tutorial</a>
             <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/SYNTAX.md" target="_blank" rel="noopener noreferrer">Syntax Reference</a>
             <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">AI Agent Guide</a>


### PR DESCRIPTION
## What
A topic-cluster of supporting articles, one per core feature, to help the project surface for how people search after the 0.8 diagram redesign.

- **Hub**: `/blog/` (CollectionPage + ItemList schema), linked from the footer.
- **Spokes** (each: headline, target-keyword + search-intent brief in-source, meta title/description, H2/H3 headings, internal links to playground/docs/siblings, BlogPosting schema, CTA):
  - `/blog/animated-diagrams-as-code/` — *diagram as code / architecture as code*
  - `/blog/browser-native-diagram-animation/` — *web animations api / gsap alternative*
  - `/blog/ai-generated-architecture-diagrams/` — *ai diagram generator / llm diagram*
  - `/blog/animated-diagrams-astro-mdx/` — *astro diagrams / mdx / docs as code*
- Shared `ArticleLayout.astro` (SEO meta via Layout + article styling + CTA).

Website builds green (8 pages). Code examples are valid 0.8 MarkdyScript.