### PR TITLE
feat: add semantic node cards and learning path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] — 2026-08-04
+
+### Added
+- **Playback controls for embedded previews** — Added playback-rate support across the DOM renderer, Astro, and MDX integrations, plus YouTube-style speed buttons in the homepage playground.
+- **Semantic node cards** — Replaced visible node-kind text with compact, role-aware SVG icons while preserving semantic metadata, accessible labels, and role coloring.
+- **Scene-boundary progress control** — Added `sceneBoundaryProgress` as the preferred option for hiding or showing the rainbow scene-boundary progress indicator.
+
+### Changed
+- **Showcase readability** — Rebalanced curated showcase scenes with cleaner spacing, smaller default node cards, and simpler source ids that render readable labels automatically.
+- **MarkdyScript onboarding** — Reworked the homepage learning path into progressive how-to tutorials that build from the smallest scene shell to a production architecture explainer.
+- **Scene-first documentation** — Updated the landing page, README, and getting-started guide so `.markdy` files and CLI validation are the primary authoring path, with `createPlayer` positioned as a custom embed API.
+
+### Fixed
+- **Technical label casing** — Improved generated labels for ids such as `ApiGateway`, `UrlMappingDb`, `CdnEdge`, `kubectl`, and `etcd` so examples can avoid redundant quoted labels.
+
 ## [0.8.1] — 2026-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ beat main:
 | **Auto-layout + routing** | Rank-based layout and orthogonal edge routing are built in — no coordinates required |
 | **Flow operators** | `->` request, `<-` response, `~>` event, `--` dependency, each with its own edge style |
 | **Beats + cues** | Sequence reveals with `beat` blocks and `show`/`hide`/`glow`/`focus` cues; run cues together with `&` |
+| **Semantic node cards** | Kind-aware SVG glyphs for browsers, services, gateways, queues, workers, databases, storage, CDN, security, platform, and more |
 | **Patterns, styles, groups** | Reusable `pattern name(...)` + `use`, per-node `style`, and `group` fan-out with `stagger` |
 | **Semantic themes** | `midnight` (dark) and `paper` (light) — consistent colors per node role and edge kind |
 | **Technical diagram vocabulary** | Optional systems pack adds architecture nodes, visual primitives, and labeled flows for software-engineering diagrams |
@@ -148,33 +149,30 @@ npx markdy render examples/showcase/url-shortener-architecture.markdy --out scen
 
 ## Quick Start
 
-### Vanilla JS / TypeScript
+### Write a `.markdy` scene
 
-```sh
-pnpm add @markdy/core @markdy/renderer-dom
+Create `architecture.markdy`:
+
+```markdy
+scene "Request" theme=midnight
+layout LR
+
+browser WebApp
+service CheckoutApi
+database OrdersDb
+
+beat main:
+  show $nodes stagger=80ms
+  WebApp -> CheckoutApi "GET /orders" -> OrdersDb "query"
+  WebApp <- CheckoutApi "200 OK"
 ```
 
-```ts
-import { createPlayer } from "@markdy/renderer-dom";
+Preview or validate it with the CLI:
 
-const player = createPlayer({
-  container: document.getElementById("scene")!,
-  code: `
-    scene "Request" theme=midnight
-    browser Web
-    service API
-    beat main:
-      show $nodes
-      Web -> API "GET /users"
-  `,
-  autoplay: true,
-});
-
-// Control playback
-player.pause();
-player.seek(1.5);   // jump to 1.5 s
-player.play();
-player.destroy();    // clean up
+```sh
+pnpm add -D @markdy/cli
+pnpm markdy lint architecture.markdy
+pnpm markdy render architecture.markdy --out architecture.html
 ```
 
 ### Astro / MDX
@@ -189,11 +187,11 @@ import { Markdy } from "@markdy/astro";
 
 const code = `
   scene "Request" theme=midnight width=800 height=400
-  browser Web
-  service API
+  browser WebApp
+  service CheckoutApi
   beat main:
     show $nodes
-    Web -> API "GET /users"
+    WebApp -> CheckoutApi "GET /users"
 `;
 ---
 
@@ -228,27 +226,27 @@ Full reference: **[docs/SYNTAX.md](docs/SYNTAX.md)** · Step-by-step tutorial: *
 scene "Order Flow" theme=midnight
 layout LR
 
-browser Browser
-service API "Order Service"
-database DB "Orders DB"
+browser WebApp
+service OrderService
+database OrdersDb
 
 beat main:
   show $nodes stagger=80ms
-  Browser -> API "POST /order" -> DB "persist"
-  Browser <- API "201 Created"
+  WebApp -> OrderService "POST /order" -> OrdersDb "persist"
+  WebApp <- OrderService "201 Created"
 ```
 
 ### Groups + Patterns
 
 ```markdy
-group storage: Redis DB
+group storage: Redis OrdersDb
 
 pattern lookup(client, store):
   $client -> $store "lookup"
   $client <- $store "result"
 
 beat read:
