### PR TITLE
feat: add preview speed controls and polish showcase layouts

### DIFF
--- a/examples/showcase/kubernetes-cluster-architecture.markdy
+++ b/examples/showcase/kubernetes-cluster-architecture.markdy
@@ -1,5 +1,5 @@
-scene "Kubernetes Cluster Architecture" theme=midnight
-layout TB
+scene "Kubernetes Platform Blueprint" theme=midnight width=1320 height=780
+layout LR
 
 user Operator
 cli Kubectl "kubectl"
@@ -8,35 +8,43 @@ scheduler Scheduler
 controller Controller "Controller Manager"
 database Etcd "etcd"
 load_balancer LB "Load Balancer"
-ingress Ingress
-service KubeService "Service"
-node Worker "Worker Nodes"
-pod AppPod "App Pod"
-pod JobPod "Worker Pod"
+ingress Ingress "Ingress Gateway"
+service KubeService "Cluster Service"
+pod AppPod "App API Pod"
+pod JobPod "Worker Job Pod"
 configmap Config
 secret Secret
 volume PV "Persistent Volume"
 
-group control: Operator Kubectl APIServer Scheduler Controller Etcd
-group dataplane: LB Ingress KubeService Worker AppPod JobPod Config Secret PV
+group control_plane: Operator Kubectl APIServer Scheduler Controller Etcd
+group entry_lane: LB Ingress KubeService
+group workloads: AppPod JobPod
+group runtime_config: Config Secret PV
 
 beat layout:
-  show control stagger=50ms & show dataplane stagger=40ms
+  show control_plane stagger=45ms & show entry_lane stagger=45ms & show workloads stagger=45ms & show runtime_config stagger=45ms
 
 beat control:
-  Operator -> Kubectl "kubectl apply" -> APIServer "manifest"
+  Operator -> Kubectl "kubectl apply"
+  Kubectl -> APIServer "submit manifest"
   APIServer -> Etcd "persist state"
   APIServer ~> Scheduler "pending pod"
   APIServer ~> Controller "reconcile"
 
 beat scheduling:
-  Scheduler ~> Worker "bind pod" & Controller ~> AppPod "desired replicas"
-  Config ~> AppPod "env" & Secret ~> JobPod "mount"
+  Scheduler ~> AppPod "schedule pod"
+  Controller ~> JobPod "scale workers"
+
+beat config:
+  Config ~> AppPod "inject env"
+  Secret ~> JobPod "mount secret"
   PV ~> JobPod "storage"
 
 beat traffic:
-  LB -> Ingress "external traffic" -> KubeService "route rule" -> AppPod "cluster IP"
-  KubeService -> JobPod "load balance"
+  LB -> Ingress "external traffic"
+  Ingress -> KubeService "route to service"
+  KubeService -> AppPod "cluster IP"
+  AppPod ~> JobPod "dispatch background job"
 
 beat finish:
-  glow APIServer color=#c084fc & glow Worker color=#c084fc
+  glow APIServer color=#38bdf8 & glow AppPod color=#22c55e

--- a/examples/showcase/oauth-oidc-login-flow.markdy
+++ b/examples/showcase/oauth-oidc-login-flow.markdy
@@ -1,4 +1,4 @@
-scene "OAuth / OIDC Login Flow" theme=midnight
+scene "OAuth / OIDC Login Flow" theme=midnight width=1280 height=760
 layout LR
 
 user User
@@ -11,25 +11,30 @@ database SessionDB "Session Store"
 cache TokenCache "Token Cache"
 
 group trust: AuthSvc IdP SessionDB TokenCache
+group client_side: User Browser App Gateway
 
 beat layout:
-  show $nodes stagger=50ms
+  show client_side stagger=45ms & show trust stagger=45ms
 
 beat login:
-  User -> Browser "click sign in" -> App "start login"
-  App -> Gateway "GET /auth/login" -> AuthSvc "create state"
+  User -> Browser "click sign in"
+  Browser -> App "start login"
+  App -> Gateway "GET /auth/login"
+  Gateway -> AuthSvc "create state"
   AuthSvc -> IdP "authorize redirect"
   Browser <- IdP "login + consent"
 
 beat callback:
-  Browser -> Gateway "GET /callback" -> AuthSvc "exchange code"
+  Browser -> Gateway "GET /callback"
+  Gateway -> AuthSvc "exchange code"
   AuthSvc -> IdP "token request"
   IdP <- AuthSvc "id_token + access_token"
   AuthSvc -> SessionDB "store session" & AuthSvc ~> TokenCache "cache tokens"
 
 beat session:
   App <- AuthSvc "session cookie"
-  App -> Gateway "GET /me" -> AuthSvc "validate session"
+  App -> Gateway "GET /me"
+  Gateway -> AuthSvc "validate session"
   AuthSvc <- App "profile"
 
 beat finish:

--- a/examples/showcase/technical-diagram-vocabulary.markdy
+++ b/examples/showcase/technical-diagram-vocabulary.markdy
@@ -1,4 +1,4 @@
-scene "Technical Diagram Vocabulary" theme=midnight
+scene "Technical Diagram Vocabulary" theme=midnight width=1200 height=720
 layout LR
 
 client Browser
@@ -10,11 +10,16 @@ auth Auth
 pipeline Pipeline
 monitor Monitor
 
+group app: Browser API Auth
+group data: DB Redis Queue
+group ops: Pipeline Monitor
+
 beat layout:
-  show $nodes stagger=40ms
+  show app stagger=40ms & show data stagger=40ms & show ops stagger=40ms
 
 beat sample:
-  Browser -> API "request" -> DB "persist"
+  Browser -> API "request"
+  API -> DB "persist"
   API ~> Queue "enqueue" & API -> Redis "cache"
   Auth <- API "token"
   Pipeline -- Monitor "metrics"

--- a/examples/showcase/twitter-timeline-service.markdy
+++ b/examples/showcase/twitter-timeline-service.markdy
@@ -1,4 +1,4 @@
-scene "Twitter Timeline Fan-out" theme=midnight
+scene "Twitter Timeline Fan-out" theme=midnight width=1280 height=760
 layout LR
 
 user Author
@@ -14,12 +14,14 @@ service Notify "Notification Service"
 
 group write: Author Gateway TweetSvc TweetQueue Fanout
 group read: Reader Gateway TimelineSvc Redis TimelineDB
+group realtime: Fanout Notify
 
 beat layout:
-  show $nodes stagger=50ms
+  show write stagger=45ms & show read stagger=45ms & show realtime stagger=45ms
 
 beat post:
-  Author -> Gateway "POST tweet" -> TweetSvc "validate + store"
+  Author -> Gateway "POST tweet"
+  Gateway -> TweetSvc "validate + store"
   TweetSvc ~> TweetQueue "publish tweet"
   TweetQueue ~> Fanout "fan-out job"
 
@@ -29,9 +31,11 @@ beat fanout:
   glow Fanout color=#a78bfa
 
 beat read:
-  Reader -> Gateway "GET timeline" -> TimelineSvc "hydrate feed"
-  TimelineSvc -> Redis "read hot" -> TimelineDB "page miss"
-  TimelineSvc <- Reader "ranked feed"
+  Reader -> Gateway "GET timeline"
+  Gateway -> TimelineSvc "hydrate feed"
+  TimelineSvc -> Redis "read hot"
+  TimelineSvc -> TimelineDB "page miss"
+  Reader <- TimelineSvc "ranked feed"
 
 beat finish:
   glow Redis color=#22c55e & glow TimelineDB color=#38bdf8

--- a/examples/showcase/url-shortener-architecture.markdy
+++ b/examples/showcase/url-shortener-architecture.markdy
@@ -1,4 +1,4 @@
-scene "URL Shortener Architecture" theme=midnight
+scene "URL Shortener Architecture" theme=midnight width=1280 height=760
 layout LR
 
 user Visitor
@@ -10,17 +10,22 @@ cache Redis "Hot URL Cache"
 db UrlDB "URL Mapping DB"
 
 group storage: Redis UrlDB
+group ingress: Visitor Browser Gateway
+group app: Shortener Redirector
 
 beat layout:
-  show $nodes stagger=60ms
+  show ingress stagger=45ms & show app stagger=45ms & show storage stagger=45ms
 
 beat create:
-  Browser -> Gateway "POST /shorten" -> Shortener
+  Browser -> Gateway "POST /shorten"
+  Gateway -> Shortener "forward request"
   Shortener -> UrlDB "store slug" & Shortener ~> Redis "warm cache"
   Browser <- Shortener "short.ly/a7"
 
 beat redirect:
-  Visitor -> Browser "open short link" -> Gateway "GET /a7" -> Redirector
+  Visitor -> Browser "open short link"
+  Browser -> Gateway "GET /a7"
+  Gateway -> Redirector "resolve slug"
   Redirector -> Redis "cache lookup"
   Redis <- Redirector "target URL"
   Redirector -> UrlDB "miss fallback"

--- a/examples/showcase/youtube-processing-pipeline.markdy
+++ b/examples/showcase/youtube-processing-pipeline.markdy
@@ -1,4 +1,4 @@
-scene "YouTube Processing Pipeline" theme=midnight
+scene "YouTube Processing Pipeline" theme=midnight width=1280 height=760
 layout LR
 
 user Creator
@@ -12,18 +12,23 @@ database VideoDB "Video Metadata DB"
 bucket ObjectStore "Object Storage"
 cdn CDN "CDN Edge"
 
+group ingest: Creator Studio Gateway UploadSvc
+group processing: TranscodeQueue Transcoder ObjectStore
+group delivery: CatalogSvc VideoDB CDN
+
 beat layout:
-  show $nodes stagger=50ms
+  show ingest stagger=45ms & show processing stagger=45ms & show delivery stagger=45ms
 
 beat upload:
   Creator -> Studio "upload video" -> Gateway "POST /videos"
-  Gateway -> UploadSvc "accept upload" -> ObjectStore "store raw"
+  Gateway -> UploadSvc "accept upload"
+  UploadSvc -> ObjectStore "store raw"
   UploadSvc ~> TranscodeQueue "enqueue job"
 
 beat transcode:
   TranscodeQueue ~> Transcoder "pick job"
-  Transcoder -> ObjectStore "read raw" -> Transcoder "encode renditions"
-  Transcoder -> ObjectStore "write outputs"
+  Transcoder -> ObjectStore "read raw"
+  Transcoder -> ObjectStore "write renditions"
   Transcoder -> CatalogSvc "register renditions"
 
 beat publish:

--- a/packages/astro/src/Markdy.astro
+++ b/packages/astro/src/Markdy.astro
@@ -42,6 +42,10 @@ export interface Props {
   copyright?: boolean;
   /** Show a rainbow progress bar around the viewport border. Defaults to true. */
   progressBar?: boolean;
+  /** Preferred flag to show/hide rainbow progress at scene boundary. Defaults to true. */
+  sceneBoundaryProgress?: boolean;
+  /** Playback speed multiplier. Defaults to 1. */
+  playbackRate?: number;
   class?: string;
   /**
    * Short human-readable title for the animation.
@@ -66,6 +70,8 @@ const {
   loop = true,
   copyright = true,
   progressBar = true,
+  sceneBoundaryProgress,
+  playbackRate = 1,
   class: className,
   title = "Markdy animation",
   description,
@@ -80,6 +86,8 @@ const {
   data-markdy-loop={String(loop)}
   data-markdy-copyright={String(copyright)}
   data-markdy-progress-bar={String(progressBar)}
+  data-markdy-scene-boundary-progress={String(sceneBoundaryProgress ?? progressBar)}
+  data-markdy-playback-rate={String(playbackRate)}
   role="img"
   aria-label={title}
   aria-busy="true"
@@ -243,6 +251,8 @@ const {
     const loop = el.dataset.markdyLoop !== "false";
     const copyright = el.dataset.markdyCopyright !== "false";
     const progressBar = el.dataset.markdyProgressBar !== "false";
+    const sceneBoundaryProgress = el.dataset.markdySceneBoundaryProgress !== "false";
+    const playbackRate = Number(el.dataset.markdyPlaybackRate ?? "1");
 
     // Code-split: renderer-dom is NOT part of the initial page bundle.
     const { createPlayer } = await import("@markdy/renderer-dom");
@@ -251,7 +261,17 @@ const {
     // async import resolves, so there is no flash of empty content.
     el.innerHTML = "";
 
-    createPlayer({ container: el, code, assets, autoplay, loop, copyright, progressBar });
+    createPlayer({
+      container: el,
+      code,
+      assets,
+      autoplay,
+      loop,
+      copyright,
+      progressBar,
+      sceneBoundaryProgress,
+      playbackRate: Number.isFinite(playbackRate) && playbackRate > 0 ? playbackRate : 1,
+    });
 
     el.dataset.markdyInit = "done";
     el.removeAttribute("aria-busy");

--- a/packages/mdx/src/player.tsx
+++ b/packages/mdx/src/player.tsx
@@ -12,6 +12,8 @@ type CreatePlayerInput = {
   loop: boolean;
   copyright: boolean;
   progressBar: boolean;
+  sceneBoundaryProgress: boolean;
+  playbackRate: number;
 };
 
 export type MarkdyPlayerProps = {
@@ -24,6 +26,8 @@ export type MarkdyPlayerProps = {
   loop?: boolean | string;
   copyright?: boolean | string;
   progressBar?: boolean | string;
+  sceneBoundaryProgress?: boolean | string;
+  playbackRate?: number | string;
   className?: string;
   title?: string;
   description?: string;
@@ -74,6 +78,8 @@ export function MarkdyPlayer({
   loop = false,
   copyright = false,
   progressBar = false,
+  sceneBoundaryProgress,
+  playbackRate = 1,
   className,
   title = "Markdy animation",
   description,
@@ -84,6 +90,8 @@ export function MarkdyPlayer({
   const resolvedLoop = coerceBoolean(loop, false);
   const resolvedCopyright = coerceBoolean(copyright, false);
   const resolvedProgressBar = coerceBoolean(progressBar, false);
+  const resolvedSceneBoundaryProgress = coerceBoolean(sceneBoundaryProgress, resolvedProgressBar);
+  const resolvedPlaybackRate = coerceNumber(playbackRate, 1);
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const playerRef = useRef<PlayerInstance | null>(null);
@@ -116,6 +124,8 @@ export function MarkdyPlayer({
               loop: resolvedLoop,
               copyright: resolvedCopyright,
               progressBar: resolvedProgressBar,
+              sceneBoundaryProgress: resolvedSceneBoundaryProgress,
+              playbackRate: resolvedPlaybackRate > 0 ? resolvedPlaybackRate : 1,
             });
             root.dataset.markdyInit = "done";
             root.removeAttribute("aria-busy");
@@ -160,7 +170,16 @@ export function MarkdyPlayer({
       playerRef.current?.destroy();
       playerRef.current = null;
     };
-  }, [assets, code, resolvedAutoplay, resolvedCopyright, resolvedLoop, resolvedProgressBar]);
+  }, [
+    assets,
+    code,
+    resolvedAutoplay,
+    resolvedCopyright,
+    resolvedLoop,
+    resolvedProgressBar,
+    resolvedSceneBoundaryProgress,
+    resolvedPlaybackRate,
+  ]);
 
   return (
     <div

--- a/packages/mdx/src/remark.ts
+++ b/packages/mdx/src/remark.ts
@@ -49,6 +49,8 @@ function parseMetaValue(raw: string): MetaValue {
 
 function normalizeMetaKey(key: string): string {
   if (key === "progress_bar") return "progressBar";
+  if (key === "scene_boundary_progress") return "sceneBoundaryProgress";
+  if (key === "playback_rate") return "playbackRate";
   return key;
 }
 

--- a/packages/renderer-dom/src/player.ts
+++ b/packages/renderer-dom/src/player.ts
@@ -12,7 +12,12 @@ export interface PlayerOptions {
   autoplay?: boolean;
   loop?: boolean;
   copyright?: boolean;
+  /** @deprecated Prefer sceneBoundaryProgress. */
   progressBar?: boolean;
+  /** Show rainbow progress around scene boundary. Defaults to true. */
+  sceneBoundaryProgress?: boolean;
+  /** Playback speed multiplier. Defaults to 1. */
+  playbackRate?: number;
   onWarning?: (warning: Diagnostic) => void;
   onTimeUpdate?: (seconds: number, durationSeconds: number) => void;
   onPlayStateChange?: (playing: boolean) => void;
@@ -22,6 +27,8 @@ export interface Player {
   play(): void;
   pause(): void;
   seek(seconds: number): void;
+  setPlaybackRate(rate: number): void;
+  playbackRate(): number;
   currentTime(): number;
   duration(): number;
   isPlaying(): boolean;
@@ -37,11 +44,15 @@ export function createPlayer(opts: PlayerOptions): Player {
     autoplay = true,
     loop = true,
     copyright = true,
-    progressBar = true,
+    progressBar,
+    sceneBoundaryProgress,
+    playbackRate: initialPlaybackRate = 1,
     onWarning = (w) => console.warn(`[markdy] line ${w.line}: ${w.message}`),
     onTimeUpdate,
     onPlayStateChange,
   } = opts;
+
+  const showSceneBoundaryProgress = sceneBoundaryProgress ?? progressBar ?? true;
 
   const { ast, plan } = parseAndCompile(code);
   for (const w of ast.diagnostics) {
@@ -61,7 +72,7 @@ export function createPlayer(opts: PlayerOptions): Player {
   container.appendChild(viewport);
 
   let progressEl: HTMLElement | null = null;
-  if (progressBar) {
+  if (showSceneBoundaryProgress) {
     progressEl = document.createElement("div");
     Object.assign(progressEl.style, {
       position: "absolute",
@@ -164,6 +175,7 @@ export function createPlayer(opts: PlayerOptions): Player {
   }
 
   let sceneMs = 0;
+  let playbackRate = Number.isFinite(initialPlaybackRate) && initialPlaybackRate > 0 ? initialPlaybackRate : 1;
   let lastRafTs: number | null = null;
   let isPlaying = false;
   let rafId: number | null = null;
@@ -174,7 +186,7 @@ export function createPlayer(opts: PlayerOptions): Player {
   }
 
   function rafTick(timestamp: number): void {
-    if (lastRafTs !== null) sceneMs += timestamp - lastRafTs;
+    if (lastRafTs !== null) sceneMs += (timestamp - lastRafTs) * playbackRate;
     lastRafTs = timestamp;
 
     if (totalDurationMs > 0 && sceneMs >= totalDurationMs) {
@@ -215,6 +227,13 @@ export function createPlayer(opts: PlayerOptions): Player {
       sceneMs = totalDurationMs > 0 ? Math.min(Math.max(seconds * 1000, 0), totalDurationMs) : Math.max(seconds * 1000, 0);
       applyCurrentTime();
       if (totalDurationMs > 0) updateProgressBar(sceneMs / totalDurationMs);
+    },
+    setPlaybackRate(rate: number) {
+      if (!Number.isFinite(rate) || rate <= 0) return;
+      playbackRate = rate;
+    },
+    playbackRate() {
+      return playbackRate;
     },
     currentTime() {
       return sceneMs / 1000;

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -433,7 +433,7 @@ markdy <span class="u-fn">check-all</span> examples`;
 
       <div class="preview-col">
         <div class="panel-label">
-          <span>Preview</span>
+          <span>Embedded Preview</span>
           <div class="preview-toolbar">
             <span id="status" class="status ok"></span>
             <button id="rewind-btn" class="btn-share" title="Back 1 second" aria-label="Back 1 second">
@@ -449,6 +449,13 @@ markdy <span class="u-fn">check-all</span> examples`;
               <svg id="pause-icon" width="10" height="10" viewBox="0 0 24 24" fill="currentColor" stroke="none" style="display:none"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
               <span id="play-label">Play</span>
             </button>
+            <div class="speed-controls" role="group" aria-label="Playback speed">
+              <button class="speed-btn" type="button" data-speed="0.25" aria-pressed="false" title="Playback speed 0.25x">0.25x</button>
+              <button class="speed-btn" type="button" data-speed="0.5" aria-pressed="false" title="Playback speed 0.5x">0.5x</button>
+              <button class="speed-btn" type="button" data-speed="1" aria-pressed="true" title="Playback speed 1x">1x</button>
+              <button class="speed-btn" type="button" data-speed="1.5" aria-pressed="false" title="Playback speed 1.5x">1.5x</button>
+              <button class="speed-btn" type="button" data-speed="2" aria-pressed="false" title="Playback speed 2x">2x</button>
+            </div>
             <button id="expand-preview-btn" class="btn-share" title="Expand preview" aria-label="Expand preview" aria-pressed="false">
               <svg id="expand-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"></polyline><polyline points="9 21 3 21 3 15"></polyline><line x1="21" y1="3" x2="14" y2="10"></line><line x1="3" y1="21" x2="10" y2="14"></line></svg>
               <span id="expand-preview-label">Expand View</span>
@@ -1178,6 +1185,7 @@ beat main:
   const rewindBtn = document.getElementById("rewind-btn") as HTMLButtonElement;
   const restartBtn = document.getElementById("restart-btn") as HTMLButtonElement;
   const playBtn   = document.getElementById("play-btn")   as HTMLButtonElement;
+  const speedBtns = document.querySelectorAll<HTMLButtonElement>(".speed-btn");
   const playIcon  = document.getElementById("play-icon")  as SVGElement;
   const pauseIcon = document.getElementById("pause-icon") as SVGElement;
   const playLabel = document.getElementById("play-label") as HTMLSpanElement;
@@ -1197,6 +1205,21 @@ beat main:
   let currentPreviewStart = 0;
   let isScrubbing = false;
   let isPreviewExpanded = false;
+  let selectedPlaybackRate = 1;
+
+  function setSelectedPlaybackRate(rate: number) {
+    if (!Number.isFinite(rate) || rate <= 0) return;
+    selectedPlaybackRate = rate;
+    for (const btn of speedBtns) {
+      const btnRate = Number(btn.dataset.speed ?? "1");
+      const isActive = Math.abs(btnRate - rate) < 0.001;
+      btn.classList.toggle("active", isActive);
+      btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+    }
+    player?.setPlaybackRate(rate);
+  }
+
+  setSelectedPlaybackRate(1);
 
   function formatTime(seconds: number): string {
     if (!Number.isFinite(seconds) || seconds <= 0) return "0:00";
@@ -1333,6 +1356,8 @@ beat main:
         code: adaptCodeToTheme(code),
         autoplay: true,
         copyright: false,
+        sceneBoundaryProgress: false,
+        playbackRate: selectedPlaybackRate,
         onTimeUpdate: setTimeline,
         onPlayStateChange: setPlayState,
       });
@@ -1542,6 +1567,13 @@ beat main:
     if (!player) return;
     player.seek(0);
     if (!player.isPlaying()) player.play();
+  });
+
+  speedBtns.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const rate = Number(btn.dataset.speed ?? "1");
+      setSelectedPlaybackRate(rate);
+    });
   });
 
   timelineRange.addEventListener("input", () => {
@@ -2348,6 +2380,37 @@ f
     gap: 0.5rem;
     min-width: 0;
     flex-wrap: wrap;
+  }
+
+  .speed-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .speed-btn {
+    font-family: inherit;
+    font-size: 0.64rem;
+    font-weight: 700;
+    padding: 0.18rem 0.38rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    cursor: pointer;
+    line-height: 1.2;
+    transition: all 0.18s ease;
+  }
+
+  .speed-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .speed-btn.active {
+    background: var(--accent-light);
+    border-color: var(--accent);
+    color: var(--accent);
   }
 
   .editor-hint {
@@ -3206,6 +3269,17 @@ f
 
     .preview-toolbar {
       gap: 0.35rem;
+    }
+
+    .speed-controls {
+      gap: 0.2rem;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .speed-btn {
+      font-size: 0.62rem;
+      padding: 0.14rem 0.33rem;
     }
 
     .preview-toolbar .btn-share span {


### PR DESCRIPTION
## Summary
- add playback speed controls (0.25x, 0.5x, 1x, 1.5x, 2x) to playground preview
- add renderer playback-rate API and scene-boundary progress visibility flag
- wire Astro/MDX integrations for playback rate and scene-boundary progress options
- hide rainbow scene-boundary progress in playground embedded preview
- polish showcase diagrams for cleaner spacing, arrangement, and readability

## Validation
- pnpm run verify:examples