### PR TITLE
feat(website): expand SEO article cluster (10 articles) + 0.8.1 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-08-03
+
+### Fixed
+- **Flow-label overlap (`@markdy/renderer-dom`)** — Parallel edges between the same node pair now separate into lanes, and edge labels are placed to avoid node boxes and already-placed labels (with a halo for legibility), so dense diagrams stay readable.
+- **Playground editor initialization** — Fixed a missing editor-theme import that left the homepage playground blank (`baseTheme is not defined`).
+
+### Changed
+- Refreshed package descriptions/keywords and site metadata for the diagram-native positioning (animated architecture & system diagrams), and added a `/blog/` article cluster for discoverability.
+
 ## [0.8.0] — 2026-08-03
 
 ### Changed

--- a/website/src/pages/blog/animated-sequence-diagrams.astro
+++ b/website/src/pages/blog/animated-sequence-diagrams.astro
@@ -1,0 +1,98 @@
+---
+/*
+  SEO BRIEF — use-case/how-to article: Animated sequence diagrams
+  Target keywords: animated sequence diagram, sequence diagram animation,
+    sequence diagram as code, animated sequence diagram tool
+  Search intent: how-to — developers who want a sequence diagram that animates
+    the request/response order rather than a static ladder.
+  Meta title: How to Make Animated Sequence Diagrams as Code | Markdy
+  Meta description: Build animated sequence diagrams as code. Use Markdy beats and
+    flow operators to reveal request/response steps in order, in the browser.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/animated-sequence-diagrams/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "How to Make Animated Sequence Diagrams as Code",
+    description:
+      "Build animated sequence diagrams as code with Markdy — reveal participants, then play request/response/event steps in order over a timeline.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords: "animated sequence diagram, sequence diagram animation, sequence diagram as code",
+  },
+];
+---
+
+<ArticleLayout
+  title="How to Make Animated Sequence Diagrams as Code | Markdy"
+  description="Build animated sequence diagrams as code. Use Markdy beats and flow operators to reveal request/response steps in order, animated in the browser."
+  keywords="animated sequence diagram, sequence diagram animation, sequence diagram as code, animated sequence diagram tool, request response diagram"
+  canonicalURL={canonicalURL}
+  headline="How to Make Animated Sequence Diagrams as Code"
+  dek="A sequence diagram is a story about order. Markdy lets you play that story — reveal the participants, then trace each request and response in time."
+  structuredData={structuredData}
+>
+  <p>
+    A sequence diagram answers "what calls what, and in what order?" Static tools draw the whole ladder at once,
+    which buries the very thing you're trying to explain: the <em>order</em>. With <strong>Markdy</strong> you script
+    the steps as a timeline, so each call and return appears when it happens.
+  </p>
+
+  <h2>1. Declare the participants</h2>
+  <p>Sequence "participants" are just nodes. Use whatever kind fits — <code>client</code>, <code>service</code>, <code>database</code>, <code>auth</code>:</p>
+  <pre><code>scene "Login sequence" theme=midnight
+layout LR
+
+client User
+service API "Auth API"
+auth OIDC "OIDC Provider"
+database DB "User DB"</code></pre>
+
+  <h2>2. Reveal them, then play the calls</h2>
+  <p>
+    Wrap the flow in a <code>beat</code>. Use <code>-&gt;</code> for a request and <code>&lt;-</code> for a response
+    (Markdy draws the response back toward the caller). Each line animates in order:
+  </p>
+  <pre><code>beat login:
+  show $nodes stagger=80ms
+  User -&gt; API "POST /login"
+  API -&gt; OIDC "verify token"
+  API &lt;- OIDC "claims"
+  API -&gt; DB "load profile"
+  API &lt;- DB "user row"
+  User &lt;- API "session cookie"</code></pre>
+  <p>
+    That reads top-to-bottom like a classic sequence diagram, but it <em>plays</em> — the request travels, the
+    response returns, and a labeled pulse follows each edge.
+  </p>
+
+  <h2>3. Emphasize the important step</h2>
+  <p>Split phases into separate beats and add emphasis with <code>glow</code> or <code>focus</code>:</p>
+  <pre><code>beat highlight:
+  glow OIDC color=#f59e0b &amp; focus API zoom=1.1</code></pre>
+
+  <h2>Async steps and fan-out</h2>
+  <p>
+    Not every call is synchronous. Use <code>~&gt;</code> for an event/publish and <code>&amp;</code> to run two steps
+    together — handy for fan-out to a queue while you also write to a database:
+  </p>
+  <pre><code>beat write:
+  API -&gt; DB "persist" &amp; API ~&gt; Events "user.created"</code></pre>
+
+  <h2>Why animate a sequence at all?</h2>
+  <p>
+    Because comprehension follows attention. In a talk, a launch post, or onboarding docs, revealing one step at a
+    time keeps the reader with you. It's the same <a href="/blog/animated-diagrams-as-code/">diagram-as-code</a>
+    workflow — reviewable in PRs, and <a href="/blog/ai-generated-architecture-diagrams/">easy for an AI to draft</a>.
+    Try the login example above in the <a href="/#playground">playground</a>, then read the
+    <a href="/docs/">docs</a> for the full cue reference.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/blog/diagram-as-code-guide.astro
+++ b/website/src/pages/blog/diagram-as-code-guide.astro
@@ -1,0 +1,110 @@
+---
+/*
+  SEO BRIEF — pillar/guide article: Diagram as code
+  Target keywords: diagram as code, diagrams as code, what is diagram as code,
+    diagram as code tools, architecture diagram as code
+  Search intent: informational (pillar) — developers researching the diagram-as-
+    code approach and the tool landscape; links out to comparison/use-case spokes.
+  Meta title: Diagram as Code: The Complete Guide (2026) | Markdy
+  Meta description: What diagram as code is, why teams adopt it, the main tools
+    (Mermaid, PlantUML, D2, Graphviz, Markdy), and how to add motion. A 2026 guide.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/diagram-as-code-guide/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "Diagram as Code: The Complete Guide (2026)",
+    description:
+      "What diagram as code is, why teams adopt it, the main tools (Mermaid, PlantUML, D2, Graphviz, Markdy), and how to add motion with animated diagrams.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords: "diagram as code, diagrams as code, what is diagram as code, diagram as code tools",
+  },
+];
+---
+
+<ArticleLayout
+  title="Diagram as Code: The Complete Guide (2026) | Markdy"
+  description="What diagram as code is, why teams adopt it, the main tools (Mermaid, PlantUML, D2, Graphviz, Markdy), and how to add motion with animated diagrams."
+  keywords="diagram as code, diagrams as code, what is diagram as code, diagram as code tools, architecture diagram as code"
+  canonicalURL={canonicalURL}
+  headline="Diagram as Code: The Complete Guide"
+  dek="Why teams describe architecture in text instead of dragging boxes, the tools that make it work, and where animation fits."
+  structuredData={structuredData}
+>
+  <p>
+    <strong>Diagram as code</strong> means describing a diagram in a plain-text language and generating the picture
+    from it, instead of drawing it by hand in a GUI. The diagram lives in your repository, changes in pull requests,
+    and never drifts out of sync with the system it documents. This guide covers what it is, why it wins, the main
+    tools, and how <strong>animation</strong> takes it further.
+  </p>
+
+  <h2>Why diagram as code?</h2>
+  <ul>
+    <li><strong>Versioned.</strong> Diagrams live in git next to the code, with a full history and readable diffs.</li>
+    <li><strong>Reviewable.</strong> A diagram change is a text change in a PR — not a re-exported binary image.</li>
+    <li><strong>Always current.</strong> Update the diagram in the same commit as the system.</li>
+    <li><strong>Automatable.</strong> Generate, lint, and render diagrams in CI; let AI agents draft and revise them.</li>
+    <li><strong>Portable.</strong> Plain text — no proprietary file format or per-seat license.</li>
+  </ul>
+
+  <h2>The main diagram-as-code tools</h2>
+  <table>
+    <thead><tr><th>Tool</th><th>Strength</th><th>Output</th></tr></thead>
+    <tbody>
+      <tr><td>Mermaid</td><td>Ubiquitous; built into GitHub/GitLab</td><td>Static SVG</td></tr>
+      <tr><td>PlantUML</td><td>Comprehensive UML</td><td>Static image</td></tr>
+      <tr><td>D2</td><td>Modern layouts, polished architecture diagrams</td><td>Static SVG</td></tr>
+      <tr><td>Graphviz</td><td>Graph layout primitives (DOT)</td><td>Static image</td></tr>
+      <tr><td>Markdy</td><td>Animation, narration, architecture vocabulary</td><td>Animated, seekable scene</td></tr>
+    </tbody>
+  </table>
+  <p>
+    For static charts, Mermaid is the default for a reason. For a comparison focused on motion, see
+    <a href="/blog/markdy-vs-mermaid/">Markdy vs Mermaid</a> and
+    <a href="/blog/mermaid-alternative/">the best Mermaid alternative</a>.
+  </p>
+
+  <h2>The next step: animated diagrams as code</h2>
+  <p>
+    A static picture shows structure; an animated one shows <em>behavior</em> — the order of calls, the fan-out to a
+    queue, the cache-miss fallback. <a href="/blog/animated-diagrams-as-code/">Markdy adds motion to diagram as
+    code</a> using the <a href="/blog/browser-native-diagram-animation/">browser-native Web Animations API</a>, so
+    the diagram plays in any page without Canvas, GSAP, or a video export.
+  </p>
+  <pre><code>scene "Request path" theme=midnight
+layout LR
+
+browser Web
+service API
+database DB
+
+beat main:
+  show $nodes stagger=80ms
+  Web -&gt; API "GET /users" -&gt; DB "query"
+  Web &lt;- API "200 OK"</code></pre>
+
+  <h2>How to start</h2>
+  <ol>
+    <li>Sketch a scene in the <a href="/#playground">playground</a> — no install.</li>
+    <li>Learn the grammar in the <a href="/docs/">docs</a> or the <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">agent guide</a>.</li>
+    <li>Commit the <code>.markdy</code> file and render it in your app, <a href="/blog/animated-diagrams-astro-mdx/">Astro, or MDX</a>.</li>
+    <li>Lint diagrams in CI with <code>markdy lint</code> so a broken diagram fails the build.</li>
+  </ol>
+
+  <h2>Common use cases</h2>
+  <ul>
+    <li><a href="/blog/system-design-diagrams/">System design &amp; microservices diagrams</a></li>
+    <li><a href="/blog/kubernetes-architecture-diagram/">Kubernetes architecture diagrams</a></li>
+    <li><a href="/blog/animated-sequence-diagrams/">Animated sequence diagrams</a></li>
+    <li><a href="/blog/ai-generated-architecture-diagrams/">AI-generated architecture diagrams</a></li>
+  </ul>
+</ArticleLayout>

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -1,33 +1,90 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 
-const ARTICLES = [
+const SECTIONS = [
   {
-    slug: "animated-diagrams-as-code",
-    title: "Animated Diagrams as Code: Version Your Architecture in Git",
-    dek: "Describe your system in plain text, review it in pull requests, and let Markdy animate it in the browser.",
-    tag: "Diagram as code",
+    heading: "Start here",
+    items: [
+      {
+        slug: "diagram-as-code-guide",
+        title: "Diagram as Code: The Complete Guide",
+        dek: "What it is, why teams adopt it, the main tools, and where animation fits.",
+        tag: "Guide",
+      },
+    ],
   },
   {
-    slug: "browser-native-diagram-animation",
-    title: "Browser-Native Diagram Animation: No Canvas, No GSAP",
-    dek: "How Markdy animates architecture diagrams with the Web Animations API and CSS — tiny, seekable, embeddable.",
-    tag: "Performance",
+    heading: "Compare",
+    items: [
+      {
+        slug: "markdy-vs-mermaid",
+        title: "Markdy vs Mermaid: When to Animate Your Diagrams",
+        dek: "Both turn text into diagrams. The difference is motion — a practical comparison.",
+        tag: "Comparison",
+      },
+      {
+        slug: "mermaid-alternative",
+        title: "The Best Mermaid Alternative for Animated Diagrams",
+        dek: "Outgrown static charts? Where Markdy, D2, PlantUML, and Graphviz fit.",
+        tag: "Comparison",
+      },
+    ],
   },
   {
-    slug: "ai-generated-architecture-diagrams",
-    title: "AI-Generated Architecture Diagrams: Let LLMs Write Your Diagrams",
-    dek: "Prompt Claude, ChatGPT, or Copilot for a valid, animated architecture diagram instead of brittle JavaScript.",
-    tag: "AI authoring",
+    heading: "Use cases",
+    items: [
+      {
+        slug: "system-design-diagrams",
+        title: "Animated System Design Diagrams for Interviews & Docs",
+        dek: "Show writes fanning out to caches, queues, and replicas under load.",
+        tag: "Use case",
+      },
+      {
+        slug: "kubernetes-architecture-diagram",
+        title: "Animated Kubernetes Architecture Diagrams as Code",
+        dek: "Play the request path through ingress, services, pods, and deployments.",
+        tag: "Use case",
+      },
+      {
+        slug: "animated-sequence-diagrams",
+        title: "How to Make Animated Sequence Diagrams as Code",
+        dek: "Reveal participants, then play each request and response in order.",
+        tag: "How-to",
+      },
+    ],
   },
   {
-    slug: "animated-diagrams-astro-mdx",
-    title: "Animated Diagrams in Astro & MDX: Docs-as-Code, With Motion",
-    dek: "Embed lazy-loaded animated diagrams in Astro and MDX docs, versioned in git next to your content.",
-    tag: "Docs as code",
+    heading: "Features",
+    items: [
+      {
+        slug: "animated-diagrams-as-code",
+        title: "Animated Diagrams as Code: Version Your Architecture in Git",
+        dek: "Describe your system in plain text, review it in pull requests, animate it in the browser.",
+        tag: "Diagram as code",
+      },
+      {
+        slug: "browser-native-diagram-animation",
+        title: "Browser-Native Diagram Animation: No Canvas, No GSAP",
+        dek: "How Markdy animates diagrams with the Web Animations API and CSS — tiny and seekable.",
+        tag: "Performance",
+      },
+      {
+        slug: "ai-generated-architecture-diagrams",
+        title: "AI-Generated Architecture Diagrams: Let LLMs Write Your Diagrams",
+        dek: "Prompt Claude, ChatGPT, or Copilot for a valid, animated diagram instead of brittle JS.",
+        tag: "AI authoring",
+      },
+      {
+        slug: "animated-diagrams-astro-mdx",
+        title: "Animated Diagrams in Astro & MDX: Docs-as-Code, With Motion",
+        dek: "Embed lazy-loaded animated diagrams in Astro and MDX, versioned next to your content.",
+        tag: "Docs as code",
+      },
+    ],
   },
 ];
 
+const ALL = SECTIONS.flatMap((s) => s.items);
 const blogStructuredData = [
   {
     "@type": "CollectionPage",
@@ -35,13 +92,13 @@ const blogStructuredData = [
     url: "https://markdy.com/blog/",
     name: "Markdy Articles — Animated Diagrams as Code",
     description:
-      "Guides on animated architecture diagrams as code: diagram-as-code, browser-native motion, AI-generated diagrams, and Astro/MDX docs.",
+      "Guides, comparisons, and use cases for animated architecture and system diagrams as code.",
     isPartOf: { "@id": "https://markdy.com/#website" },
   },
   {
     "@type": "ItemList",
     "@id": "https://markdy.com/blog/#list",
-    itemListElement: ARTICLES.map((a, i) => ({
+    itemListElement: ALL.map((a, i) => ({
       "@type": "ListItem",
       position: i + 1,
       url: `https://markdy.com/blog/${a.slug}/`,
@@ -53,9 +110,9 @@ const blogStructuredData = [
 
 <Layout
   title="Markdy Articles — Animated Diagrams as Code"
-  description="Guides on animated architecture and system diagrams as code: diagram-as-code, browser-native motion, AI-generated diagrams, and Astro/MDX docs-as-code."
+  description="Guides, comparisons, and use cases for animated architecture and system diagrams as code: diagram-as-code, Mermaid alternatives, Kubernetes, system design, AI, and Astro/MDX."
   canonicalURL="https://markdy.com/blog/"
-  keywords="animated diagrams as code, diagram as code, architecture diagram guide, mermaid alternative, ai generated architecture diagram, astro diagrams, mdx diagrams"
+  keywords="animated diagrams as code, diagram as code, mermaid alternative, markdy vs mermaid, kubernetes architecture diagram, system design diagram, animated sequence diagram, ai generated architecture diagram, astro diagrams, mdx diagrams"
   structuredData={blogStructuredData}
 >
   <main class="hub">
@@ -68,24 +125,29 @@ const blogStructuredData = [
     <header class="hub-head">
       <h1>Animated diagrams as code — guides &amp; deep dives</h1>
       <p class="hub-dek">
-        Short, practical articles on turning plain text into animated architecture and system diagrams.
+        Practical articles on turning plain text into animated architecture and system diagrams.
         Start with the <a href="/#playground">interactive playground</a> or the
         <a href="/docs/">documentation</a>, then dig into a topic below.
       </p>
     </header>
 
-    <ul class="hub-list">
-      {ARTICLES.map((a) => (
-        <li class="hub-card">
-          <a href={`/blog/${a.slug}/`}>
-            <span class="hub-tag">{a.tag}</span>
-            <h2>{a.title}</h2>
-            <p>{a.dek}</p>
-            <span class="hub-more">Read the guide →</span>
-          </a>
-        </li>
-      ))}
-    </ul>
+    {SECTIONS.map((section) => (
+      <section class="hub-section">
+        <h2 class="hub-section-title">{section.heading}</h2>
+        <ul class="hub-list">
+          {section.items.map((a) => (
+            <li class="hub-card">
+              <a href={`/blog/${a.slug}/`}>
+                <span class="hub-tag">{a.tag}</span>
+                <h3>{a.title}</h3>
+                <p>{a.dek}</p>
+                <span class="hub-more">Read →</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
 
     <aside class="hub-cta">
       <p>New to Markdy? The fastest way in is the <a href="/#playground">live playground</a> — edit a real architecture scene and watch it animate.</p>
@@ -95,7 +157,7 @@ const blogStructuredData = [
 
 <style>
   .hub {
-    max-width: 820px;
+    max-width: 880px;
     margin: 0 auto;
     padding: 5rem 1.25rem 4rem;
   }
@@ -119,16 +181,27 @@ const blogStructuredData = [
     margin: 0 0 2.5rem;
   }
   .hub-dek a, .hub-cta a { color: var(--accent, #0ea5e9); }
+  .hub-section { margin-bottom: 2.5rem; }
+  .hub-section-title {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-secondary, #64748b);
+    margin: 0 0 1rem;
+  }
   .hub-list {
     list-style: none;
     padding: 0;
     margin: 0;
     display: grid;
-    gap: 1rem;
+    gap: 0.9rem;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   }
   .hub-card a {
     display: block;
-    padding: 1.5rem;
+    height: 100%;
+    padding: 1.35rem;
     border-radius: 14px;
     border: 1px solid var(--border-color, #e2e8f0);
     background: var(--bg-secondary, #ffffff);
@@ -141,31 +214,32 @@ const blogStructuredData = [
   }
   .hub-tag {
     display: inline-block;
-    font-size: 0.72rem;
+    font-size: 0.7rem;
     font-weight: 700;
     letter-spacing: 0.06em;
     text-transform: uppercase;
     color: var(--accent, #0ea5e9);
     margin-bottom: 0.5rem;
   }
-  .hub-card h2 {
-    font-size: 1.3rem;
+  .hub-card h3 {
+    font-size: 1.12rem;
     line-height: 1.25;
     margin: 0 0 0.5rem;
     color: var(--text-primary, #0f172a);
   }
   .hub-card p {
     color: var(--text-secondary, #475569);
-    line-height: 1.6;
-    margin: 0 0 0.9rem;
+    line-height: 1.55;
+    font-size: 0.95rem;
+    margin: 0 0 0.8rem;
   }
   .hub-more {
     font-weight: 600;
     color: var(--accent, #0ea5e9);
-    font-size: 0.95rem;
+    font-size: 0.9rem;
   }
   .hub-cta {
-    margin-top: 2.5rem;
+    margin-top: 1rem;
     padding: 1.4rem 1.6rem;
     border-radius: 14px;
     background: var(--bg-secondary, rgba(56, 189, 248, 0.06));

--- a/website/src/pages/blog/kubernetes-architecture-diagram.astro
+++ b/website/src/pages/blog/kubernetes-architecture-diagram.astro
@@ -1,0 +1,97 @@
+---
+/*
+  SEO BRIEF — use-case article: Kubernetes architecture diagrams
+  Target keywords: kubernetes architecture diagram, k8s diagram, kubernetes
+    diagram tool, kubernetes diagram as code, animated kubernetes diagram
+  Search intent: use-case — engineers documenting or presenting a Kubernetes
+    cluster who want an as-code, animated diagram.
+  Meta title: Animated Kubernetes Architecture Diagrams as Code | Markdy
+  Meta description: Draw Kubernetes architecture diagrams as code and animate the
+    request path — ingress, services, pods, and deployments — in the browser.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/kubernetes-architecture-diagram/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "Animated Kubernetes Architecture Diagrams as Code",
+    description:
+      "Draw Kubernetes architecture diagrams as code with Markdy and animate the request path through ingress, services, pods, and deployments.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords: "kubernetes architecture diagram, k8s diagram, kubernetes diagram tool, kubernetes diagram as code",
+  },
+];
+---
+
+<ArticleLayout
+  title="Animated Kubernetes Architecture Diagrams as Code | Markdy"
+  description="Draw Kubernetes architecture diagrams as code and animate the request path — ingress, services, pods, and deployments — in the browser with Markdy."
+  keywords="kubernetes architecture diagram, k8s diagram, kubernetes diagram tool, kubernetes diagram as code, animated kubernetes diagram"
+  canonicalURL={canonicalURL}
+  headline="Animated Kubernetes Architecture Diagrams as Code"
+  dek="Kubernetes topology is hard to show in a static box-and-line picture. Script it in text and let the request path animate through ingress, services, and pods."
+  structuredData={structuredData}
+>
+  <p>
+    Explaining a <strong>Kubernetes</strong> cluster with a static diagram usually means a wall of boxes nobody
+    reads. <strong>Markdy</strong> ships a first-class Kubernetes vocabulary, so you can describe the cluster in
+    plain text and animate how a request actually travels through it.
+  </p>
+
+  <h2>Kubernetes node kinds</h2>
+  <p>These are built into the language — no plugins, no icon packs to manage:</p>
+  <ul>
+    <li><code>cluster</code>, <code>namespace</code>, <code>node</code></li>
+    <li><code>ingress</code>, <code>service</code>, <code>load_balancer</code>, <code>gateway</code></li>
+    <li><code>pod</code>, <code>deployment</code>, <code>replicaset</code>, <code>statefulset</code>, <code>daemonset</code></li>
+    <li><code>configmap</code>, <code>pvc</code>, <code>sidecar</code>, <code>service_mesh</code></li>
+    <li>Aliases like <code>k8s</code> → <code>cluster</code> and <code>lb</code> → <code>load_balancer</code></li>
+  </ul>
+
+  <h2>An animated cluster request path</h2>
+  <pre><code>scene "Kubernetes request path" theme=midnight
+layout LR
+
+client User
+load_balancer LB "Cloud LB"
+ingress Ingress "NGINX Ingress"
+service Svc "orders Service"
+pod PodA "orders pod 1"
+pod PodB "orders pod 2"
+database DB "Postgres"
+
+group pods: PodA PodB
+
+beat topology:
+  show $nodes stagger=60ms
+
+beat request:
+  User -&gt; LB "HTTPS" -&gt; Ingress "route /orders" -&gt; Svc
+  Svc -&gt; PodA "load-balanced" &amp; Svc -&gt; PodB "load-balanced"
+  PodA -&gt; DB "query"
+
+beat highlight:
+  glow pods color=#38bdf8</code></pre>
+  <p>
+    Reveal the topology first, then play the hop from load balancer to ingress to service to pods to the database.
+    Because the layout and edge routing are automatic, adding a pod or a sidecar is a one-line change — perfect for
+    keeping the diagram accurate as the manifests evolve.
+  </p>
+
+  <h2>Great for runbooks, RFCs, and talks</h2>
+  <p>
+    Drop the scene into your <a href="/blog/animated-diagrams-astro-mdx/">Astro or MDX docs</a> so the cluster
+    diagram lives next to the manifests and updates in the same PR — real
+    <a href="/blog/animated-diagrams-as-code/">diagrams as code</a>. For a broader systems example, see
+    <a href="/blog/system-design-diagrams/">animated system design diagrams</a>, or open this one in the
+    <a href="/#playground">playground</a> and tweak it.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/blog/markdy-vs-mermaid.astro
+++ b/website/src/pages/blog/markdy-vs-mermaid.astro
@@ -1,0 +1,101 @@
+---
+/*
+  SEO BRIEF — comparison article: Markdy vs Mermaid
+  Target keywords: markdy vs mermaid, mermaid animated, animated mermaid,
+    mermaid alternative, animated diagrams vs mermaid
+  Search intent: commercial-comparison — developers choosing between static
+    text diagrams (Mermaid) and animated diagrams-as-code (Markdy).
+  Meta title: Markdy vs Mermaid — Animated vs Static Diagrams as Code | Markdy
+  Meta description: Markdy vs Mermaid compared. Mermaid renders static charts;
+    Markdy animates architecture and system diagrams as code. When to use each.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/markdy-vs-mermaid/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "Markdy vs Mermaid: When to Animate Your Diagrams as Code",
+    description:
+      "Markdy and Mermaid both turn text into diagrams. Mermaid renders static charts; Markdy animates architecture and system diagrams. A practical comparison.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords: "markdy vs mermaid, mermaid animated, animated mermaid, mermaid alternative",
+  },
+];
+---
+
+<ArticleLayout
+  title="Markdy vs Mermaid — Animated vs Static Diagrams as Code | Markdy"
+  description="Markdy vs Mermaid compared. Mermaid renders static charts; Markdy animates architecture and system diagrams as code. When to use each, with examples."
+  keywords="markdy vs mermaid, mermaid animated, animated mermaid, mermaid alternative, animated diagrams vs mermaid, diagram as code"
+  canonicalURL={canonicalURL}
+  headline="Markdy vs Mermaid: When to Animate Your Diagrams as Code"
+  dek="Both turn plain text into diagrams and live in git. The difference is motion: Mermaid draws a static picture; Markdy plays the story."
+  structuredData={structuredData}
+>
+  <p>
+    <strong>Mermaid</strong> popularized diagram-as-code — flowcharts and sequence diagrams from fenced code blocks
+    in your README. It's great, widely supported, and the right tool for a static chart. <strong>Markdy</strong>
+    starts from the same idea (declare a diagram in text, keep it in version control) but adds the thing Mermaid
+    doesn't do: it <strong>animates</strong> the diagram, revealing nodes and tracing labeled flows over a timeline.
+  </p>
+
+  <h2>Side by side</h2>
+  <table>
+    <thead><tr><th></th><th>Mermaid</th><th>Markdy</th></tr></thead>
+    <tbody>
+      <tr><td>Output</td><td>Static SVG chart</td><td>Animated, seekable scene</td></tr>
+      <tr><td>Best for</td><td>Flowcharts, static sequence/ER/Gantt</td><td>Architecture &amp; system flows, narrated explainers</td></tr>
+      <tr><td>Motion / timeline</td><td>—</td><td>Beats, cues, labeled request/response/event edges</td></tr>
+      <tr><td>Auto-layout</td><td>Yes</td><td>Yes (+ orthogonal edge routing)</td></tr>
+      <tr><td>Lives in git</td><td>Yes</td><td>Yes</td></tr>
+      <tr><td>AI-friendly text DSL</td><td>Yes</td><td>Yes</td></tr>
+      <tr><td>Runtime</td><td>SVG</td><td>Web Animations API + CSS (no Canvas/GSAP)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>The same idea, in each syntax</h2>
+  <p>A request path in Mermaid is a static sequence:</p>
+  <pre><code>sequenceDiagram
+  Web-&gt;&gt;API: GET /users
+  API-&gt;&gt;DB: query
+  DB--&gt;&gt;API: rows
+  API--&gt;&gt;Web: 200 OK</code></pre>
+  <p>The same flow in Markdy is a scene that plays out beat by beat:</p>
+  <pre><code>scene "Request path" theme=midnight
+layout LR
+
+browser Web
+service API
+database DB
+
+beat main:
+  show $nodes stagger=80ms
+  Web -&gt; API "GET /users" -&gt; DB "query"
+  Web &lt;- API "200 OK"</code></pre>
+
+  <h2>When to use which</h2>
+  <ul>
+    <li><strong>Use Mermaid</strong> for a static flowchart, ER diagram, or Gantt chart embedded in docs — especially where Mermaid rendering is already built in (GitHub, GitLab, many wikis).</li>
+    <li><strong>Use Markdy</strong> when the <em>sequence</em> is the point: walking a reader through an architecture, a cache-miss fallback, a deploy pipeline, or an onboarding flow with motion and emphasis.</li>
+  </ul>
+  <p>
+    They're not mutually exclusive — many teams keep Mermaid for quick static charts and reach for Markdy on the
+    hero diagram of a launch post or an architecture review.
+  </p>
+
+  <h2>Looking specifically for a Mermaid alternative?</h2>
+  <p>
+    If you're here because Mermaid feels too static, read <a href="/blog/mermaid-alternative/">the best Mermaid
+    alternative for animated diagrams</a>, or see how the authoring model works in
+    <a href="/blog/animated-diagrams-as-code/">animated diagrams as code</a>. You can also try the exact examples
+    above in the <a href="/#playground">playground</a>.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/blog/mermaid-alternative.astro
+++ b/website/src/pages/blog/mermaid-alternative.astro
@@ -1,0 +1,97 @@
+---
+/*
+  SEO BRIEF — commercial article: Mermaid alternative
+  Target keywords: mermaid alternative, alternative to mermaid, mermaid for
+    animation, animated diagram tool, mermaid js alternative
+  Search intent: commercial — developers actively seeking an alternative to
+    Mermaid, usually because they want motion or richer architecture diagrams.
+  Meta title: The Best Mermaid Alternative for Animated Diagrams | Markdy
+  Meta description: Looking for a Mermaid alternative? Markdy is a diagram-as-code
+    tool that animates architecture and system diagrams in the browser. Free, OSS.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/mermaid-alternative/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "The Best Mermaid Alternative for Animated Architecture Diagrams",
+    description:
+      "Markdy is a diagram-as-code Mermaid alternative that animates architecture and system diagrams in the browser — plus where D2, PlantUML, and Graphviz fit.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords: "mermaid alternative, alternative to mermaid, mermaid for animation, animated diagram tool",
+  },
+];
+---
+
+<ArticleLayout
+  title="The Best Mermaid Alternative for Animated Diagrams | Markdy"
+  description="Looking for a Mermaid alternative? Markdy is a diagram-as-code tool that animates architecture and system diagrams in the browser. Free and open source."
+  keywords="mermaid alternative, alternative to mermaid, mermaid for animation, animated diagram tool, mermaid js alternative, diagram as code"
+  canonicalURL={canonicalURL}
+  headline="The Best Mermaid Alternative for Animated Architecture Diagrams"
+  dek="Mermaid is excellent for static charts. If you've outgrown it because you need motion, narration, or richer architecture diagrams, here's where to look."
+  structuredData={structuredData}
+>
+  <p>
+    Most people searching for a <strong>Mermaid alternative</strong> aren't unhappy with Mermaid — they've simply
+    hit its edges. Common reasons: the diagram needs to <em>move</em>, the architecture is too rich for a flowchart,
+    or a launch post needs a hero visual with more polish than a static SVG. If that's you,
+    <strong>Markdy</strong> is built for exactly that gap.
+  </p>
+
+  <h2>What Markdy adds over Mermaid</h2>
+  <ul>
+    <li><strong>Motion, as code.</strong> Reveal nodes, then trace labeled request/response/event flows over a timeline with <code>beat</code> blocks — no imperative animation code.</li>
+    <li><strong>Architecture-first vocabulary.</strong> Semantic node kinds (<code>service</code>, <code>database</code>, <code>queue</code>, <code>cache</code>, <code>gateway</code>, <code>cluster</code>, <code>pod</code>, …) with role-based colors.</li>
+    <li><strong>Auto-layout + edge routing.</strong> No coordinates; edges route around boxes and labels avoid collisions.</li>
+    <li><strong>Browser-native + tiny.</strong> Web Animations API and CSS — <a href="/blog/browser-native-diagram-animation/">no Canvas or GSAP</a>.</li>
+    <li><strong>Same superpowers you liked in Mermaid:</strong> plain text, version-controlled, and <a href="/blog/ai-generated-architecture-diagrams/">AI-friendly</a>.</li>
+  </ul>
+
+  <h2>Try it in 8 lines</h2>
+  <pre><code>scene "Order Flow" theme=midnight
+layout LR
+
+browser Web
+service API "Order Service"
+database DB "Orders DB"
+
+beat main:
+  show $nodes stagger=80ms
+  Web -&gt; API "POST /order" -&gt; DB "persist"
+  Web &lt;- API "201 Created"</code></pre>
+  <p>Paste that into the <a href="/#playground">playground</a> and it animates immediately.</p>
+
+  <h2>Other diagram-as-code alternatives (and when they fit)</h2>
+  <table>
+    <thead><tr><th>Tool</th><th>Best for</th></tr></thead>
+    <tbody>
+      <tr><td>Markdy</td><td>Animated architecture &amp; system diagrams, narrated explainers</td></tr>
+      <tr><td>Mermaid</td><td>Static flowcharts, sequence, ER, Gantt — built into many platforms</td></tr>
+      <tr><td>D2</td><td>Polished static architecture diagrams with a dedicated layout engine</td></tr>
+      <tr><td>PlantUML</td><td>Comprehensive static UML</td></tr>
+      <tr><td>Graphviz</td><td>Graph layout primitives (DOT)</td></tr>
+    </tbody>
+  </table>
+  <p>
+    See the head-to-head in <a href="/blog/markdy-vs-mermaid/">Markdy vs Mermaid</a>, or the bigger picture in the
+    <a href="/blog/diagram-as-code-guide/">diagram-as-code guide</a>.
+  </p>
+
+  <h2>Migrating a mental model</h2>
+  <p>
+    If you already think in Mermaid, the jump is small: nodes become <code>&lt;kind&gt; Id "Label"</code>, arrows
+    become flow operators (<code>-&gt;</code>, <code>&lt;-</code>, <code>~&gt;</code>, <code>--</code>), and you wrap
+    the flows in a <code>beat</code> so they animate. The <a href="/docs/">docs</a> and
+    <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">agent guide</a>
+    have the full grammar.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/blog/system-design-diagrams.astro
+++ b/website/src/pages/blog/system-design-diagrams.astro
@@ -1,0 +1,105 @@
+---
+/*
+  SEO BRIEF — use-case article: System design diagrams
+  Target keywords: system design diagram, system design diagram tool,
+    microservices diagram, distributed system diagram, system design as code
+  Search intent: use-case — engineers and interview-preppers who want to draw
+    and animate system-design / microservices architectures.
+  Meta title: Animated System Design Diagrams for Interviews & Docs | Markdy
+  Meta description: Draw microservices and distributed-system diagrams as code and
+    animate the data flow — fan-out, caches, queues, and databases — with Markdy.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/system-design-diagrams/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "Animated System Design Diagrams for Interviews and Docs",
+    description:
+      "Draw microservices and distributed-system diagrams as code with Markdy and animate the data flow: fan-out, caches, queues, and databases.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords: "system design diagram, microservices diagram, distributed system diagram, system design as code",
+  },
+];
+---
+
+<ArticleLayout
+  title="Animated System Design Diagrams for Interviews & Docs | Markdy"
+  description="Draw microservices and distributed-system diagrams as code and animate the data flow — fan-out, caches, queues, and databases — with Markdy."
+  keywords="system design diagram, system design diagram tool, microservices diagram, distributed system diagram, system design as code"
+  canonicalURL={canonicalURL}
+  headline="Animated System Design Diagrams for Interviews and Docs"
+  dek="System design is about data flow under load. Static boxes hide it; an animated diagram-as-code shows writes fanning out to caches, queues, and replicas."
+  structuredData={structuredData}
+>
+  <p>
+    Whether you're writing an RFC, prepping for a system-design interview, or documenting a platform, the hard part
+    isn't drawing the boxes — it's showing how data <em>moves</em> under load. <strong>Markdy</strong> models the
+    building blocks of a distributed system and animates the write path and read path so the trade-offs are obvious.
+  </p>
+
+  <h2>The building blocks are node kinds</h2>
+  <ul>
+    <li>Compute: <code>service</code>, <code>api</code>, <code>worker</code>, <code>function</code>, <code>gateway</code></li>
+    <li>Data: <code>database</code>, <code>cache</code>, <code>bucket</code>, <code>search</code>, <code>warehouse</code></li>
+    <li>Messaging: <code>queue</code>, <code>topic</code>, <code>stream</code>, <code>broker</code></li>
+    <li>Distributed: <code>replica</code>, <code>shard</code>, <code>leader</code>, <code>follower</code></li>
+  </ul>
+
+  <h2>Example: a write that fans out</h2>
+  <pre><code>scene "Timeline service" theme=midnight
+layout LR
+
+client Mobile
+gateway Gateway "API Gateway"
+service Writes "Write Service"
+queue Fanout "fanout.jobs"
+worker Worker "Fan-out Worker"
+cache Timeline "Timeline Cache"
+database Store "Tweet Store"
+
+group storage: Timeline Store
+
+beat topology:
+  show $nodes stagger=60ms
+
+beat write:
+  Mobile -&gt; Gateway "POST /tweet" -&gt; Writes
+  Writes -&gt; Store "persist" &amp; Writes ~&gt; Fanout "enqueue"
+  Fanout ~&gt; Worker "consume"
+  Worker -&gt; Timeline "push to followers"
+
+beat read:
+  Mobile -&gt; Gateway "GET /timeline" -&gt; Timeline "cache hit"
+
+beat highlight:
+  glow storage color=#22c55e</code></pre>
+  <p>
+    The animation makes the design legible: the synchronous write persists <em>and</em> emits a fan-out event; a
+    worker consumes it and warms the timeline cache; reads then hit the cache. That's the story a static picture
+    can't tell.
+  </p>
+
+  <h2>Show the trade-off, then the takeaway</h2>
+  <p>
+    Split phases into beats so you can narrate write-path vs. read-path separately, and end with a <code>glow</code>
+    or <code>focus</code> on the component that matters — the cache, the leader, the queue. It's the same
+    <a href="/blog/animated-diagrams-as-code/">diagram-as-code</a> workflow, so the diagram is reviewable in a PR and
+    easy for an <a href="/blog/ai-generated-architecture-diagrams/">AI agent to draft</a> from a prompt.
+  </p>
+
+  <h2>Related</h2>
+  <p>
+    Running on Kubernetes? See <a href="/blog/kubernetes-architecture-diagram/">animated Kubernetes architecture
+    diagrams</a>. Explaining call order? See <a href="/blog/animated-sequence-diagrams/">animated sequence
+    diagrams</a>. Or open the example above in the <a href="/#playground">playground</a>.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -261,6 +261,7 @@ markdy <span class="u-fn">check-all</span> examples`;
       <a href="#playground">Playground</a>
       <a href="#learn">Learn</a>
       <a href="/docs/">Docs</a>
+      <a href="/blog/">Articles</a>
       <a href="#ai-gen">AI</a>
       <a href="#faq">FAQ</a>
       <a href="https://github.com/HoangYell/markdy-com" target="_blank" rel="noopener noreferrer" class="nav-github">


### PR DESCRIPTION
## What
Expands the topic cluster from 4 to **10 articles** — the high-intent pages top products invest in — and preps the 0.8.1 changelog.

**New spokes**
- Comparison: `markdy-vs-mermaid`, `mermaid-alternative`
- Use cases: `system-design-diagrams`, `kubernetes-architecture-diagram`, `animated-sequence-diagrams`
- Pillar guide: `diagram-as-code-guide` (links to all spokes)

**Also**
- `/blog/` hub reorganized into Start here / Compare / Use cases / Features, with `CollectionPage` + `ItemList` schema over all 10.
- "Articles" added to the top nav.
- CHANGELOG `[0.8.1]` entry (renderer label-overlap fix, playground init fix, metadata/SEO refresh).

Each article: headline, in-source keyword/intent brief, meta title/description, headings, internal links, `BlogPosting` schema, CTA. Website builds green (14 pages); code examples verified clean.