-  use lookup(API, Redis)
+  use lookup(OrderService, Redis)
 ```
 
 ### Flow operators
@@ -301,7 +299,9 @@ interface PlayerOptions {
   autoplay?: boolean;       // Start immediately (default: true)
   loop?: boolean;           // Loop at end (default: true)
   copyright?: boolean;      // "Powered by Markdy" badge (default: true)
-  progressBar?: boolean;    // Rainbow border progress bar (default: true)
+  progressBar?: boolean;    // Deprecated: use sceneBoundaryProgress
+  sceneBoundaryProgress?: boolean; // Rainbow border progress bar (default: true)
+  playbackRate?: number;    // Timeline speed multiplier (default: 1)
   onWarning?: (w: Diagnostic) => void;                 // Soft parse warnings
   onTimeUpdate?: (seconds: number, duration: number) => void;
   onPlayStateChange?: (playing: boolean) => void;
@@ -311,6 +311,8 @@ interface Player {
   play(): void;             // Start / resume
   pause(): void;            // Pause at current position
   seek(seconds: number): void;  // Jump to time
+  setPlaybackRate(rate: number): void; // Set timeline speed, e.g. 0.5 or 2
+  playbackRate(): number;    // Current timeline speed multiplier
   seekToBeat(name: string): void;  // Jump to a named beat
   destroy(): void;          // Remove DOM + cancel animations
 }
@@ -329,6 +331,8 @@ interface Player {
 | `loop` | `boolean` | `true` | Loop the animation when it ends |
 | `copyright` | `boolean` | `true` | Show a "Powered by Markdy" badge below the animation |
 | `progressBar` | `boolean` | `true` | Show a rainbow progress bar around the viewport border |
+| `sceneBoundaryProgress` | `boolean` | `progressBar` | Preferred flag for the rainbow scene-boundary progress bar |
+| `playbackRate` | `number` | `1` | Timeline speed multiplier |
 | `class` | `string` | — | CSS class for outer wrapper |
 
 ---

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -4,45 +4,47 @@ Markdy is an open-source text-to-animation DSL for animated diagrams, architectu
 
 Use this guide when you want to answer: "How do I turn a text description into an animated developer diagram?"
 
-## 1. Install the core packages
+## 1. Write a scene file
 
-```sh
-npm i @markdy/core @markdy/renderer-dom
-```
+Create `architecture.markdy`:
 
-The full architecture node vocabulary ships inside `@markdy/core`, so no registration step is needed. `@markdy/stdlib-systems` is an optional re-export/manifest of that vocabulary for tooling.
-
-## 2. Render a scene in the browser
-
-```ts
-import { createPlayer } from "@markdy/renderer-dom";
-
-createPlayer({
-  container: document.getElementById("scene")!,
-  code: `
+```markdy
 scene "Request" theme=midnight
 layout LR
 
-browser Browser
-service API
-database Postgres "Postgres"
+browser WebApp
+service ApiServer
+database Postgres
 
 beat main:
   show $nodes stagger=80ms
-  Browser -> API "GET /users" -> Postgres "query"
-  Browser <- API "200 OK"
-`,
-});
+  WebApp -> ApiServer "GET /users" -> Postgres "query"
+  WebApp <- ApiServer "200 OK"
 ```
+
+Node labels are optional. IDs like `ApiServer` and `OrdersDb` render as readable labels such as `API Server` and `Orders DB`.
+
+## 2. Preview and validate it
+
+```sh
+npm i -D @markdy/cli
+npx markdy lint architecture.markdy
+npx markdy render architecture.markdy --out architecture.html
+```
+
+The full architecture node vocabulary ships inside Markdy, so no registration step is needed. `@markdy/stdlib-systems` is an optional re-export/manifest of that vocabulary for tooling.
 
 ## 3. Pick the right integration
 
+Use the scene file directly when you can. Reach for package APIs only when you need to embed or automate it.
+
 | Goal | Use |
 |---|---|
-| Render in a web app | `@markdy/core` + `@markdy/renderer-dom` |
+| Preview, lint, format, or render files | `@markdy/cli` |
 | Embed in Astro docs | `@markdy/astro` |
 | Write fenced code blocks in MDX | `@markdy/mdx` |
-| Lint, format, render, or preview files | `@markdy/cli` |
+| Build a custom browser player | `@markdy/renderer-dom` |
+| Parse or inspect scenes in tooling | `@markdy/core` |
 | Autocomplete and diagnostics in editors | `@markdy/language-server` |
 | Architecture node vocabulary manifest | `@markdy/stdlib-systems` (optional) |
 

--- a/examples/01-first-diagram.markdy
+++ b/examples/01-first-diagram.markdy
@@ -1,15 +1,15 @@
 // First diagram — declare nodes and connect them with a flow.
-// Node syntax: <kind> <Id> ["Label"]. Omit the label to reuse the id.
+// Node syntax: <kind> <Id> ["Label"]. Omit the label to humanize the id.
 scene "First Diagram" theme=midnight
 layout LR
 
-browser Browser
-service API "API Server"
-database DB "Postgres"
+browser WebApp
+service ApiServer
+database Postgres
 
 // A beat groups animated cues. `show $nodes` reveals every node,
 // then the flow chain draws request edges left to right.
 beat main:
   show $nodes stagger=80ms
-  Browser -> API "GET /users" -> DB "query"
-  Browser <- API "200 OK"
+  WebApp -> ApiServer "GET /users" -> Postgres "query"
+  WebApp <- ApiServer "200 OK"

--- a/examples/02-flow-operators.markdy
+++ b/examples/02-flow-operators.markdy
@@ -2,14 +2,14 @@
 scene "Flow Operators" theme=midnight
 layout LR
 
-client Web
-service API
-database DB
-queue Queue
+client WebApp
+service Api
+database RecordsDb
+queue EventQueue
 
 beat flows:
   show $nodes
-  Web -> API "request"       // -> solid request edge
-  API <- Web "response"      // <- dashed response (drawn back toward API)
-  API ~> Queue "event"       // ~> dotted event edge
-  API -- DB "dependency"     // -- thin dependency link
+  WebApp -> Api "request"          // -> solid request edge
+  Api <- WebApp "response"         // <- dashed response (drawn back toward API)
+  Api ~> EventQueue "event"        // ~> dotted event edge
+  Api -- RecordsDb "dependency"    // -- thin dependency link

--- a/examples/03-beats-and-groups.markdy
+++ b/examples/03-beats-and-groups.markdy
@@ -4,19 +4,19 @@ scene "Beats And Groups" theme=midnight
 layout LR
 
 user Visitor
-gateway Gateway "API Gateway"
-service Orders "Order Service"
-cache Redis "Cache"
-database DB "Orders DB"
+gateway ApiGateway
+service OrderService
+cache Redis
+database OrdersDb
 
-group storage: Redis DB
+group storage: Redis OrdersDb
 
 beat intro:
   show Visitor Gateway Orders & show storage stagger=80ms
 
 beat checkout:
-  Visitor -> Gateway "POST /order" -> Orders
-  Orders -> Redis "cache write" & Orders -> DB "persist"
+  Visitor -> ApiGateway "POST /order" -> OrderService
+  OrderService -> Redis "cache write" & OrderService -> OrdersDb "persist"
 
 beat highlight:
-  glow storage color=#22c55e & focus Orders zoom=1.1
+  glow storage color=#22c55e & focus OrderService zoom=1.1

--- a/examples/04-patterns-and-styles.markdy
+++ b/examples/04-patterns-and-styles.markdy
@@ -5,9 +5,9 @@ layout TB
 
 style hot = fill=#f59e0b
 
-service API
-database Primary "Primary DB" style=hot
-database Replica "Read Replica"
+service Api
+database PrimaryDb style=hot
+database ReadReplica
 
 pattern replicate(leader, follower):
   $leader -> $follower "stream WAL"
@@ -15,6 +15,6 @@ pattern replicate(leader, follower):
 
 beat main:
   show $nodes stagger=90ms
-  API -> Primary "write"
-  use replicate(Primary, Replica)
-  API -> Replica "read"
+  Api -> PrimaryDb "write"
+  use replicate(PrimaryDb, ReadReplica)
+  Api -> ReadReplica "read"

--- a/examples/showcase/kubernetes-cluster-architecture.markdy
+++ b/examples/showcase/kubernetes-cluster-architecture.markdy
@@ -2,49 +2,49 @@ scene "Kubernetes Platform Blueprint" theme=midnight width=1320 height=780
 layout LR
 
 user Operator
-cli Kubectl "kubectl"
-api APIServer "API Server"
+cli kubectl
+api ApiServer
 scheduler Scheduler
-controller Controller "Controller Manager"
-database Etcd "etcd"
-load_balancer LB "Load Balancer"
-ingress Ingress "Ingress Gateway"
-service KubeService "Cluster Service"
-pod AppPod "App API Pod"
-pod JobPod "Worker Job Pod"
+controller ControllerManager
+database etcd
+load_balancer LoadBalancer
+ingress IngressGateway
+service ClusterService
+pod AppApiPod
+pod WorkerJobPod
 configmap Config
 secret Secret
-volume PV "Persistent Volume"
+volume PersistentVolume
 
-group control_plane: Operator Kubectl APIServer Scheduler Controller Etcd
-group entry_lane: LB Ingress KubeService
-group workloads: AppPod JobPod
-group runtime_config: Config Secret PV
+group control_plane: Operator kubectl ApiServer Scheduler ControllerManager etcd
+group entry_lane: LoadBalancer IngressGateway ClusterService
+group workloads: AppApiPod WorkerJobPod
+group runtime_config: Config Secret PersistentVolume
 
 beat layout:
   show control_plane stagger=45ms & show entry_lane stagger=45ms & show workloads stagger=45ms & show runtime_config stagger=45ms
 
 beat control:
-  Operator -> Kubectl "kubectl apply"
-  Kubectl -> APIServer "submit manifest"
-  APIServer -> Etcd "persist state"
-  APIServer ~> Scheduler "pending pod"
-  APIServer ~> Controller "reconcile"
+  Operator -> kubectl "kubectl apply"
+  kubectl -> ApiServer "submit manifest"
+  ApiServer -> etcd "persist state"
+  ApiServer ~> Scheduler "pending pod"
+  ApiServer ~> ControllerManager "reconcile"
 
 beat scheduling:
-  Scheduler ~> AppPod "schedule pod"
-  Controller ~> JobPod "scale workers"
+  Scheduler ~> AppApiPod "schedule pod"
+  ControllerManager ~> WorkerJobPod "scale workers"
 
 beat config:
-  Config ~> AppPod "inject env"
-  Secret ~> JobPod "mount secret"
-  PV ~> JobPod "storage"
+  Config ~> AppApiPod "inject env"
+  Secret ~> WorkerJobPod "mount secret"
+  PersistentVolume ~> WorkerJobPod "storage"
 
 beat traffic:
-  LB -> Ingress "external traffic"
-  Ingress -> KubeService "route to service"
-  KubeService -> AppPod "cluster IP"
-  AppPod ~> JobPod "dispatch background job"
+  LoadBalancer -> IngressGateway "external traffic"
+  IngressGateway -> ClusterService "route to service"
+  ClusterService -> AppApiPod "cluster IP"
+  AppApiPod ~> WorkerJobPod "dispatch background job"
 
 beat finish:
-  glow APIServer color=#38bdf8 & glow AppPod color=#22c55e
+  glow ApiServer color=#38bdf8 & glow AppApiPod color=#22c55e

--- a/examples/showcase/oauth-oidc-login-flow.markdy
+++ b/examples/showcase/oauth-oidc-login-flow.markdy
@@ -2,40 +2,40 @@ scene "OAuth / OIDC Login Flow" theme=midnight width=1280 height=760
 layout LR
 
 user User
-browser Browser
-client App "Web App"
-gateway Gateway "API Gateway"
-service AuthSvc "Auth Service"
-service IdP "Identity Provider"
-database SessionDB "Session Store"
-cache TokenCache "Token Cache"
+browser UserAgent
+client WebApp
+gateway ApiGateway
+service AuthService
+service IdentityProvider
+database SessionStore
+cache TokenCache
 
-group trust: AuthSvc IdP SessionDB TokenCache
-group client_side: User Browser App Gateway
+group trust: AuthService IdentityProvider SessionStore TokenCache
+group client_side: User UserAgent WebApp ApiGateway
 
 beat layout:
   show client_side stagger=45ms & show trust stagger=45ms
 
 beat login:
-  User -> Browser "click sign in"
-  Browser -> App "start login"
-  App -> Gateway "GET /auth/login"
-  Gateway -> AuthSvc "create state"
-  AuthSvc -> IdP "authorize redirect"
-  Browser <- IdP "login + consent"
+  User -> UserAgent "click sign in"
+  UserAgent -> WebApp "start login"
+  WebApp -> ApiGateway "GET /auth/login"
+  ApiGateway -> AuthService "create state"
+  AuthService -> IdentityProvider "authorize redirect"
+  UserAgent <- IdentityProvider "login + consent"
 
 beat callback:
-  Browser -> Gateway "GET /callback"
-  Gateway -> AuthSvc "exchange code"
-  AuthSvc -> IdP "token request"
-  IdP <- AuthSvc "id_token + access_token"
-  AuthSvc -> SessionDB "store session" & AuthSvc ~> TokenCache "cache tokens"
+  UserAgent -> ApiGateway "GET /callback"
+  ApiGateway -> AuthService "exchange code"
+  AuthService -> IdentityProvider "token request"
+  IdentityProvider <- AuthService "id_token + access_token"
+  AuthService -> SessionStore "store session" & AuthService ~> TokenCache "cache tokens"
 
 beat session:
-  App <- AuthSvc "session cookie"
-  App -> Gateway "GET /me"
-  Gateway -> AuthSvc "validate session"
-  AuthSvc <- App "profile"
+  WebApp <- AuthService "session cookie"
+  WebApp -> ApiGateway "GET /me"
+  ApiGateway -> AuthService "validate session"
+  AuthService <- WebApp "profile"
 
 beat finish:
-  glow trust color=#fb7185 & focus AuthSvc
+  glow trust color=#fb7185 & focus AuthService

--- a/examples/showcase/twitter-timeline-service.markdy
+++ b/examples/showcase/twitter-timeline-service.markdy
@@ -3,39 +3,39 @@ layout LR
 
 user Author
 user Reader
-gateway Gateway "API Gateway"
-service TweetSvc "Tweet Service"
-queue TweetQueue "Tweet Queue"
-worker Fanout "Fan-out Workers"
-service TimelineSvc "Timeline Service"
-cache Redis "Redis Timeline Cache"
-database TimelineDB "Timeline DB"
-service Notify "Notification Service"
+gateway ApiGateway
+service TweetService
+queue TweetQueue
+worker FanoutWorkers
+service TimelineService
+cache RedisTimelineCache
+database TimelineDb
+service NotificationService
 
-group write: Author Gateway TweetSvc TweetQueue Fanout
-group read: Reader Gateway TimelineSvc Redis TimelineDB
-group realtime: Fanout Notify
+group write: Author ApiGateway TweetService TweetQueue FanoutWorkers
+group read: Reader ApiGateway TimelineService RedisTimelineCache TimelineDb
+group realtime: FanoutWorkers NotificationService
 
 beat layout:
   show write stagger=45ms & show read stagger=45ms & show realtime stagger=45ms
 
 beat post:
-  Author -> Gateway "POST tweet"
-  Gateway -> TweetSvc "validate + store"
-  TweetSvc ~> TweetQueue "publish tweet"
-  TweetQueue ~> Fanout "fan-out job"
+  Author -> ApiGateway "POST tweet"
+  ApiGateway -> TweetService "validate + store"
+  TweetService ~> TweetQueue "publish tweet"
+  TweetQueue ~> FanoutWorkers "fan-out job"
 
 beat fanout:
-  Fanout ~> Redis "home timelines" & Fanout ~> TimelineDB "persist entries"
-  Fanout ~> Notify "mentions"
-  glow Fanout color=#a78bfa
+  FanoutWorkers ~> RedisTimelineCache "home timelines" & FanoutWorkers ~> TimelineDb "persist entries"
+  FanoutWorkers ~> NotificationService "mentions"
+  glow FanoutWorkers color=#a78bfa
 
 beat read:
-  Reader -> Gateway "GET timeline"
-  Gateway -> TimelineSvc "hydrate feed"
-  TimelineSvc -> Redis "read hot"
-  TimelineSvc -> TimelineDB "page miss"
-  Reader <- TimelineSvc "ranked feed"
+  Reader -> ApiGateway "GET timeline"
+  ApiGateway -> TimelineService "hydrate feed"
+  TimelineService -> RedisTimelineCache "read hot"
+  TimelineService -> TimelineDb "page miss"
+  Reader <- TimelineService "ranked feed"
 
 beat finish:
-  glow Redis color=#22c55e & glow TimelineDB color=#38bdf8
+  glow RedisTimelineCache color=#22c55e & glow TimelineDb color=#38bdf8

--- a/examples/showcase/url-shortener-architecture.markdy
+++ b/examples/showcase/url-shortener-architecture.markdy
@@ -2,34 +2,34 @@ scene "URL Shortener Architecture" theme=midnight width=1280 height=760
 layout LR
 
 user Visitor
-browser Browser
-gateway Gateway "API Gateway"
-service Shortener "URL Shortener"
-service Redirector "Redirect Service"
-cache Redis "Hot URL Cache"
-db UrlDB "URL Mapping DB"
+browser WebClient
+gateway ApiGateway
+service UrlShortener
+service RedirectService
+cache HotUrlCache
+db UrlMappingDb
 
-group storage: Redis UrlDB
-group ingress: Visitor Browser Gateway
-group app: Shortener Redirector
+group storage: HotUrlCache UrlMappingDb
+group ingress: Visitor WebClient ApiGateway
+group app: UrlShortener RedirectService
 
 beat layout:
   show ingress stagger=45ms & show app stagger=45ms & show storage stagger=45ms
 
 beat create:
-  Browser -> Gateway "POST /shorten"
-  Gateway -> Shortener "forward request"
-  Shortener -> UrlDB "store slug" & Shortener ~> Redis "warm cache"
-  Browser <- Shortener "short.ly/a7"
+  WebClient -> ApiGateway "POST /shorten"
+  ApiGateway -> UrlShortener "forward request"
+  UrlShortener -> UrlMappingDb "store slug" & UrlShortener ~> HotUrlCache "warm cache"
+  WebClient <- UrlShortener "short.ly/a7"
 
 beat redirect:
-  Visitor -> Browser "open short link"
-  Browser -> Gateway "GET /a7"
-  Gateway -> Redirector "resolve slug"
-  Redirector -> Redis "cache lookup"
-  Redis <- Redirector "target URL"
-  Redirector -> UrlDB "miss fallback"
-  Browser <- Redirector "301 redirect"
+  Visitor -> WebClient "open short link"
+  WebClient -> ApiGateway "GET /a7"
+  ApiGateway -> RedirectService "resolve slug"
+  RedirectService -> HotUrlCache "cache lookup"
+  HotUrlCache <- RedirectService "target URL"
+  RedirectService -> UrlMappingDb "miss fallback"
+  WebClient <- RedirectService "301 redirect"
 
 beat finish:
-  glow storage color=#22c55e & glow UrlDB color=#38bdf8
+  glow storage color=#22c55e & glow UrlMappingDb color=#38bdf8

--- a/examples/showcase/youtube-processing-pipeline.markdy
+++ b/examples/showcase/youtube-processing-pipeline.markdy
@@ -1,40 +1,40 @@
-scene "YouTube Processing Pipeline" theme=midnight width=1280 height=760
+scene "YouTube Processing Pipeline" theme=midnight width=1360 height=760
 layout LR
 
 user Creator
-browser Studio "Creator Studio"
-gateway Gateway "API Gateway"
-service UploadSvc "Upload Service"
-queue TranscodeQueue "Transcode Queue"
-worker Transcoder "Transcoder Workers"
-service CatalogSvc "Catalog Service"
-database VideoDB "Video Metadata DB"
-bucket ObjectStore "Object Storage"
-cdn CDN "CDN Edge"
+browser CreatorStudio
+gateway UploadGateway
+service UploadService
+queue TranscodeJobs
+worker Transcoder
+service VideoCatalog
+database MetadataDb
+bucket ObjectStorage
+cdn CdnEdge
 
-group ingest: Creator Studio Gateway UploadSvc
-group processing: TranscodeQueue Transcoder ObjectStore
-group delivery: CatalogSvc VideoDB CDN
+group ingest: Creator CreatorStudio UploadGateway UploadService TranscodeJobs
+group processing: Transcoder ObjectStorage
+group delivery: VideoCatalog MetadataDb CdnEdge
 
 beat layout:
-  show ingest stagger=45ms & show processing stagger=45ms & show delivery stagger=45ms
+  show ingest stagger=40ms & show processing stagger=40ms & show delivery stagger=40ms
 
 beat upload:
-  Creator -> Studio "upload video" -> Gateway "POST /videos"
-  Gateway -> UploadSvc "accept upload"
-  UploadSvc -> ObjectStore "store raw"
-  UploadSvc ~> TranscodeQueue "enqueue job"
+  Creator -> CreatorStudio "upload"
+  CreatorStudio -> UploadGateway "POST /videos"
+  UploadGateway -> UploadService "accept"
+  UploadService -> ObjectStorage "raw"
+  UploadService ~> TranscodeJobs "enqueue"
 
 beat transcode:
-  TranscodeQueue ~> Transcoder "pick job"
-  Transcoder -> ObjectStore "read raw"
-  Transcoder -> ObjectStore "write renditions"
-  Transcoder -> CatalogSvc "register renditions"
+  TranscodeJobs ~> Transcoder "start"
+  Transcoder -> ObjectStorage "read"
+  Transcoder -> ObjectStorage "write"
+  Transcoder -> VideoCatalog "register"
 
 beat publish:
-  CatalogSvc -> VideoDB "persist metadata"
-  CatalogSvc ~> CDN "warm edge cache"
-  Studio <- CatalogSvc "video ready"
+  VideoCatalog -> MetadataDb "meta"
+  VideoCatalog ~> CdnEdge "warm cache"
 
 beat finish:
-  glow Transcoder color=#38bdf8 & glow CDN color=#22c55e
+  glow Transcoder color=#38bdf8 & glow CdnEdge color=#22c55e

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -7,6 +7,7 @@
 - **SSR placeholder** — correctly-sized `<div>` prevents layout shift before hydration
 - **Viewport-triggered hydration** — `IntersectionObserver` with 100px root margin
 - **View Transition compatible** — re-observes elements on `astro:page-load`
+- **Semantic node cards** — inherits renderer SVG glyphs for technical node kinds
 - **Zero config** — pass your MarkdyScript code as a prop
 
 ## Installation
@@ -77,7 +78,9 @@ export const code = `
 | `autoplay` | `boolean` | `true` | Start playing on hydration |
 | `loop` | `boolean` | `true` | Loop the animation when it ends |
 | `copyright` | `boolean` | `true` | Show a "Powered by Markdy" badge below the animation |
-| `progressBar` | `boolean` | `true` | Show a rainbow progress bar around the viewport border |
+| `progressBar` | `boolean` | `true` | Deprecated compatibility flag for the rainbow scene-boundary progress bar |
+| `sceneBoundaryProgress` | `boolean` | `progressBar` | Preferred flag for the rainbow scene-boundary progress bar |
+| `playbackRate` | `number` | `1` | Timeline speed multiplier |
 | `class` | `string` | — | CSS class for the outer wrapper |
 
 > **Tip:** Match `width`, `height`, and `bg` props to your `scene` declaration values to avoid a visual flash on hydration.

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -3,8 +3,8 @@ import { nodeRole } from "./registry.js";
 
 const SAFE = 64;
 const TITLE_BAND = 96;
-const NODE_W = 184;
-const NODE_H = 88;
+const NODE_W = 168;
+const NODE_H = 72;
 const RANK_GAP = 96;
 const ROW_GAP = 40;
 

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -20,10 +20,25 @@ export function nodeRole(kind: string): string {
 }
 
 export function humanizeId(id: string): string {
+  const acronyms = new Set(["api", "cdn", "db", "dns", "http", "https", "id", "jwt", "oidc", "sdk", "tls", "ui", "url"]);
+  const exactCase = new Map([
+    ["etcd", "etcd"],
+    ["kubectl", "kubectl"],
+  ]);
   return id
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
     .replace(/[_-]+/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => {
+      const lower = word.toLowerCase();
+      const exact = exactCase.get(lower);
+      if (exact) return exact;
+      if (acronyms.has(lower)) return lower.toUpperCase();
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
 }
 
 /** Node kind aliases for concise authoring. */

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -9,22 +9,22 @@ scene "URL Shortener Architecture" theme=midnight
 layout LR
 
 user Visitor
-browser Browser
-gateway Gateway "API Gateway"
-service Shortener "URL Shortener"
-service Redirector "Redirect Service"
-cache Redis "Hot URL Cache"
-db UrlDB "URL Mapping DB"
+browser WebClient
+gateway ApiGateway
+service UrlShortener
+service RedirectService
+cache HotUrlCache
+db UrlMappingDb
 
-group storage: Redis UrlDB
+group storage: HotUrlCache UrlMappingDb
 
 beat layout:
   show $nodes stagger=60ms
 
 beat create:
-  Browser -> Gateway "POST /shorten" -> Shortener
-  Shortener -> UrlDB "store slug" & Shortener ~> Redis "warm cache"
-  Browser <- Shortener "short.ly/a7"
+  WebClient -> ApiGateway "POST /shorten" -> UrlShortener
+  UrlShortener -> UrlMappingDb "store slug" & UrlShortener ~> HotUrlCache "warm cache"
+  WebClient <- UrlShortener "short.ly/a7"
 
 beat finish:
   glow storage color=#22c55e
@@ -37,13 +37,29 @@ describe("diagram parser", () => {
     expect(ast.meta.theme).toBe("midnight");
     expect(ast.meta.direction).toBe("LR");
     expect(Object.keys(ast.nodes)).toHaveLength(7);
-    expect(ast.nodes.Browser.kind).toBe("browser");
-    expect(ast.nodes.UrlDB.label).toBe("URL Mapping DB");
+    expect(ast.nodes.WebClient.kind).toBe("browser");
+    expect(ast.nodes.ApiGateway.label).toBe("API Gateway");
+    expect(ast.nodes.UrlMappingDb.label).toBe("URL Mapping DB");
+  });
+
+  it("humanizes unlabeled node ids while preserving technical casing", () => {
+    const ast = parse(`
+scene theme=midnight
+cli kubectl
+database etcd
+service ApiServer
+cdn CdnEdge
+`);
+
+    expect(ast.nodes.kubectl.label).toBe("kubectl");
+    expect(ast.nodes.etcd.label).toBe("etcd");
+    expect(ast.nodes.ApiServer.label).toBe("API Server");
+    expect(ast.nodes.CdnEdge.label).toBe("CDN Edge");
   });
 
   it("parses groups and beats", () => {
     const ast = parse(URL_SHORTENER);
-    expect(ast.groups.storage.members).toEqual(["Redis", "UrlDB"]);
+    expect(ast.groups.storage.members).toEqual(["HotUrlCache", "UrlMappingDb"]);
     expect(ast.beats.map((b) => b.name)).toEqual(["layout", "create", "finish"]);
     expect(ast.beats[1].cues[0].kind).toBe("flow");
   });
@@ -66,8 +82,8 @@ describe("diagram parser", () => {
     const ast = parse(URL_SHORTENER);
     const create = ast.beats.find((b) => b.name === "create")!;
     const firstFlow = create.cues.filter(isFlow)[0];
-    expect(firstFlow.segments[0]).toMatchObject({ from: "Browser", to: "Gateway", label: "POST /shorten" });
-    expect(firstFlow.segments[1]).toMatchObject({ from: "Gateway", to: "Shortener" });
+    expect(firstFlow.segments[0]).toMatchObject({ from: "WebClient", to: "ApiGateway", label: "POST /shorten" });
+    expect(firstFlow.segments[1]).toMatchObject({ from: "ApiGateway", to: "UrlShortener" });
   });
 
   it("reverses response edges while keeping their label", () => {
@@ -77,7 +93,7 @@ describe("diagram parser", () => {
       .filter(isFlow)
       .flatMap((c) => c.segments)
       .find((s) => s.op === "response");
-    expect(response).toMatchObject({ from: "Shortener", to: "Browser", label: "short.ly/a7" });
+    expect(response).toMatchObject({ from: "UrlShortener", to: "WebClient", label: "short.ly/a7" });
   });
 
   it("only references declared nodes in compiled flow cues", () => {

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -4,6 +4,7 @@ MDX integration for MarkdyScript with Lighthouse-safe defaults:
 
 - `remarkMarkdy` converts fenced code blocks (` ```markdy `) into a player component.
 - `MarkdyPlayer` hydrates only when visible and lazy-loads `@markdy/renderer-dom`.
+- Rendered diagrams use the same semantic SVG node cards as `@markdy/renderer-dom`.
 
 ## Install
 
@@ -48,7 +49,7 @@ export const mdxComponents = {
 Then write Markdown:
 
 ````md
-```markdy width=800 height=400 bg="#07111f" autoplay=false loop=false
+```markdy width=800 height=400 bg="#07111f" autoplay=false loop=false playback_rate=0.5 scene_boundary_progress=false
 scene "Request" theme=midnight width=800 height=400
 browser Web
 service API
@@ -63,3 +64,13 @@ beat main:
 - Default transform options set `autoplay=false`, `loop=false`, `progressBar=false`.
 - Runtime player does not import renderer code until the block enters viewport.
 - Placeholder is SSR-safe and keeps stable layout ratio to avoid CLS.
+
+## Fence Metadata
+
+Fenced block metadata is passed as props to `MarkdyPlayer`. Snake-case aliases are normalized for renderer options:
+
+| Metadata | Prop | Description |
+|---|---|---|
+| `progress_bar=false` | `progressBar={false}` | Deprecated compatibility flag for the scene-boundary progress bar |
+| `scene_boundary_progress=false` | `sceneBoundaryProgress={false}` | Preferred flag for the scene-boundary progress bar |
+| `playback_rate=0.5` | `playbackRate={0.5}` | Timeline speed multiplier |

--- a/packages/renderer-dom/README.md
+++ b/packages/renderer-dom/README.md
@@ -8,7 +8,9 @@ Web Animations API renderer for [MarkdyScript](../../docs/SYNTAX.md) scenes. Tra
 - **Auto-layout diagrams** — renders positioned nodes and orthogonal, obstacle-aware edges from a compiled `RenderPlan`
 - **Flow edges** — `->` request, `<-` response, `~>` event, `--` dependency, each with its own stroke, plus a pulse that travels the edge as it draws
 - **Beat-driven cues** — `show`, `hide`, `glow`, and `focus`, sequenced by named beats
+- **Semantic node cards** — compact SVG glyphs for browsers, services, gateways, queues, workers, databases, storage, CDN, security, platform, and more
 - **Seek-safe** — manual `currentTime` control enables reliable `seek()` in any direction
+- **Playback-rate controls** — set timeline speed to slow down or speed up diagrams without rebuilding animations
 - **Semantic themes** — `midnight` and `paper`, with per-role node colors
 - **Single dependency** — only `@markdy/core`
 
@@ -68,7 +70,9 @@ player.destroy();    // clean up DOM + cancel animations
 | `autoplay` | `boolean` | `true` | Start playing immediately |
 | `loop` | `boolean` | `true` | Loop the animation when it reaches the end |
 | `copyright` | `boolean` | `true` | Show a small "Powered by Markdy" badge below the animation |
-| `progressBar` | `boolean` | `true` | Show a rainbow progress bar around the viewport border |
+| `progressBar` | `boolean` | `true` | Deprecated compatibility flag for the rainbow scene-boundary progress bar |
+| `sceneBoundaryProgress` | `boolean` | `progressBar ?? true` | Preferred flag for the rainbow scene-boundary progress bar |
+| `playbackRate` | `number` | `1` | Timeline speed multiplier |
 | `onWarning` | `(warning: Diagnostic) => void` | `console.warn` | Called for each soft parse warning |
 | `onTimeUpdate` | `(seconds: number, durationSeconds: number) => void` | — | Called whenever playback or seek changes the current time |
 | `onPlayStateChange` | `(playing: boolean) => void` | — | Called when playback starts or pauses |
@@ -80,6 +84,8 @@ player.destroy();    // clean up DOM + cancel animations
 | `play()` | Start or resume playback |
 | `pause()` | Pause at current position |
 | `seek(seconds)` | Jump to a specific time |
+| `setPlaybackRate(rate)` | Change timeline speed; ignores non-positive or non-finite values |
+| `playbackRate()` | Current timeline speed multiplier |
 | `currentTime()` | Current playback position in seconds |
 | `duration()` | Total scene duration in seconds |
 | `isPlaying()` | Whether the scene is currently playing |

--- a/packages/renderer-dom/src/nodes.ts
+++ b/packages/renderer-dom/src/nodes.ts
@@ -12,7 +12,7 @@ export function ensureNodeStyles(doc: Document): void {
   box-sizing: border-box;
   width: var(--md-node-w, 184px);
   height: var(--md-node-h, 88px);
-  border-radius: 16px;
+  border-radius: 14px;
   border: 1px solid var(--md-border);
   background: linear-gradient(145deg, var(--md-surface-raised), var(--md-surface));
   color: var(--md-text);
@@ -43,15 +43,41 @@ export function ensureNodeStyles(doc: Document): void {
   border-radius: 16px 0 0 16px;
 }
 .markdy-node__type {
-  padding: 10px 14px 0 18px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--md-text-muted);
+  display: none;
+}
+.markdy-node__body {
+  height: 100%;
+  padding: 0 14px 0 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.markdy-node__icon {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--md-role-color, var(--md-accent));
+  background: color-mix(in srgb, var(--md-role-color, var(--md-accent)) 16%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--md-role-color, var(--md-accent)) 28%, transparent) inset;
+}
+.markdy-node__icon svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+  stroke: currentColor;
+}
+.markdy-node[data-icon="decision"] .markdy-node__icon,
+.markdy-node[data-icon="flow"] .markdy-node__icon {
+  border-radius: 999px;
 }
 .markdy-node__label {
-  padding: 2px 14px 0 18px;
+  min-width: 0;
+  padding: 0;
   font-size: 15px;
   font-weight: 650;
   line-height: 1.25;
@@ -84,6 +110,144 @@ export function ensureNodeStyles(doc: Document): void {
   doc.head.appendChild(style);
 }
 
+type SvgSpec = Array<[string, Record<string, string>]>;
+
+const ICONS: Record<string, SvgSpec> = {
+  compute: [
+    ["rect", { x: "5", y: "5", width: "14", height: "14", rx: "3" }],
+    ["path", { d: "M9 9h6v6H9zM9 2.5v2.5M15 2.5v2.5M9 19v2.5M15 19v2.5M2.5 9h2.5M2.5 15h2.5M19 9h2.5M19 15h2.5" }],
+  ],
+  user: [
+    ["circle", { cx: "12", cy: "8", r: "3.4" }],
+    ["path", { d: "M5.5 20a6.5 6.5 0 0 1 13 0" }],
+  ],
+  browser: [
+    ["rect", { x: "3", y: "5", width: "18", height: "14", rx: "2.5" }],
+    ["path", { d: "M3 9h18" }],
+    ["path", { d: "M7 7h.01M10 7h.01" }],
+  ],
+  service: [
+    ["path", { d: "M12 3 4.5 7.2 12 11.4l7.5-4.2L12 3Z" }],
+    ["path", { d: "M4.5 12 12 16.2 19.5 12" }],
+    ["path", { d: "M4.5 16.8 12 21l7.5-4.2" }],
+  ],
+  gateway: [
+    ["circle", { cx: "5", cy: "12", r: "2" }],
+    ["circle", { cx: "19", cy: "6", r: "2" }],
+    ["circle", { cx: "19", cy: "18", r: "2" }],
+    ["path", { d: "M7 12h4l5.5-5" }],
+    ["path", { d: "M11 12l5.5 5" }],
+  ],
+  queue: [
+    ["rect", { x: "5", y: "5", width: "14", height: "4", rx: "1.4" }],
+    ["rect", { x: "5", y: "10", width: "14", height: "4", rx: "1.4" }],
+    ["rect", { x: "5", y: "15", width: "14", height: "4", rx: "1.4" }],
+  ],
+  worker: [
+    ["circle", { cx: "12", cy: "12", r: "3.2" }],
+    ["path", { d: "M12 2.8v3M12 18.2v3M2.8 12h3M18.2 12h3M5.5 5.5l2.1 2.1M16.4 16.4l2.1 2.1M18.5 5.5l-2.1 2.1M7.6 16.4l-2.1 2.1" }],
+  ],
+  database: [
+    ["ellipse", { cx: "12", cy: "5.5", rx: "7", ry: "3" }],
+    ["path", { d: "M5 5.5v10c0 1.7 3.1 3 7 3s7-1.3 7-3v-10" }],
+    ["path", { d: "M5 10.5c0 1.7 3.1 3 7 3s7-1.3 7-3" }],
+  ],
+  storage: [
+    ["path", { d: "M4 8.5 12 4l8 4.5v7L12 20l-8-4.5v-7Z" }],
+    ["path", { d: "M4 8.5 12 13l8-4.5" }],
+    ["path", { d: "M12 13v7" }],
+  ],
+  cdn: [
+    ["circle", { cx: "12", cy: "12", r: "8" }],
+    ["path", { d: "M4 12h16M12 4c2.2 2.1 3.3 4.8 3.3 8S14.2 17.9 12 20M12 4c-2.2 2.1-3.3 4.8-3.3 8S9.8 17.9 12 20" }],
+  ],
+  cache: [
+    ["path", { d: "M13 2 5 13h6l-1 9 9-13h-6l0-7Z" }],
+  ],
+  code: [
+    ["path", { d: "m9 18-6-6 6-6" }],
+    ["path", { d: "m15 6 6 6-6 6" }],
+    ["path", { d: "m14 4-4 16" }],
+  ],
+  messaging: [
+    ["path", { d: "M4 6h16v10H8l-4 4V6Z" }],
+    ["path", { d: "M8 10h8M8 13h5" }],
+  ],
+  network: [
+    ["circle", { cx: "6", cy: "7", r: "2" }],
+    ["circle", { cx: "18", cy: "7", r: "2" }],
+    ["circle", { cx: "12", cy: "18", r: "2" }],
+    ["path", { d: "M8 8.5 11 16M16 8.5 13 16M8 7h8" }],
+  ],
+  platform: [
+    ["rect", { x: "4", y: "5", width: "16", height: "14", rx: "2.5" }],
+    ["path", { d: "M8 9h8M8 13h8M8 17h4" }],
+  ],
+  security: [
+    ["path", { d: "M12 3 5 6v5c0 4.5 3 7.7 7 10 4-2.3 7-5.5 7-10V6l-7-3Z" }],
+    ["path", { d: "M9.5 12.5 11.2 14 15 10" }],
+  ],
+  delivery: [
+    ["path", { d: "M4 7h10" }],
+    ["path", { d: "M4 12h16" }],
+    ["path", { d: "M4 17h10" }],
+    ["path", { d: "m16 7 4 5-4 5" }],
+  ],
+  observability: [
+    ["path", { d: "M4 14s2.5-5 8-5 8 5 8 5-2.5 5-8 5-8-5-8-5Z" }],
+    ["circle", { cx: "12", cy: "14", r: "2.5" }],
+  ],
+  distributed: [
+    ["circle", { cx: "6", cy: "12", r: "2.5" }],
+    ["circle", { cx: "18", cy: "6", r: "2.5" }],
+    ["circle", { cx: "18", cy: "18", r: "2.5" }],
+    ["path", { d: "M8.4 11 15.6 7M8.4 13 15.6 17" }],
+  ],
+  flow: [
+    ["path", { d: "M5 12h14" }],
+    ["path", { d: "m13 6 6 6-6 6" }],
+  ],
+  decision: [
+    ["path", { d: "M12 3 21 12 12 21 3 12 12 3Z" }],
+    ["path", { d: "M12 8v4" }],
+    ["path", { d: "M12 16h.01" }],
+  ],
+};
+
+function iconKeyForNode(node: PositionedNode): string {
+  if (node.kind === "api_gateway" || node.kind === "gateway" || node.kind === "load_balancer" || node.kind === "ingress") return "gateway";
+  if (node.kind === "db" || node.kind === "database" || node.kind === "sql" || node.kind === "nosql" || node.kind === "warehouse") return "database";
+  if (node.kind === "bucket" || node.kind === "object_store" || node.kind === "blob" || node.kind === "volume" || node.kind === "disk") return "storage";
+  if (node.kind === "cdn" || node.kind === "dns" || node.kind === "internet") return "cdn";
+  if (node.kind === "queue" || node.kind === "topic" || node.kind === "stream" || node.kind === "event_bus" || node.kind === "broker") return "queue";
+  if (node.kind === "worker" || node.kind === "job" || node.kind === "scheduler" || node.kind === "cron" || node.kind === "batch") return "worker";
+  if (node.kind === "browser" || node.kind === "web" || node.kind === "frontend" || node.kind === "app") return "browser";
+  if (node.kind === "user" || node.kind === "client") return "user";
+  if (node.kind === "decision" || node.kind === "condition") return "decision";
+  if (node.kind === "cache") return "cache";
+  return ICONS[node.kind] ? node.kind : node.role;
+}
+
+function createIconEl(doc: Document, node: PositionedNode): HTMLElement {
+  const wrap = doc.createElement("div");
+  wrap.className = "markdy-node__icon";
+  wrap.setAttribute("aria-hidden", "true");
+  const svg = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  const spec = ICONS[iconKeyForNode(node)] ?? ICONS.service;
+  for (const [tag, attrs] of spec) {
+    const child = doc.createElementNS("http://www.w3.org/2000/svg", tag);
+    for (const [name, value] of Object.entries(attrs)) child.setAttribute(name, value);
+    svg.appendChild(child);
+  }
+  wrap.appendChild(svg);
+  return wrap;
+}
+
 export function createNodeEl(node: PositionedNode, theme: ThemeTokens): HTMLElement {
   const el = document.createElement("div");
   el.className = "markdy-node markdy-scene-actor";
@@ -95,16 +259,25 @@ export function createNodeEl(node: PositionedNode, theme: ThemeTokens): HTMLElem
   el.style.setProperty("--md-node-h", `${node.height}px`);
   const roleColor = theme.roles[node.role] ?? theme.accent;
   el.style.setProperty("--md-role-color", roleColor);
+  const typeText = node.kind.replace(/_/g, " ");
+  el.dataset.kind = node.kind;
+  el.dataset.icon = iconKeyForNode(node);
+  el.title = `${node.label} (${typeText})`;
+  el.setAttribute("aria-label", el.title);
 
   const rail = document.createElement("div");
   rail.className = "markdy-node__rail";
   const type = document.createElement("div");
   type.className = "markdy-node__type";
-  type.textContent = node.kind.replace(/_/g, " ");
+  type.textContent = typeText;
+  const body = document.createElement("div");
+  body.className = "markdy-node__body";
+  const icon = createIconEl(document, node);
   const label = document.createElement("div");
   label.className = "markdy-node__label";
   label.textContent = node.label;
-  el.append(rail, type, label);
+  body.append(icon, label);
+  el.append(rail, type, body);
   return el;
 }
 

--- a/packages/renderer-dom/tests/render.extended.test.ts
+++ b/packages/renderer-dom/tests/render.extended.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseAndCompile } from "@markdy/core";
+import { createNodeEl } from "../src/nodes";
 
 const SAMPLE = `
 scene "Test" theme=midnight
@@ -17,5 +18,63 @@ describe("diagram render plan", () => {
     expect(plan.nodes).toHaveLength(2);
     expect(plan.cues.length).toBeGreaterThan(0);
     expect(plan.theme.name).toBe("midnight");
+  });
+
+  it("renders node cards with label-first icons and preserved kind metadata", () => {
+    const node = {
+      id: "Web",
+      kind: "browser",
+      role: "client",
+      label: "Browser",
+      x: 0,
+      y: 0,
+      width: 168,
+      height: 72,
+      opacity: 0,
+    };
+    const theme = {
+      roles: { client: "#38bdf8" },
+      accent: "#38bdf8",
+    } as any;
+    const el = createNodeEl(node, theme);
+    expect(el.querySelector(".markdy-node__label")?.textContent).toBe("Browser");
+    expect(el.querySelector(".markdy-node__icon svg")).not.toBeNull();
+    expect(el.dataset.kind).toBe("browser");
+    expect(el.dataset.icon).toBe("browser");
+    expect(el.title).toBe("Browser (browser)");
+    expect(el.getAttribute("aria-label")).toBe("Browser (browser)");
+  });
+
+  it("uses role fallback icons for broad vocabulary families", () => {
+    const theme = {
+      roles: { code: "#a78bfa", distributed: "#22c55e" },
+      accent: "#38bdf8",
+    } as any;
+
+    const codeNode = createNodeEl({
+      id: "SDK",
+      kind: "sdk",
+      role: "code",
+      label: "SDK",
+      x: 0,
+      y: 0,
+      width: 168,
+      height: 72,
+      opacity: 0,
+    }, theme);
+    const distributedNode = createNodeEl({
+      id: "Leader",
+      kind: "leader",
+      role: "distributed",
+      label: "Leader",
+      x: 0,
+      y: 0,
+      width: 168,
+      height: 72,
+      opacity: 0,
+    }, theme);
+
+    expect(codeNode.dataset.icon).toBe("code");
+    expect(distributedNode.dataset.icon).toBe("distributed");
   });
 });

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -19,25 +19,24 @@ const FEATURES = [
 ];
 
 /* ── Packages: one card per published package, each with a real usage line ──
-   `required` packages are the minimum to render a scene anywhere; everything
-   else is an optional add-on for a specific host (Astro, MDX), workflow
-   (CLI, editor tooling), or content pack (system-diagram vocabulary). ── */
+   MarkdyScript is the primary authoring surface; packages support validation,
+   docs embeds, editor tooling, and browser playback. ── */
 const PACKAGES = [
   {
     name: "@markdy/core",
-    required: true,
-    badge: "Engine",
-    desc: "Parser + AST types. Every other package builds on this — no DOM, no dependencies.",
+    required: false,
+    badge: "Grammar",
+    desc: "Parser + AST types for tools that need to inspect, validate, or compile MarkdyScript.",
     size: "~12 KB",
-    snippet: `<span class="u-kw">import</span> { parse } <span class="u-kw">from</span> <span class="u-str">"@markdy/core"</span>;`,
+    snippet: `<span class="u-kw">scene</span> <span class="u-str">"Checkout Flow"</span> theme=midnight`,
   },
   {
     name: "@markdy/renderer-dom",
-    required: true,
-    badge: "DOM",
-    desc: "Takes a parsed scene and animates it in the browser via the Web Animations API.",
+    required: false,
+    badge: "Runtime",
+    desc: "Browser playback runtime behind Astro, MDX, the CLI preview, and custom embeds.",
     size: "~22 KB",
-    snippet: `<span class="u-kw">import</span> { createPlayer } <span class="u-kw">from</span> <span class="u-str">"@markdy/renderer-dom"</span>;`,
+    snippet: `<span class="u-fn">seek</span>(1.5) · <span class="u-fn">play</span>() · <span class="u-fn">pause</span>()`,
   },
   {
     name: "@markdy/astro",
@@ -77,7 +76,7 @@ const PACKAGES = [
     badge: "Vocabulary",
     desc: "Optional add-on: the full architecture node vocabulary and flow kinds for animated system diagrams.",
     size: "<1 KB",
-    snippet: `<span class="u-kw">service</span> API <span class="u-str">"Checkout API"</span>`,
+    snippet: `<span class="u-kw">service</span> CheckoutApi`,
   },
 ] as const;
 
@@ -127,7 +126,7 @@ const FAQS = [
   },
   {
     question: "Which packages do I need to render a scene?",
-    answer: "Use @markdy/core to parse MarkdyScript and @markdy/renderer-dom to render scenes in a browser. Add @markdy/stdlib-systems for system architecture diagrams and @markdy/astro or @markdy/mdx for documentation sites.",
+    answer: "Start by writing a .markdy scene. Use @markdy/cli to validate or preview files, @markdy/astro or @markdy/mdx for documentation sites, and @markdy/renderer-dom only when you need a custom browser embed.",
   },
 ] as const;
 
@@ -186,29 +185,29 @@ const homepageStructuredData = [
 ];
 
 /* ── Usage code snippets (pre-formatted HTML to avoid Astro expression parsing) ── */
-const USAGE_VANILLA = `<span class="u-kw">import</span> { createPlayer } <span class="u-kw">from</span> <span class="u-str">"@markdy/renderer-dom"</span>;
+const USAGE_SCENE = `<span class="u-comment">// architecture.markdy</span>
+<span class="u-kw">scene</span> <span class="u-str">"Checkout Request"</span> theme=midnight
+layout LR
 
-createPlayer({
-  container: <span class="u-fn">document.getElementById</span>(<span class="u-str">"stage"</span>),
-  code: <span class="u-str">\`scene "Request" theme=midnight
-  browser Web
-  service API
-  beat main:
-    show $nodes
-    Web -> API "GET /users"\`</span>,
-  autoplay: <span class="u-lit">true</span>,
-});`;
+browser WebApp
+service CheckoutApi
+database OrdersDb
+
+beat main:
+  show $nodes stagger=80ms
+  WebApp -> CheckoutApi <span class="u-str">"GET /orders"</span> -> OrdersDb <span class="u-str">"query"</span>
+  WebApp <- CheckoutApi <span class="u-str">"200 OK"</span>`;
 
 const USAGE_ASTRO = `<span class="u-comment">---</span>
 <span class="u-kw">import</span> { Markdy } <span class="u-kw">from</span> <span class="u-str">"@markdy/astro"</span>;
 
 <span class="u-kw">const</span> code = <span class="u-str">\`
   scene "Request" theme=midnight width=800 height=400
-  browser Web
-  service API
+  browser WebApp
+  service CheckoutApi
   beat main:
     show $nodes
-    Web -> API "GET /users"
+    WebApp -> CheckoutApi "GET /users"
 \`</span>;
 <span class="u-comment">---</span>
 
@@ -224,11 +223,11 @@ const USAGE_MDX = `<span class="u-comment">// mdx.config.mjs — one-time setup<
 <span class="u-comment">// content.mdx — no imports, just write markdown</span>
 \`\`\`markdy
 scene <span class="u-str">"Request"</span> theme=midnight
-browser Web
-service API
+browser WebApp
+service CheckoutApi
 beat main:
   show $nodes
-  Web -> API <span class="u-str">"GET /users"</span>
+  WebApp -> CheckoutApi <span class="u-str">"GET /users"</span>
 \`\`\``;
 
 const USAGE_CLI = `<span class="u-comment"># validate, format, and preview a scene</span>
@@ -304,21 +303,21 @@ markdy <span class="u-fn">check-all</span> examples`;
     <!-- ─── Usage tabs ──────────────────────────────────────────────── -->
     <div class="usage-section">
       <div class="usage-tabs" role="tablist">
-        <button class="usage-tab active" data-tab="vanilla" role="tab" aria-selected="true">Vanilla</button>
+        <button class="usage-tab active" data-tab="scene" role="tab" aria-selected="true">.markdy</button>
         <button class="usage-tab" data-tab="cli" role="tab" aria-selected="false">CLI</button>
         <button class="usage-tab" data-tab="astro" role="tab" aria-selected="false">Astro</button>
         <button class="usage-tab" data-tab="mdx" role="tab" aria-selected="false">MDX</button>
       </div>
 
-      <div class="usage-panel active" data-panel="vanilla">
+      <div class="usage-panel active" data-panel="scene">
         <div class="usage-install">
-          <code class="usage-cmd">npm i @markdy/core @markdy/renderer-dom</code>
-          <button class="copy-btn" title="Copy" aria-label="Copy install command">
+          <code class="usage-cmd">architecture.markdy</code>
+          <button class="copy-btn" title="Copy" aria-label="Copy filename">
             <svg class="copy-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
             <svg class="copy-icon-check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none"><polyline points="20 6 9 17 4 12"></polyline></svg>
           </button>
         </div>
-        <pre class="usage-code"><code set:html={USAGE_VANILLA} /></pre>
+        <pre class="usage-code"><code set:html={USAGE_SCENE} /></pre>
       </div>
 
       <div class="usage-panel" data-panel="cli">
@@ -377,7 +376,7 @@ markdy <span class="u-fn">check-all</span> examples`;
     <div class="section-header">
       <span class="section-tag">Ecosystem</span>
       <h2>Lightweight Packages for Docs-as-Code Animation</h2>
-      <p>Two packages render any scene. Optional packages add Astro, MDX, CLI, LSP, and architecture-diagram vocabulary.</p>
+      <p>Write portable <code>.markdy</code> scenes first. Use packages for validation, docs embeds, editor tooling, previews, and custom playback.</p>
     </div>
     <div class="pkg-grid">
       {PACKAGES.map((pkg) => (
@@ -478,250 +477,264 @@ markdy <span class="u-fn">check-all</span> examples`;
     </div>
   </section>
 
-  <!-- ─── Syntax Reference (Learning Path) ─────────────────────────────── -->
-  <section id="learn" class="syntax-ref" aria-label="Learn MarkdyScript syntax">
+  <!-- ─── How-To Tutorials (Learning Path) ─────────────────────────────── -->
+  <section id="learn" class="syntax-ref" aria-label="Learn MarkdyScript tutorials">
     <div class="section-header">
       <span class="section-tag">Step-by-Step</span>
       <h2>Learn MarkdyScript</h2>
-      <p>Build production architecture diagrams step by step: declare nodes, group them, narrate flows with <code>-></code>/<code>&lt;-</code>/<code>~&gt;</code>, and compose everything in concise <code>beat</code> blocks. Every card is runnable in the playground.</p>
+      <p>Follow a progressive learning path from the smallest runnable scene to production-grade architecture choreography. Each level teaches one practical skill, includes a runnable example, and ends with a task that proves you are ready for the next concept.</p>
     </div>
 
     <div class="ref-grid">
 
-      <!-- Step 1: Cinematic Scene Setup -->
+      <!-- Level 1: Scene shell -->
       <article class="ref-card">
         <div class="ref-card-header">
           <div class="step-badge">1</div>
-          <h3>Scene + Layout</h3>
+          <h3>Level 1: Scene Shell</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Start with a titled scene and semantic theme. Declare nodes by kind, group related services, then reveal them in the first beat.</p>
+        <p class="ref-intro"><strong>Objective:</strong> create the smallest complete MarkdyScript scene: a title, a layout direction, declared nodes, and one reveal beat.</p>
         <div class="ref-code-wrap">
-        <pre><code>scene "Checkout Service" theme=midnight
+        <pre><code>scene "Request Path" theme=midnight
 layout LR
 
-client Web "Web App"
-gateway Gateway "API Gateway"
-service Orders "Order Service"
-database OrderDB "Orders DB"
+browser WebApp
+service ApiServer
 
-group nodes: Web Gateway Orders OrderDB
-
-beat layout:
+beat reveal:
   show $nodes stagger=60ms</code></pre>
         <script type="text/plain" class="ref-code-data">
-scene "Checkout Service" theme=midnight
+scene "Request Path" theme=midnight
 layout LR
 
-client Web "Web App"
-gateway Gateway "API Gateway"
-service Orders "Order Service"
-database OrderDB "Orders DB"
+browser WebApp
+service ApiServer
 
-group nodes: Web Gateway Orders OrderDB
-
-beat layout:
+beat reveal:
   show $nodes stagger=60ms
         </script>
         </div>
         <table>
-          <thead><tr><th>Property</th><th>Default</th><th>Description</th></tr></thead>
+          <thead><tr><th>Step</th><th>Action</th><th>Why it matters</th></tr></thead>
           <tbody>
-            <tr><td><code>theme</code></td><td><code>midnight</code></td><td>Semantic palette — <code>midnight</code> or <code>paper</code></td></tr>
-            <tr><td><code>layout</code></td><td><code>LR</code></td><td>Auto-layout direction — <code>LR</code>, <code>TB</code>, <code>RL</code>, <code>BT</code></td></tr>
-            <tr><td><code>beat</code></td><td>—</td><td>Named narrative block with indented cues</td></tr>
-            <tr><td><code>bg</code></td><td><code>white</code></td><td>Dark backgrounds (<code>#07111f</code>) make node accents pop</td></tr>
-            <tr><td><code>group</code></td><td><i>—</i></td><td>Name a set of nodes to reveal or animate together with <code>stagger</code></td></tr>
+            <tr><td>1</td><td>Add <code>scene</code></td><td>Names the diagram and picks the semantic palette.</td></tr>
+            <tr><td>2</td><td>Add <code>layout LR</code></td><td>Lets Markdy place nodes left-to-right without coordinates.</td></tr>
+            <tr><td>3</td><td>Declare every node</td><td>Flow lines can only reference ids that already exist.</td></tr>
+            <tr><td>4</td><td>Add a <code>beat</code></td><td>Beats are the timeline sections that contain animation cues.</td></tr>
           </tbody>
         </table>
+        <p><strong>Ready task:</strong> Add <code>database Postgres</code> to the scene. If <code>show $nodes</code> reveals all three nodes, move to Level 2.</p>
       </article>
 
-      <!-- Step 2: Node Kinds -->
+      <!-- Level 2: Semantic nodes -->
       <article class="ref-card">
         <div class="ref-card-header">
           <div class="step-badge">2</div>
-          <h3>Node Kinds</h3>
+          <h3>Level 2: Semantic Nodes</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Every node is declared as <code>&lt;kind&gt; &lt;Id&gt; ["Label"]</code>. The kind sets the node's semantic color and role; the label is optional and defaults to the id.</p>
+        <p class="ref-intro"><strong>Objective:</strong> choose node kinds that explain the architecture, then use readable ids so labels can be generated automatically.</p>
         <div class="ref-code-wrap">
-        <pre><code>client Web "Web App"
-service API "Checkout API"
-database DB "Orders DB"
-queue Events "order.events"</code></pre>
+        <pre><code>user Customer
+browser WebApp
+gateway ApiGateway
+service CheckoutApi
+database OrdersDb
+queue OrderEvents</code></pre>
         <script type="text/plain" class="ref-code-data">
-scene "Node Kinds" theme=midnight
+scene "Checkout Roles" theme=midnight
 layout LR
 
-client Web "Web App"
-service API "Checkout API"
-database DB "Orders DB"
-queue Events "order.events"
+user Customer
+browser WebApp
+gateway ApiGateway
+service CheckoutApi
+database OrdersDb
+queue OrderEvents
 
 beat main:
   show $nodes stagger=80ms
         </script>
         </div>
         <table>
-          <thead><tr><th>Role</th><th>Example kinds</th><th>Use for</th></tr></thead>
+          <thead><tr><th>Kind family</th><th>Common kinds</th><th>Use when you mean</th></tr></thead>
           <tbody>
-            <tr><td>client</td><td><code>client</code>, <code>browser</code>, <code>mobile</code>, <code>user</code></td><td>Entry points and front ends</td></tr>
-            <tr><td>compute</td><td><code>service</code>, <code>api</code>, <code>worker</code>, <code>function</code></td><td>Backends and jobs</td></tr>
-            <tr><td>data</td><td><code>database</code>, <code>cache</code>, <code>bucket</code>, <code>search</code></td><td>Storage and retrieval</td></tr>
-            <tr><td>messaging</td><td><code>queue</code>, <code>topic</code>, <code>stream</code>, <code>broker</code></td><td>Async events and pipelines</td></tr>
+            <tr><td>Client</td><td><code>user</code>, <code>browser</code>, <code>client</code></td><td>Humans, apps, and entry points.</td></tr>
+            <tr><td>Compute</td><td><code>service</code>, <code>api</code>, <code>worker</code></td><td>Code that handles requests or jobs.</td></tr>
+            <tr><td>Data</td><td><code>database</code>, <code>cache</code>, <code>bucket</code></td><td>State, files, and fast lookup layers.</td></tr>
+            <tr><td>Messaging</td><td><code>queue</code>, <code>topic</code>, <code>stream</code></td><td>Async events and background work.</td></tr>
           </tbody>
         </table>
-        <p>Aliases like <code>db</code>, <code>api</code>, <code>lb</code>, and <code>k8s</code> expand to their canonical kinds.</p>
+        <p>Prefer ids like <code>CheckoutApi</code> and <code>OrdersDb</code>. Markdy renders them as <code>Checkout API</code> and <code>Orders DB</code>, so quoted labels are only needed for unusual display text.</p>
+        <p><strong>Ready task:</strong> Add <code>cache RedisCache</code>. If the rendered card has the cache role and a readable label, move to Level 3.</p>
       </article>
 
-      <!-- Step 3: Flow Edges -->
+      <!-- Level 3: Request and event flows -->
       <article class="ref-card">
         <div class="ref-card-header">
           <div class="step-badge">3</div>
-          <h3>Flow Edges</h3>
+          <h3>Level 3: Request Flow</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Connect nodes with four flow operators. Chain hops on one line and add a short <code>"label"</code> after any target. Edges route around other nodes automatically.</p>
+        <p class="ref-intro"><strong>Objective:</strong> describe what happens between nodes using directed flow lines inside a beat. Labels belong after the target they describe.</p>
         <div class="ref-code-wrap">
-        <pre><code>Web -> API "POST /checkout"
-API ~> Events "order.created"
-Web <- API "201 Created"</code></pre>
+        <pre><code>WebApp -> CheckoutApi "POST /checkout"
+CheckoutApi ~> OrderEvents "order.created"
+WebApp <- CheckoutApi "201 Created"</code></pre>
         <script type="text/plain" class="ref-code-data">
 scene "Flow Edges" theme=midnight
 layout LR
 
-client Web "Web App"
-service API "Checkout API"
-queue Events "order.events"
-database DB "Orders DB"
+client WebApp
+service CheckoutApi
+queue OrderEvents
+database OrdersDb
 
 beat flow:
   show $nodes stagger=70ms
-  Web -> API "POST /checkout"
-  API -> DB "persist" & API ~> Events "order.created"
-  Web <- API "201 Created"
+  WebApp -> CheckoutApi "POST /checkout"
+  CheckoutApi -> OrdersDb "persist" & CheckoutApi ~> OrderEvents "order.created"
+  WebApp <- CheckoutApi "201 Created"
         </script>
         </div>
         <table>
-          <thead><tr><th>Operator</th><th>Edge kind</th><th>Rendered as</th></tr></thead>
+          <thead><tr><th>Operator</th><th>Use it for</th><th>Rendered intent</th></tr></thead>
           <tbody>
-            <tr><td><code>-&gt;</code></td><td>request</td><td>Solid directed call</td></tr>
-            <tr><td><code>&lt;-</code></td><td>response</td><td>Dashed return, drawn back to the caller</td></tr>
-            <tr><td><code>~&gt;</code></td><td>event</td><td>Dotted async publish / event</td></tr>
-            <tr><td><code>--</code></td><td>dependency</td><td>Thin structural link</td></tr>
+            <tr><td><code>-&gt;</code></td><td>Calls, writes, reads</td><td>Solid request edge.</td></tr>
+            <tr><td><code>&lt;-</code></td><td>Returns and acknowledgements</td><td>Dashed response edge back to the caller.</td></tr>
+            <tr><td><code>~&gt;</code></td><td>Publishes and async jobs</td><td>Dotted event edge.</td></tr>
+            <tr><td><code>--</code></td><td>Static dependency</td><td>Thin relationship edge.</td></tr>
           </tbody>
         </table>
-        <p>Labels auto-place clear of nodes and each other, so dense scenes stay readable instead of turning into spaghetti.</p>
+        <p>Keep labels short and action-oriented: <code>persist</code>, <code>enqueue</code>, <code>cache hit</code>. Long prose belongs in surrounding docs, not edge labels.</p>
+        <p><strong>Ready task:</strong> Add a <code>RedisCache</code> node and one <code>CheckoutApi -> RedisCache "cache write"</code> edge. If every id is declared and the flow renders, move to Level 4.</p>
       </article>
 
-      <!-- Step 4: Beats & Cues -->
+      <!-- Level 4: Beats and timeline cues -->
       <article class="ref-card">
         <div class="ref-card-header">
           <div class="step-badge">4</div>
-          <h3>Beats &amp; Cues</h3>
+          <h3>Level 4: Beats &amp; Cues</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">A <code>beat</code> groups cues that play in order. Reveal nodes with <code>show</code>, then emphasize with <code>glow</code> and <code>focus</code>. Put <code>&amp;</code> between two cues to run them together.</p>
+        <p class="ref-intro"><strong>Objective:</strong> split a diagram into narrative beats so viewers can follow setup, traffic, async work, and emphasis in sequence.</p>
         <div class="ref-code-wrap">
         <pre><code>beat highlight:
-  glow storage color=#22c55e & focus API zoom=1.1</code></pre>
+  glow data color=#22c55e & focus CheckoutApi zoom=1.1</code></pre>
         <script type="text/plain" class="ref-code-data">
-scene "Beats & Cues" theme=midnight
+scene "Checkout Beats" theme=midnight
 layout LR
 
-client Web
-service API
-database DB
-cache Redis
+browser WebApp
+service CheckoutApi
+database OrdersDb
+cache RedisCache
+queue OrderEvents
 
-group storage: DB Redis
+group data: OrdersDb RedisCache OrderEvents
 
 beat intro:
-  show Web API & show storage stagger=80ms
+  show WebApp CheckoutApi & show data stagger=80ms
 
 beat traffic:
-  Web -> API "request" -> DB "query"
-  API -> Redis "cache"
+  WebApp -> CheckoutApi "POST /checkout" -> OrdersDb "persist"
+  CheckoutApi -> RedisCache "cache write"
+
+beat publish:
+  CheckoutApi ~> OrderEvents "order.created"
 
 beat highlight:
-  glow storage color=#22c55e & focus API zoom=1.1
+  glow data color=#22c55e & focus CheckoutApi zoom=1.1
         </script>
         </div>
         <table>
-          <thead><tr><th>Cue</th><th>Parameters</th><th>What it does</th></tr></thead>
+          <thead><tr><th>Cue</th><th>Use it when</th><th>Common options</th></tr></thead>
           <tbody>
-            <tr><td><code>show</code></td><td>stagger, dur</td><td>Reveals nodes or a group</td></tr>
-            <tr><td><code>hide</code></td><td>dur</td><td>Fades nodes out</td></tr>
-            <tr><td><code>glow</code></td><td>color, strength, dur</td><td>Cinematic emphasis without extra HTML</td></tr>
-            <tr><td><code>focus</code></td><td>zoom, dur</td><td>Pulse-scales a node to draw attention</td></tr>
+            <tr><td><code>show</code></td><td>Introducing nodes or groups.</td><td><code>stagger</code>, <code>dur</code></td></tr>
+            <tr><td><code>glow</code></td><td>Marking the important path.</td><td><code>color</code>, <code>strength</code></td></tr>
+            <tr><td><code>focus</code></td><td>Calling attention to one node.</td><td><code>zoom</code>, <code>dur</code></td></tr>
+            <tr><td><code>&amp;</code></td><td>Running two cues together.</td><td>Place it between cues on one line.</td></tr>
           </tbody>
         </table>
-        <p>Cues without an explicit <code>show</code> fall back to revealing every node at the start.</p>
+        <p>Name beats after the story moment: <code>intro</code>, <code>traffic</code>, <code>publish</code>, <code>finish</code>. This makes generated scenes easier for people and LLMs to revise.</p>
+        <p><strong>Ready task:</strong> Add a <code>finish</code> beat that glows <code>CheckoutApi</code> and <code>OrdersDb</code> together. If the story still reads in order, move to Level 5.</p>
       </article>
 
-      <!-- Step 5: Groups -->
+      <!-- Level 5: Groups and subsystem targets -->
       <article class="ref-card">
         <div class="ref-card-header">
           <div class="step-badge">5</div>
-          <h3>Groups</h3>
+          <h3>Level 5: Subsystem Groups</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Name a set of nodes with <code>group</code>, then target them all at once in any cue. Perfect for revealing a storage tier or glowing a whole subsystem together.</p>
+        <p class="ref-intro"><strong>Objective:</strong> organize real systems into named tiers, then target each tier with one cue instead of repeating node ids everywhere.</p>
         <div class="ref-code-wrap">
-        <pre><code>group storage: DB Redis
+        <pre><code>group ingress: WebApp ApiGateway
+group data: RedisCache OrdersDb
 
-beat highlight:
-  glow storage color=#22c55e</code></pre>
+beat layout:
+  show ingress & show data stagger=70ms</code></pre>
         <script type="text/plain" class="ref-code-data">
-scene "Groups" theme=midnight
+scene "Grouped Checkout" theme=midnight
 layout LR
 
-service API
-database DB
-cache Redis
-queue Events
+browser WebApp
+gateway ApiGateway
+service CheckoutApi
+cache RedisCache
+database OrdersDb
+queue OrderEvents
+monitor Metrics
 
-group storage: DB Redis
+group ingress: WebApp ApiGateway
+group app: CheckoutApi
+group data: RedisCache OrdersDb
+group ops: Metrics
 
-beat reveal:
-  show API Events & show storage stagger=80ms
+beat layout:
+  show ingress stagger=50ms & show app stagger=50ms & show data stagger=50ms & show ops stagger=50ms
 
 beat traffic:
-  API -> DB "write" & API -> Redis "cache"
+  WebApp -> ApiGateway "POST /checkout" -> CheckoutApi
+  CheckoutApi -> RedisCache "cache write" & CheckoutApi -> OrdersDb "persist"
+  CheckoutApi -- Metrics "request metrics"
 
 beat highlight:
-  glow storage color=#22c55e
+  glow data color=#22c55e & focus Metrics
         </script>
         </div>
         <table>
-          <thead><tr><th>Form</th><th>Meaning</th></tr></thead>
+          <thead><tr><th>Pattern</th><th>Why it scales</th></tr></thead>
           <tbody>
-            <tr><td><code>group name: A B C</code></td><td>Declares a group of node ids</td></tr>
-            <tr><td><code>show name</code></td><td>Targets every member of the group</td></tr>
-            <tr><td><code>$nodes</code></td><td>Built-in selector for every node in the scene</td></tr>
+            <tr><td><code>group ingress: ...</code></td><td>Names an architectural tier.</td></tr>
+            <tr><td><code>show ingress</code></td><td>Reveals the whole tier without repeating ids.</td></tr>
+            <tr><td><code>glow data</code></td><td>Highlights all related stateful components at once.</td></tr>
           </tbody>
         </table>
+        <p>Groups are especially useful in AI-generated diagrams because they give the model reusable targets and reduce typo-prone repeated node lists.</p>
+        <p><strong>Ready task:</strong> Add an <code>async</code> group with a queue and worker, reveal it in <code>layout</code>, and send one <code>~&gt;</code> event into it. Then move to Level 6.</p>
       </article>
 
-      <!-- Step 6: Patterns -->
+      <!-- Level 6: Reusable patterns -->
       <article class="ref-card">
         <div class="ref-card-header">
           <div class="step-badge">6</div>
-          <h3>Patterns</h3>
+          <h3>Level 6: Reusable Patterns</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Define a reusable flow once with <code>pattern</code>, then expand it anywhere with <code>use</code>. Parameters (<code>$name</code>) are substituted at the call site — great for repeated request/response pairs.</p>
+        <p class="ref-intro"><strong>Objective:</strong> remove repeated flow choreography by defining a pattern once and applying it to different node pairs.</p>
         <div class="ref-code-wrap">
         <pre><code>pattern lookup(client, store):
   $client -> $store "lookup"
   $client <- $store "result"</code></pre>
         <script type="text/plain" class="ref-code-data">
-scene "Patterns" theme=midnight
+scene "Lookup Pattern" theme=midnight
 layout LR
 
-service API
-database DB
-cache Redis
+service CheckoutApi
+cache RedisCache
+database OrdersDb
 
 pattern lookup(client, store):
   $client -> $store "lookup"
@@ -729,90 +742,147 @@ pattern lookup(client, store):
 
 beat main:
   show $nodes stagger=80ms
-  use lookup(API, Redis)
-  use lookup(API, DB)
+  use lookup(CheckoutApi, RedisCache)
+  use lookup(CheckoutApi, OrdersDb)
         </script>
         </div>
         <table>
-          <thead><tr><th>Form</th><th>Meaning</th></tr></thead>
+          <thead><tr><th>Part</th><th>What to write</th><th>What happens</th></tr></thead>
           <tbody>
-            <tr><td><code>pattern name(a, b):</code></td><td>Declares a reusable cue template</td></tr>
-            <tr><td><code>$a</code></td><td>A parameter placeholder, replaced on <code>use</code></td></tr>
-            <tr><td><code>use name(API, DB)</code></td><td>Expands the pattern with positional args</td></tr>
+            <tr><td>Definition</td><td><code>pattern lookup(client, store):</code></td><td>Declares reusable cue lines.</td></tr>
+            <tr><td>Placeholder</td><td><code>$client</code>, <code>$store</code></td><td>Marks values to substitute later.</td></tr>
+            <tr><td>Call site</td><td><code>use lookup(Api, Db)</code></td><td>Expands the pattern with concrete ids.</td></tr>
           </tbody>
         </table>
+        <p>Patterns should be small and meaningful. If the repeated action has a name people use in architecture reviews, it is a good pattern candidate.</p>
+        <p><strong>Ready task:</strong> Add a second pattern called <code>publish(app, queue)</code> with one <code>~&gt;</code> event edge, then use it from <code>CheckoutApi</code> to the declared <code>OrderEvents</code> queue. Then move to Level 7.</p>
       </article>
 
-      <!-- Step 7: Styles -->
+      <!-- Level 7: Styling and emphasis -->
       <article class="ref-card">
         <div class="ref-card-header">
           <div class="step-badge">7</div>
-          <h3>Styles</h3>
+          <h3>Level 7: Styling &amp; Emphasis</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Override a node's look with a named <code>style</code>. Attach it with <code>style=name</code> to highlight a primary, a hot path, or a deprecated component.</p>
+        <p class="ref-intro"><strong>Objective:</strong> tune visual meaning without changing the architecture: choose a theme, set direction, and style the path the viewer should remember.</p>
         <div class="ref-code-wrap">
         <pre><code>style hot = fill=#f59e0b
 
-database Primary "Primary DB" style=hot</code></pre>
+service CheckoutApi style=hot</code></pre>
         <script type="text/plain" class="ref-code-data">
-scene "Styles" theme=midnight
-layout LR
+scene "Styled Hot Path" theme=paper
+layout TB
 
 style hot = fill=#f59e0b
 
-service API
-database Primary "Primary DB" style=hot
-database Replica "Read Replica"
+browser WebApp
+gateway ApiGateway
+service CheckoutApi style=hot
+database OrdersDb
+queue OrderEvents
 
 beat main:
   show $nodes stagger=80ms
-  API -> Primary "write"
-  API -> Replica "read"
+  WebApp -> ApiGateway "POST /checkout" -> CheckoutApi
+  CheckoutApi -> OrdersDb "persist"
+  CheckoutApi ~> OrderEvents "order.created"
+
+beat finish:
+  glow CheckoutApi color=#f59e0b & focus OrdersDb
         </script>
         </div>
         <table>
-          <thead><tr><th>Form</th><th>Meaning</th></tr></thead>
+          <thead><tr><th>Control</th><th>Use it for</th><th>Example</th></tr></thead>
           <tbody>
-            <tr><td><code>style name = k=v</code></td><td>Declares a reusable style with key/value props</td></tr>
-            <tr><td><code>&lt;kind&gt; Id style=name</code></td><td>Applies the style to a node</td></tr>
+            <tr><td><code>theme</code></td><td>Overall palette.</td><td><code>midnight</code>, <code>paper</code></td></tr>
+            <tr><td><code>layout</code></td><td>Scene reading direction.</td><td><code>LR</code>, <code>TB</code></td></tr>
+            <tr><td><code>style</code></td><td>Persistent node styling.</td><td><code>style hot = fill=#f59e0b</code></td></tr>
+            <tr><td><code>glow</code></td><td>Timeline emphasis.</td><td><code>glow CheckoutApi</code></td></tr>
           </tbody>
         </table>
+        <p>Use styles sparingly. One persistent highlight plus one final glow usually reads cleaner than styling every node.</p>
+        <p><strong>Ready task:</strong> Switch the scene between <code>paper</code>/<code>midnight</code> and <code>TB</code>/<code>LR</code>. If the story still reads clearly in both layouts, move to Level 8.</p>
       </article>
 
-      <!-- Step 8: Themes & Direction -->
+      <!-- Level 8: Production composition -->
       <article class="ref-card">
         <div class="ref-card-header">
           <div class="step-badge">8</div>
-          <h3>Themes &amp; Direction</h3>
+          <h3>Level 8: Production Scene</h3>
           <button class="apply-ref-btn" title="Try in Playground" aria-label="Try this example in the playground" onclick="window.applyRefCode && window.applyRefCode(this.closest('.ref-card').querySelector('.ref-code-data').textContent.trim())"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg></button>
         </div>
-        <p class="ref-intro">Pick a semantic <code>theme</code> and a <code>layout</code> direction. Themes set consistent colors per node role; direction controls how auto-layout flows the ranks.</p>
+        <p class="ref-intro"><strong>Objective:</strong> combine semantic nodes, groups, beats, flows, patterns, and emphasis into a real architecture explainer that can survive review.</p>
         <div class="ref-code-wrap">
-        <pre><code>scene "Pipeline" theme=paper
-layout TB</code></pre>
+        <pre><code>scene "URL Shortener Production Flow" theme=midnight width=1280 height=760
+layout LR
+
+group ingress: Visitor WebClient ApiGateway
+group app: UrlShortener RedirectService
+group data: HotUrlCache UrlMappingDb</code></pre>
         <script type="text/plain" class="ref-code-data">
-scene "Themes & Direction" theme=paper
-layout TB
+scene "URL Shortener Production Flow" theme=midnight width=1280 height=760
+layout LR
 
-client User
-service API
-queue Jobs
-worker Worker
+style hot = fill=#22c55e
 
-beat main:
-  show $nodes stagger=80ms
-  User -> API "request"
-  API ~> Jobs "enqueue" -> Worker "process"
+user Visitor
+browser WebClient
+gateway ApiGateway
+service UrlShortener style=hot
+service RedirectService
+cache HotUrlCache
+database UrlMappingDb
+queue AnalyticsEvents
+worker AnalyticsWorker
+monitor Metrics
+
+group ingress: Visitor WebClient ApiGateway
+group app: UrlShortener RedirectService
+group data: HotUrlCache UrlMappingDb
+group async: AnalyticsEvents AnalyticsWorker Metrics
+
+pattern resolve(app, store):
+  $app -> $store "lookup"
+  $app <- $store "result"
+
+beat layout:
+  show ingress stagger=40ms & show app stagger=40ms & show data stagger=40ms & show async stagger=40ms
+
+beat create:
+  WebClient -> ApiGateway "POST /shorten"
+  ApiGateway -> UrlShortener "validate"
+  UrlShortener -> UrlMappingDb "store slug" & UrlShortener ~> HotUrlCache "warm cache"
+  WebClient <- UrlShortener "short.ly/a7"
+
+beat redirect:
+  Visitor -> WebClient "open link"
+  WebClient -> ApiGateway "GET /a7"
+  ApiGateway -> RedirectService "resolve"
+  use resolve(RedirectService, HotUrlCache)
+  RedirectService -> UrlMappingDb "fallback"
+  WebClient <- RedirectService "301 redirect"
+
+beat telemetry:
+  RedirectService ~> AnalyticsEvents "click event"
+  AnalyticsEvents ~> AnalyticsWorker "process"
+  AnalyticsWorker -- Metrics "publish metrics"
+
+beat finish:
+  glow app color=#22c55e & glow data color=#38bdf8
         </script>
         </div>
         <table>
-          <thead><tr><th>Setting</th><th>Values</th><th>Description</th></tr></thead>
+          <thead><tr><th>Production habit</th><th>Why it matters</th></tr></thead>
           <tbody>
-            <tr><td><code>theme</code></td><td><code>midnight</code>, <code>paper</code></td><td>Dark or light semantic palette</td></tr>
-            <tr><td><code>layout</code></td><td><code>LR</code>, <code>RL</code>, <code>TB</code>, <code>BT</code></td><td>Auto-layout flow direction</td></tr>
+            <tr><td>Declare nodes first</td><td>Makes every later flow, group, and cue easy to validate.</td></tr>
+            <tr><td>Group by subsystem</td><td>Lets readers see ingress, app, data, and async tiers before traffic starts.</td></tr>
+            <tr><td>Use beats as story chapters</td><td>Keeps create, redirect, telemetry, and finish concerns separate.</td></tr>
+            <tr><td>End with emphasis</td><td>Confirms the main path and persistent state after the animation completes.</td></tr>
           </tbody>
         </table>
+        <p>When prompting an LLM, ask for this same order: scene metadata, nodes, groups, patterns, beats, then validation against declared ids.</p>
+        <p><strong>Final task:</strong> Build a scene for one real system with at least eight nodes, three groups, four beats, one request, one response, one async event, one pattern, and one final glow. If it validates and a teammate can explain the architecture from the animation, you are ready for independent use.</p>
       </article>
 
     </div>


### PR DESCRIPTION
## Summary
- add compact semantic SVG icons for renderer node cards while preserving accessible metadata
- clean example ids and improve generated labels for architecture terms
- refactor homepage learning content into progressive MarkdyScript how-to tutorials
- update release notes and docs for scene-first authoring

## Validation
- pnpm run build
- pnpm run lint
- pnpm run test
- pnpm run verify:examples
- parsed 8 homepage tutorial snippets with @markdy/core