### PR TITLE
feat: add camera framing and playground workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Dedicated playground page** — Added `/playground/`, a spacious browser workspace for learning and testing MarkdyScript with curated examples moved outside the main work area, adjustable editor/preview split panes, CodeMirror editing, diagnostics, beat jumping, timeline scrubbing, playback speed controls, snippet insertion, and shareable scene URLs.
+- **Playground SEO article** — Added `/blog/markdy-playground/`, a search-focused guide for learning, testing, validating, and sharing animated architecture diagrams in the browser.
+- **Camera framing cues** — Added `frame` cues for guiding attention through large architecture diagrams. Authors can frame nodes, groups, or `frame $nodes` to reset smoothly back to the full diagram for loop-friendly scenes.
+- **Beat captions** — Optional beat labels such as `beat trace "Follow the request":` now render as timed caption pills over the scene, making architecture walkthroughs easier to follow without extra overlay code.
+- **Reference diagnostics** — The parser now warns about unresolved flow endpoints, cue targets, group members, and named styles, giving AI-generated MarkdyScript faster and more actionable validation feedback.
+
+### Changed
+- **More expressive storytelling examples** — Refreshed the URL shortener showcase and beats/groups tutorial example with camera framing, captions, and full-diagram reset cues while keeping the homepage example set curated.
+- **Styled node rendering** — Named node styles now affect rendered cards (`fill`, `stroke`, `text`, and `accent`) while preserving the premium gradient treatment for custom fills.
+- **Example quality gate** — `verify:examples` now treats warnings as failures so shipped examples stay parse-clean, diagnostic-clean, and safe for users or LLMs to copy.
+
+### Fixed
+- **Focus zoom parameter** — `focus ... zoom=` now controls the rendered pulse scale instead of always using the same hard-coded emphasis.
+- **Formatter round-tripping** — `markdy fmt` now preserves non-style node props such as `icon=`, `image=`, and `logo=` instead of dropping them.
+- **Cue property parsing** — Cues with multiple properties, such as `frame API zoom=1.2 dur=500ms`, now parse every property instead of only the first one.
+
 ## [0.8.5] — 2026-08-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <a href="https://markdy.com"><b>✨ Try the Interactive Playground</b></a>
+  <a href="https://markdy.com/playground/"><b>✨ Try the Interactive Playground</b></a>
 </p>
 
 <p align="center">
@@ -35,8 +35,9 @@ browser Client
 service API
 database DB
 
-beat main:
+beat main "Trace the request":
   show $nodes
+  frame Client API zoom=1.12
   Client -> API "GET /items" -> DB "query"
   Client <- API "200 OK"
 ```
@@ -50,7 +51,7 @@ beat main:
 | **Diagram-native DSL** | Declare nodes, `group`s, and `beat`s; the engine handles layout, routing, timing, and rendering |
 | **Auto-layout + routing** | Rank-based layout and orthogonal edge routing are built in — no coordinates required |
 | **Flow operators** | `->` request, `<-` response, `~>` event, `--` dependency, each with its own edge style |
-| **Beats + cues** | Sequence reveals with `beat` blocks and `show`/`hide`/`glow`/`focus` cues; run cues together with `&` |
+| **Beats + cues** | Sequence reveals with `beat` blocks, captions, and `show`/`hide`/`glow`/`focus`/`frame` cues; run cues together with `&` |
 | **Semantic node cards** | Kind-aware SVG glyphs for browsers, services, gateways, queues, workers, databases, storage, CDN, security, platform, and more |
 | **Patterns, styles, groups** | Reusable `pattern name(...)` + `use`, per-node `style`, and `group` fan-out with `stagger` |
 | **Semantic themes** | `midnight` (dark) and `paper` (light) — consistent colors per node role and edge kind |
@@ -141,7 +142,7 @@ npm i -g @markdy/cli
   <img src="website/public/images/markdy-output-preview.webp" alt="Markdy output preview" width="1100" />
 </p>
 
-The homepage playground mirrors this workflow: choose a shipped `.markdy` scene, edit syntax-highlighted MarkdyScript, and watch the embedded architecture preview update in the browser.
+The dedicated playground mirrors this workflow: choose a shipped `.markdy` scene, edit syntax-highlighted MarkdyScript, resize the editor/preview split, and watch the embedded architecture preview update in the browser.
 
 To preview a full scene result locally, run:
 
@@ -270,6 +271,7 @@ Cues live inside a `beat` and are scheduled in order; put `&` between two cues t
 | `hide` | Fade nodes out | `dur` |
 | `glow` | Emphasize with a colored glow | `color`, `strength`, `dur` |
 | `focus` | Pulse-scale to draw attention | `zoom`, `dur` |
+| `frame` | Move the scene camera to nodes or groups | `zoom`, `dur` |
 | `use` | Expand a `pattern` | pattern args |
 
 Selectors: `$nodes` targets every node; a group name targets its members. Themes: `midnight` (dark, default) and `paper` (light).

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -9,6 +9,7 @@ MarkdyScript 0.8 is **diagram-native**: you declare nodes, groups, and beats, an
 - Prefer concise beats over manual positioning — layout is automatic.
 - Default theme is `paper`; default layout direction is `LR`.
 - Keep flow labels short (≤ ~28 chars) so they stay readable.
+- Use beat labels and `frame` when the scene should guide attention through a large diagram.
 
 ## Minimal example
 
@@ -85,11 +86,14 @@ database Primary "Primary DB" style=hot
 Cues inside a beat are scheduled in order. Beats run one after another.
 
 ```markdy
-beat checkout:
+beat checkout "Process checkout":
   show $nodes stagger=80ms
+  frame API DB zoom=1.15
   Client -> API "POST /order" -> DB "persist"
   glow API color=#22c55e & focus DB zoom=1.1
 ```
+
+The optional quoted beat label is rendered as a caption during the beat.
 
 ### Flow operators
 
@@ -120,6 +124,7 @@ Cues live inside a beat. Put `&` between two cues to run them in parallel.
 | `hide` | `dur` | Fade nodes out |
 | `glow` | `color`, `strength`, `dur` | Colored emphasis glow |
 | `focus` | `zoom`, `dur` | Pulse-scale a node to draw attention |
+| `frame` | `zoom`, `dur` | Move the scene camera to a node or group (`frame $nodes` resets to the whole diagram) |
 | `use` | pattern args | Expand a `pattern` |
 
 Selectors: `$nodes` targets every node; a group name targets its members.
@@ -180,20 +185,23 @@ database UrlDB "URL Mapping DB"
 
 group storage: Redis UrlDB
 
-beat layout:
+beat layout "Reveal the architecture":
   show $nodes stagger=60ms
 
-beat create:
+beat create "Create a short URL":
+  frame Browser Gateway Shortener zoom=1.12
   Browser -> Gateway "POST /shorten" -> Shortener
   Shortener -> UrlDB "store slug" & Shortener ~> Redis "warm cache"
   Browser <- Shortener "short.ly/a7"
 
-beat redirect:
+beat redirect "Resolve a short link":
+  frame Visitor Browser Gateway Shortener zoom=1.08
   Visitor -> Browser "open link" -> Gateway "GET /a7" -> Shortener
   Shortener -> Redis "cache lookup"
   Browser <- Shortener "301 redirect"
 
-beat finish:
+beat finish "Storage keeps it fast":
+  frame storage zoom=1.18
   glow storage color=#22c55e
 ```
 
@@ -238,6 +246,8 @@ beat main:
 - Declare every node id before referencing it in a flow, group, or cue.
 - Let layout infer positions; use `layout LR|RL|TB|BT` instead of coordinates.
 - Keep repeated paths in `pattern` blocks and call them with `use`.
+- Use `frame groupName zoom=...` for attention, not manual coordinates or extra duplicate nodes.
+- Reset the camera with `frame $nodes` before a loop so the diagram returns to the full view.
 
 ## Validation checklist
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,15 +144,17 @@ Frame loop:
 
 | Source | DOM Output |
 |---|---|
-| Node (`nodes.ts`) | `<div class="markdy-node markdy-scene-node" data-node data-role>` with a role-aware SVG glyph (or an `image=`/`logo=` `<img>`) plus a label |
+| Node (`nodes.ts`) | `<div class="markdy-node markdy-scene-node" data-node data-role>` with a role-aware SVG glyph (or an `image=`/`logo=` `<img>`) plus a label; named `style` props map to CSS variables such as node fill, stroke, text, and accent |
 | Scene title | `<div>` positioned at the top-left of the scene |
 | Edge (`edges.ts`) | `<svg>` overlay with a routed `<path>`, arrowhead marker, animated dash reveal, a moving packet dot, and an optional rounded label pill |
+| Camera layer | A transformed content layer used by `frame` cues to guide attention without changing compiled node coordinates |
+| Beat captions | Optional beat labels rendered as timed caption pills over the scene |
 
 Node kind → semantic role → colour + icon mapping lives in `@markdy/core` (`system-vocabulary.ts`) and in `nodes.ts` (`iconKeyForNode`).
 
 #### Cue Animations
 
-Beat cues (`show`, `hide`, `glow`, `focus`) and flow edges compile to WAAPI keyframes in `buildCueAnimations` (`edges.ts`). `show`/`hide` fade and lift nodes (with optional `stagger`); `glow`/`focus` add emphasis; the flow operators (`->`, `<-`, `~>`, `--`) drive the edge dash + packet reveal.
+Beat cues (`show`, `hide`, `glow`, `focus`, `frame`) and flow edges compile to WAAPI keyframes in `buildCueAnimations` (`edges.ts`). `show`/`hide` fade and lift nodes (with optional `stagger`); `glow`/`focus` add emphasis; `frame` transforms the camera layer around selected nodes or groups; the flow operators (`->`, `<-`, `~>`, `--`) drive the edge dash + packet reveal. Optional beat labels compile to caption animations in the renderer.
 
 #### Animation Pre-Initialisation
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -26,7 +26,7 @@ Node labels are optional. IDs like `ApiServer` and `OrdersDb` render as readable
 
 ## 2. Preview and validate it
 
-For a quick visual pass, open the homepage playground and start from one of the shipped architecture examples. It uses the same `.markdy` files from `examples/showcase/`, shows syntax-highlighted MarkdyScript, and links back to each source file.
+For a quick visual pass, open the dedicated playground at <https://markdy.com/playground/> and start from one of the shipped architecture examples. It uses the same `.markdy` files from `examples/showcase/`, shows syntax-highlighted MarkdyScript, offers an adjustable editor/preview split, and links back to each source file.
 
 ```sh
 npm i -D @markdy/cli
@@ -79,4 +79,3 @@ Use `docs/AGENT.md` as the full grammar reference and ask for MarkdyScript direc
 Example prompt:
 
 > Use the Markdy agent guide. Create a 1280x720 animated architecture diagram for a URL shortener. Include short-link creation, redirect resolution, Redis cache lookup, database fallback, beats, labeled flow edges (`->`, `<-`, `~>`), and a final `glow` on the hot path.
-

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -31,12 +31,15 @@ group storage: Redis UrlDB
 ### Beats and flows
 
 ```markdy
-beat create:
+beat create "Create a short URL":
   show $nodes stagger=60ms
+  frame app zoom=1.15 dur=600ms
   Browser -> API "POST /shorten" -> Shortener
   Shortener ~> Redis "warm cache"
   Browser <- Shortener "short.ly/a7"
 ```
+
+The optional beat label is rendered as a short caption during that beat.
 
 Flow operators:
 - `->` — request
@@ -61,3 +64,16 @@ beat main:
 - `midnight` — dark developer canvas
 - `blueprint` — technical blueprint canvas
 - `graphite` — restrained dark graphite canvas
+
+### Cues
+
+| Cue | Description | Parameters |
+|---|---|---|
+| `show` | Reveal nodes or groups | `stagger`, `dur` |
+| `hide` | Fade nodes out | `dur` |
+| `glow` | Emphasize with a colored glow | `color`, `strength`, `dur` |
+| `focus` | Pulse-scale nodes to draw attention | `zoom`, `dur` |
+| `frame` | Move the scene camera to a node or group | `zoom`, `dur` |
+| `use` | Expand a pattern | pattern args |
+
+`frame $nodes` returns the camera to the full diagram — a good final cue for looping scenes.

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -24,12 +24,12 @@ A step-by-step guide to creating animated architecture diagrams, system explaine
 
 Use this path when learning Markdy for animated diagrams, architecture visualization, and AI-generated technical explainers:
 
-1. **Quick Start** — try a shipped scene in the homepage playground, then install `@markdy/core` and `@markdy/renderer-dom` when you are ready to embed.
+1. **Quick Start** — try a shipped scene in the dedicated playground at <https://markdy.com/playground/>, then install `@markdy/core` and `@markdy/renderer-dom` when you are ready to embed.
 2. **Core Concepts** — understand scenes, node kinds, flow operators, beats, and cues.
 3. **Basic Examples** — declare nodes, connect them, and reveal them beat by beat.
 4. **Real-World Examples** — study URL shorteners, OAuth, Kubernetes, video pipelines, and timeline services in `examples/showcase/`.
 5. **Best Practices** — keep labels short, avoid overlap, use semantic node kinds, and split long flows across beats.
-6. **Advanced Features** — use `group`, `pattern`/`use`, and `style`.
+6. **Advanced Features** — use `group`, `pattern`/`use`, `style`, beat captions, and `frame`.
 7. **AI Agent Workflow** — give `docs/AGENT.md` to the model, ask for MarkdyScript, lint it, and iterate on layout/timing.
 8. **Production Use Cases** — embed in Astro/MDX docs, launch posts, onboarding, architecture reviews, and internal platform docs.
 
@@ -39,11 +39,11 @@ Quick install:
 npm i @markdy/core @markdy/renderer-dom
 ```
 
-The playground is the fastest feedback loop: it keeps the editor syntax-highlighted, links each curated example to its source `.markdy` file, and scales the embedded preview for narrow or landscape viewports.
+The playground is the fastest feedback loop: it keeps the editor syntax-highlighted, links each curated example to its source `.markdy` file, gives the editor and preview an adjustable split, and surfaces parse warnings before you copy a scene into your project.
 
 AI prompt starter:
 
-> Use `docs/AGENT.md`. Create a 1280x720 animated architecture diagram for an OAuth login flow. Use semantic node kinds, beats, labeled flow edges (`->`, `<-`, `~>`), short labels, and a final `focus` on the token exchange.
+> Use `docs/AGENT.md`. Create a 1280x720 animated architecture diagram for an OAuth login flow. Use semantic node kinds, labeled beats, `frame` cues for attention, flow edges (`->`, `<-`, `~>`), short labels, and a final `focus` on the token exchange.
 
 ---
 
@@ -97,7 +97,8 @@ Edges route automatically around other nodes, and labels place themselves clear 
 A `beat` groups cues that play in order; beats run one after another. Besides `show`, cues let you direct attention.
 
 ```markdy
-beat highlight:
+beat highlight "Inspect the database path":
+  frame API DB zoom=1.15
   glow API color=#22c55e
   focus DB zoom=1.1
 ```
@@ -108,6 +109,7 @@ beat highlight:
 | `hide` | `dur` | Fade nodes out |
 | `glow` | `color`, `strength`, `dur` | Colored emphasis glow |
 | `focus` | `zoom`, `dur` | Pulse-scale a node |
+| `frame` | `zoom`, `dur` | Move the camera to nodes or a group (`frame $nodes` resets the view) |
 
 Run two cues together by putting `&` between them:
 
@@ -166,6 +168,7 @@ database Replica "Read Replica"
 
 - Themes: `paper` (light, default), `midnight` (dark), `blueprint`, and `graphite`.
 - Directions: `LR` (default), `RL`, `TB`, `BT`.
+- Named styles currently support visual props such as `fill`, `stroke`, `text`, and `accent`.
 
 ---
 
@@ -184,20 +187,23 @@ database UrlDB "URL Mapping DB"
 
 group storage: Redis UrlDB
 
-beat layout:
+beat layout "Reveal the architecture":
   show $nodes stagger=60ms
 
-beat create:
+beat create "Create a short URL":
+  frame Browser Gateway Shortener zoom=1.12
   Browser -> Gateway "POST /shorten" -> Shortener
   Shortener -> UrlDB "store slug" & Shortener ~> Redis "warm cache"
   Browser <- Shortener "short.ly/a7"
 
-beat redirect:
+beat redirect "Resolve the link":
+  frame Visitor Browser Gateway Shortener zoom=1.08
   Visitor -> Browser "open link" -> Gateway "GET /a7" -> Shortener
   Shortener -> Redis "cache lookup"
   Browser <- Shortener "301 redirect"
 
-beat finish:
+beat finish "Storage keeps it fast":
+  frame storage zoom=1.18
   glow storage color=#22c55e
 ```
 
@@ -234,6 +240,7 @@ beat finish:
 | `show` / `hide` | reveal / hide nodes |
 | `glow` | colored emphasis |
 | `focus` | attention pulse |
+| `frame` | camera move to nodes/groups |
 | `use` | expand a pattern |
 | `&` | run two cues in parallel |
 

--- a/docs/marketing/TUTORIAL_DRAFT_DEVTO.md
+++ b/docs/marketing/TUTORIAL_DRAFT_DEVTO.md
@@ -79,7 +79,7 @@ I wrote an [AGENT.md instructions file](https://github.com/HoangYell/markdy-com/
 
 ### Give it a spin
 If you build interactive docs or just want to play around with bringing code scenes to life:
-1. Try the online playground: [markdy.com](https://markdy.com)
+1. Try the online playground: [markdy.com/playground](https://markdy.com/playground/)
 2. You can check out the engine's source code on GitHub: [HoangYell/markdy-com](https://github.com/HoangYell/markdy-com)
 
 Would love to hear what developers think of the syntax design!

--- a/docs/marketing/X_THREAD_DRAFT.md
+++ b/docs/marketing/X_THREAD_DRAFT.md
@@ -46,5 +46,5 @@ Instead of dragging nodes around in Figma or coding keyframes by hand, you can j
 Try the interactive playground and see the source code here! 
 Star it if you hate writing UI animation code yourself 🌟
 
-**Playground:** [https://markdy.com](https://markdy.com)
+**Playground:** [https://markdy.com/playground/](https://markdy.com/playground/)
 **GitHub:** [https://github.com/HoangYell/markdy-com](https://github.com/HoangYell/markdy-com)

--- a/examples/03-beats-and-groups.markdy
+++ b/examples/03-beats-and-groups.markdy
@@ -11,12 +11,15 @@ database OrdersDb
 
 group storage: Redis OrdersDb
 
-beat intro:
-  show Visitor Gateway Orders & show storage stagger=80ms
+beat intro "Reveal the checkout system":
+  show Visitor ApiGateway OrderService & show storage stagger=80ms
 
-beat checkout:
+beat checkout "Follow the checkout request":
+  frame ApiGateway OrderService storage zoom=1.12 dur=500ms
   Visitor -> ApiGateway "POST /order" -> OrderService
   OrderService -> Redis "cache write" & OrderService -> OrdersDb "persist"
 
-beat highlight:
+beat highlight "Storage records the order":
+  frame storage zoom=1.18 dur=600ms
   glow storage color=#22c55e & focus OrderService zoom=1.1
+  frame $nodes dur=500ms

--- a/examples/showcase/url-shortener-architecture.markdy
+++ b/examples/showcase/url-shortener-architecture.markdy
@@ -13,16 +13,18 @@ group storage: HotUrlCache UrlMappingDb
 group ingress: Visitor WebClient ApiGateway
 group app: UrlShortener RedirectService
 
-beat layout:
+beat layout "Reveal the moving parts":
   show ingress stagger=45ms & show app stagger=45ms & show storage stagger=45ms
 
-beat create:
+beat create "Create a short URL":
+  frame WebClient ApiGateway UrlShortener UrlMappingDb zoom=1.1 dur=500ms
   WebClient -> ApiGateway "POST /shorten"
   ApiGateway -> UrlShortener "forward request"
   UrlShortener -> UrlMappingDb "store slug" & UrlShortener ~> HotUrlCache "warm cache"
   WebClient <- UrlShortener "short.ly/a7"
 
-beat redirect:
+beat redirect "Resolve a short link":
+  frame ingress app zoom=1.06 dur=500ms
   Visitor -> WebClient "open short link"
   WebClient -> ApiGateway "GET /a7"
   ApiGateway -> RedirectService "resolve slug"
@@ -31,5 +33,7 @@ beat redirect:
   RedirectService -> UrlMappingDb "miss fallback"
   WebClient <- RedirectService "301 redirect"
 
-beat finish:
+beat finish "Storage keeps redirects fast":
+  frame storage zoom=1.18 dur=600ms
   glow storage color=#22c55e & glow UrlMappingDb color=#38bdf8
+  frame $nodes dur=600ms

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -59,6 +59,10 @@ function formatNode(node: NodeDecl): string {
   let line = `${node.kind} ${node.id}`;
   if (node.label !== node.id && node.label) line += ` ${JSON.stringify(node.label)}`;
   if (node.style) line += ` style=${node.style}`;
+  const extraProps = Object.entries(node.props).filter(([key]) => key !== "style");
+  for (const [key, value] of extraProps) {
+    line += ` ${key}=${formatValue(value)}`;
+  }
   return line;
 }
 
@@ -118,6 +122,12 @@ function formatCue(cue: Cue): string {
   }
   if (cue.kind === "focus") {
     let line = `focus ${cue.targets.join(" ")}`;
+    if (cue.zoom !== undefined) line += ` zoom=${cue.zoom}`;
+    if (cue.dur !== undefined) line += ` dur=${cue.dur}s`;
+    return line;
+  }
+  if (cue.kind === "frame") {
+    let line = `frame ${cue.targets.join(" ")}`;
     if (cue.zoom !== undefined) line += ` zoom=${cue.zoom}`;
     if (cue.dur !== undefined) line += ` dur=${cue.dur}s`;
     return line;

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -72,4 +72,18 @@ describe("markdy cli", () => {
     const second = await runCli(["fmt", file, "--check"], new BufferIo(), { openBrowser: async () => {} });
     expect(second.exitCode).toBe(0);
   });
+
+  it("formats frame cues and preserves node props", async () => {
+    const dir = await tempDir();
+    const file = join(dir, "story.markdy");
+    await writeFile(file, `scene "Story" theme=paper\nservice API icon=server\nbeat main "Inspect API":\n  frame API zoom=1.2 dur=500ms\n`, "utf8");
+    const io = new BufferIo();
+
+    const result = await runCli(["fmt", file, "--write"], io, { openBrowser: async () => {} });
+    expect(result.exitCode).toBe(0);
+    const formatted = await readFile(file, "utf8");
+    expect(formatted).toContain("service API icon=server");
+    expect(formatted).toContain("beat main \"Inspect API\":");
+    expect(formatted).toContain("frame API zoom=1.2 dur=0.5s");
+  });
 });

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,6 +5,7 @@
     "types": ["node"],
     "baseUrl": ".",
     "paths": {
+      "@markdy/core": ["../core/src/index.ts"],
       "@markdy/stdlib-systems": ["../stdlib-systems/src/index.ts"]
     }
   },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,11 @@
+import { resolve } from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@markdy/core": resolve(__dirname, "../core/src/index.ts"),
+      "@markdy/stdlib-systems": resolve(__dirname, "../stdlib-systems/src/index.ts"),
+    },
+  },
+});

--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -63,6 +63,7 @@ export type Cue =
   | { kind: "hide"; targets: string[]; dur?: number; line: number }
   | { kind: "glow"; targets: string[]; color?: string; strength?: number; dur?: number; line: number }
   | { kind: "focus"; targets: string[]; zoom?: number; dur?: number; line: number }
+  | { kind: "frame"; targets: string[]; zoom?: number; dur?: number; line: number }
   | { kind: "use"; pattern: string; args: Record<string, string>; line: number }
   | { kind: "parallel"; cues: Cue[]; line: number };
 
@@ -149,7 +150,7 @@ export type RoutedEdge = {
 export type TimedCue = {
   start: number;
   duration: number;
-  kind: "show" | "hide" | "flow" | "glow" | "focus";
+  kind: "show" | "hide" | "flow" | "glow" | "focus" | "frame";
   targets: string[];
   edgeId?: string;
   segments?: FlowSegment[];

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -14,6 +14,7 @@ const DEFAULTS = {
   flow: 0.55,
   glow: 0.45,
   focus: 0.6,
+  frame: 0.7,
   beatGap: 0.14,
   cueGap: 0.08,
   stagger: 0.06,
@@ -234,7 +235,7 @@ function scheduleBeats(ast: DiagramAST, edges: RoutedEdge[]): { cues: TimedCue[]
         return;
       }
 
-      if (cue.kind !== "show" && cue.kind !== "hide" && cue.kind !== "glow" && cue.kind !== "focus") return;
+      if (cue.kind !== "show" && cue.kind !== "hide" && cue.kind !== "glow" && cue.kind !== "focus" && cue.kind !== "frame") return;
 
       const targets = resolveTargets(cue.targets, ast, Object.fromEntries(Object.entries(ast.groups).map(([k, g]) => [k, g.members])));
 
@@ -247,7 +248,7 @@ function scheduleBeats(ast: DiagramAST, edges: RoutedEdge[]): { cues: TimedCue[]
           stagger: cue.kind === "show" ? (cue.stagger ?? DEFAULTS.stagger) : undefined,
           color: cue.kind === "glow" ? cue.color : undefined,
           strength: cue.kind === "glow" ? cue.strength : undefined,
-          zoom: cue.kind === "focus" ? cue.zoom : undefined,
+          zoom: cue.kind === "focus" || cue.kind === "frame" ? cue.zoom : undefined,
         },
         beat: beat.name,
       });

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -23,7 +23,7 @@ import {
   EDGE_OPERATORS,
   humanizeId,
   NODE_KINDS,
-  nodeRole,
+  RESERVED_SELECTORS,
   SCENE_KEYS,
 } from "./registry.js";
 import { compilePlan } from "./compiler.js";
@@ -147,8 +147,7 @@ function splitTargetLabel(token: string, lineNo: number): { node: string; label?
 
 function parseCueLine(line: string, lineNo: number): Cue {
   const trimmed = line.trim();
-  const propsMatch = trimmed.match(/\s+(?:dur|stagger|color|strength|zoom|after)=\S+/);
-  const props = propsMatch ? parseProps(propsMatch[0]) : {};
+  const props = parseProps(trimmed);
 
   if (trimmed.includes(" & ")) {
     const parts = trimmed.split(/\s+&\s+/);
@@ -206,6 +205,19 @@ function parseCueLine(line: string, lineNo: number): Cue {
     };
   }
 
+  if (keyword === "frame") {
+    const targetRaw = rest.join(" ").split(/\s+(?:zoom|dur)=/)[0];
+    const targets = splitTargets(targetRaw);
+    if (targets.length === 0) throw new ParseError(`expected frame target`, lineNo);
+    return {
+      kind: "frame",
+      targets,
+      zoom: typeof props.zoom === "number" ? props.zoom : undefined,
+      dur: typeof props.dur === "number" ? props.dur : undefined,
+      line: lineNo,
+    };
+  }
+
   if (keyword === "use") {
     const call = rest.join(" ");
     const m = call.match(/^(\w+)\s*\((.*)\)\s*$/);
@@ -257,10 +269,9 @@ function substitutePatternCue(cue: Cue, params: string[], args: Record<string, s
   params.forEach((p, i) => {
     if (resolvedArgs[p] === undefined && positional[i]) resolvedArgs[p] = positional[i];
   });
-  delete resolvedArgs.__pos_0;
-  delete resolvedArgs.__pos_1;
-  delete resolvedArgs.__pos_2;
-  delete resolvedArgs.__pos_3;
+  for (const key of Object.keys(resolvedArgs)) {
+    if (key.startsWith("__pos_")) delete resolvedArgs[key];
+  }
 
   const sub = (s: string) => {
     for (const p of params) {
@@ -280,7 +291,7 @@ function substitutePatternCue(cue: Cue, params: string[], args: Record<string, s
       })),
     };
   }
-  if (cue.kind === "show" || cue.kind === "hide" || cue.kind === "glow" || cue.kind === "focus") {
+  if (cue.kind === "show" || cue.kind === "hide" || cue.kind === "glow" || cue.kind === "focus" || cue.kind === "frame") {
     return { ...cue, targets: cue.targets.map(sub) };
   }
   if (cue.kind === "parallel") {
@@ -311,6 +322,75 @@ function readIndentedBody(blocks: Block[], startIdx: number, parentIndent: numbe
     i++;
   }
   return { body, nextIdx: i };
+}
+
+function pushWarning(diagnostics: Diagnostic[], seen: Set<string>, line: number, message: string): void {
+  const key = `${line}:${message}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  diagnostics.push({ severity: "warning", message, line });
+}
+
+function visitCues(cues: Cue[], visit: (cue: Cue) => void): void {
+  for (const cue of cues) {
+    visit(cue);
+    if (cue.kind === "parallel") visitCues(cue.cues, visit);
+  }
+}
+
+function validateReferences(ast: DiagramAST): void {
+  const seen = new Set<string>();
+  const hasNode = (id: string) => Boolean(ast.nodes[id]);
+  const hasGroup = (id: string) => Boolean(ast.groups[id]);
+  const isKnownTarget = (target: string) => {
+    if (RESERVED_SELECTORS.has(target)) return true;
+    if (target.startsWith("$")) return hasGroup(target.slice(1));
+    return hasNode(target) || hasGroup(target);
+  };
+
+  for (const group of Object.values(ast.groups)) {
+    for (const member of group.members) {
+      if (!hasNode(member)) {
+        pushWarning(ast.diagnostics, seen, group.line, `group '${group.id}' references unknown node '${member}'`);
+      }
+    }
+  }
+
+  for (const node of Object.values(ast.nodes)) {
+    if (node.style && !ast.styles[node.style]) {
+      pushWarning(ast.diagnostics, seen, node.line, `node '${node.id}' references unknown style '${node.style}'`);
+    }
+  }
+
+  const validateFlowEndpoint = (line: number, endpoint: string) => {
+    if (!hasNode(endpoint)) {
+      pushWarning(ast.diagnostics, seen, line, `flow references unknown node '${endpoint}'`);
+    }
+  };
+
+  for (const edge of ast.edges) {
+    validateFlowEndpoint(edge.line, edge.from);
+    validateFlowEndpoint(edge.line, edge.to);
+  }
+
+  for (const beat of ast.beats) {
+    visitCues(beat.cues, (cue) => {
+      if (cue.kind === "flow") {
+        for (const segment of cue.segments) {
+          validateFlowEndpoint(cue.line, segment.from);
+          validateFlowEndpoint(cue.line, segment.to);
+        }
+        return;
+      }
+      if (cue.kind === "show" || cue.kind === "hide" || cue.kind === "glow" || cue.kind === "focus" || cue.kind === "frame") {
+        for (const target of cue.targets) {
+          if (!isKnownTarget(target)) {
+            pushWarning(ast.diagnostics, seen, cue.line, `${cue.kind} references unknown target '${target}'`);
+          }
+        }
+      }
+    });
+  }
 }
 
 export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
@@ -469,11 +549,6 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
     throw new ParseError(`unexpected statement`, lineNo);
   }
 
-  const errors = diagnostics.filter((d) => d.severity === "error");
-  if (errors.length) {
-    throw new ParseError(errors[0].message, errors[0].line, errors[0].column);
-  }
-
   const ast: DiagramAST = {
     meta: { ...meta, title: title || undefined },
     styles,
@@ -484,6 +559,13 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
     beats,
     diagnostics,
   };
+
+  validateReferences(ast);
+
+  const errors = ast.diagnostics.filter((d) => d.severity === "error");
+  if (errors.length) {
+    throw new ParseError(errors[0].message, errors[0].line, errors[0].column);
+  }
 
   if (!opts.parseOnly && Object.keys(nodes).length === 0 && beats.length === 0) {
     // Allow empty parse for tooling

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -11,7 +11,7 @@ export const EDGE_OPERATORS: Record<string, "request" | "response" | "event" | "
 
 export const RESERVED_SELECTORS = new Set(["$title", "$nodes", "$edges"]);
 
-export const BEAT_CUE_KEYWORDS = new Set(["show", "hide", "glow", "focus", "use"]);
+export const BEAT_CUE_KEYWORDS = new Set(["show", "hide", "glow", "focus", "frame", "use"]);
 
 export const SCENE_KEYS = new Set(["width", "height", "fps", "theme", "duration", "direction"]);
 

--- a/packages/core/tests/compiler.test.ts
+++ b/packages/core/tests/compiler.test.ts
@@ -34,4 +34,24 @@ beat two:
     expect(plan.beats.map((b) => b.name)).toEqual(["one", "two"]);
     expect(plan.cues.some((c) => c.kind === "flow")).toBe(true);
   });
+
+  it("resolves frame cue targets and keeps zoom parameters", () => {
+    const source = `
+scene theme=paper
+service API
+database DB
+group backend: API DB
+
+beat inspect:
+  frame backend zoom=1.3 dur=1s
+`;
+    const plan = compile(parse(source));
+    const frame = plan.cues.find((cue) => cue.kind === "frame");
+    expect(frame).toMatchObject({
+      kind: "frame",
+      targets: ["API", "DB"],
+      duration: 1,
+      params: { zoom: 1.3 },
+    });
+  });
 });

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -110,4 +110,68 @@ cdn CdnEdge
       for (const id of cue.targets) expect(nodeIds.has(id)).toBe(true);
     }
   });
+
+  it("parses frame cues and beat labels for camera-guided storytelling", () => {
+    const ast = parse(`
+scene "Framed Story" theme=paper
+layout LR
+service API
+database DB
+group backend: API DB
+
+beat inspect "Zoom into backend":
+  frame backend zoom=1.25 dur=500ms
+`);
+    expect(ast.beats[0].label).toBe("Zoom into backend");
+    expect(ast.beats[0].cues[0]).toMatchObject({
+      kind: "frame",
+      targets: ["backend"],
+      zoom: 1.25,
+      dur: 0.5,
+    });
+  });
+
+  it("emits warnings for unresolved references without accepting invalid syntax", () => {
+    const ast = parse(`
+scene "Diagnostics" theme=paper
+style hot = fill=#f59e0b
+service API style=missing
+group backend: API Worker
+
+beat main:
+  show Worker
+  frame backend
+  API -> Missing "call"
+`);
+
+    expect(ast.diagnostics.map((d) => d.message)).toEqual(expect.arrayContaining([
+      "node 'API' references unknown style 'missing'",
+      "group 'backend' references unknown node 'Worker'",
+      "show references unknown target 'Worker'",
+      "flow references unknown node 'Missing'",
+    ]));
+  });
+
+  it("substitutes all positional pattern arguments without leaking internal keys", () => {
+    const ast = parse(`
+scene "Pattern Args" theme=paper
+service A
+service B
+service C
+service D
+service E
+
+pattern five(a, b, c, d, e):
+  $a -> $b "one"
+  $c -> $d "two"
+  frame $e
+
+beat main:
+  use five(A, B, C, D, E)
+`);
+    const cues = ast.beats[0].cues;
+    expect(cues[0]).toMatchObject({ kind: "flow", segments: [{ from: "A", to: "B" }] });
+    expect(cues[1]).toMatchObject({ kind: "flow", segments: [{ from: "C", to: "D" }] });
+    expect(cues[2]).toMatchObject({ kind: "frame", targets: ["E"] });
+  });
 });

--- a/packages/markdy-language-server/src/index.ts
+++ b/packages/markdy-language-server/src/index.ts
@@ -38,6 +38,7 @@ const KEYWORDS = [
   "hide",
   "glow",
   "focus",
+  "frame",
   ...BEAT_CUE_KEYWORDS,
   ...NODE_KINDS,
 ];
@@ -131,6 +132,7 @@ connection.onHover((params) => {
   if (!doc) return null;
   const line = doc.getText().split(/\r?\n/)[params.position.line]?.trim() ?? "";
   if (line.startsWith("beat ")) return { contents: { kind: "markdown", value: "Named narrative beat with indented cues." } };
+  if (line.startsWith("frame ")) return { contents: { kind: "markdown", value: "Camera cue that frames one or more nodes or groups." } };
   if (line.includes("->")) return { contents: { kind: "markdown", value: "Request/call flow edge." } };
   return null;
 });

--- a/packages/renderer-dom/src/diagram.ts
+++ b/packages/renderer-dom/src/diagram.ts
@@ -43,6 +43,44 @@ export interface Diagram {
   destroy(): void;
 }
 
+export function createBeatCaptionLayer(doc: Document, beats: BeatRange[]): HTMLElement {
+  const layer = doc.createElement("div");
+  layer.className = "markdy-beat-caption-layer";
+  for (const beat of beats) {
+    if (!beat.label) continue;
+    const caption = doc.createElement("div");
+    caption.className = "markdy-beat-caption";
+    caption.textContent = beat.label;
+    caption.dataset.beat = beat.name;
+    layer.appendChild(caption);
+  }
+  return layer;
+}
+
+function buildBeatCaptionAnimations(beats: BeatRange[], layer: HTMLElement): Animation[] {
+  const anims: Animation[] = [];
+  const captions = Array.from(layer.querySelectorAll<HTMLElement>(".markdy-beat-caption"));
+  for (const beat of beats) {
+    if (!beat.label) continue;
+    const caption = captions.find((item) => item.dataset.beat === beat.name);
+    if (!caption) continue;
+    const startMs = beat.start * 1000;
+    const durMs = Math.max((beat.end - beat.start) * 1000, 650);
+    anims.push(
+      caption.animate(
+        [
+          { opacity: 0, transform: "translateY(8px)" },
+          { opacity: 1, transform: "translateY(0)", offset: 0.16 },
+          { opacity: 1, transform: "translateY(0)", offset: 0.82 },
+          { opacity: 0, transform: "translateY(-4px)" },
+        ],
+        { duration: durMs, delay: startMs, fill: "forwards", easing: "ease-out" },
+      ),
+    );
+  }
+  return anims;
+}
+
 export function createDiagram(opts: DiagramOptions): Diagram {
   const {
     container,
@@ -150,12 +188,19 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   Object.assign(sceneContent.style, { position: "absolute", inset: "0" });
   scene.appendChild(sceneContent);
 
+  const titleEl = createTitleEl(plan.title);
+  sceneContent.appendChild(titleEl);
+
+  const cameraLayer = document.createElement("div");
+  cameraLayer.className = "markdy-camera-layer";
+  sceneContent.appendChild(cameraLayer);
+
   const nodeLayer = document.createElement("div");
   nodeLayer.className = "markdy-scene-node-layer";
-  sceneContent.appendChild(nodeLayer);
+  cameraLayer.appendChild(nodeLayer);
 
-  const titleEl = createTitleEl(plan.title);
-  nodeLayer.appendChild(titleEl);
+  const captionLayer = createBeatCaptionLayer(document, plan.beats);
+  sceneContent.appendChild(captionLayer);
 
   const nodeEls = new Map<string, HTMLElement>();
   for (const node of plan.nodes) {
@@ -172,10 +217,13 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   const resizeObserver = new ResizeObserver(scaleScene);
   resizeObserver.observe(viewport);
 
-  const allAnims = buildCueAnimations(plan.cues, nodeEls, plan.nodes, plan.theme, sceneContent, titleEl, {
-    width: plan.meta.width,
-    height: plan.meta.height,
-  });
+  const allAnims = [
+    ...buildCueAnimations(plan.cues, nodeEls, plan.nodes, plan.theme, cameraLayer, titleEl, {
+      width: plan.meta.width,
+      height: plan.meta.height,
+    }),
+    ...buildBeatCaptionAnimations(plan.beats, captionLayer),
+  ];
   for (const anim of allAnims) {
     anim.pause();
     anim.currentTime = 0;

--- a/packages/renderer-dom/src/edges.ts
+++ b/packages/renderer-dom/src/edges.ts
@@ -11,6 +11,11 @@ const EDGE_STYLES: Record<EdgeKind, { dash: string; marker: string }> = {
   dependency: { dash: "4 4", marker: "none" },
 };
 
+const INITIAL_CAMERA_TRANSFORM = "translate(0px, 0px) scale(1)";
+const DEFAULT_FRAME_ZOOM = 1.18;
+const MAX_FRAME_ZOOM = 1.75;
+const FRAME_PADDING = 88;
+
 /** Drops consecutive duplicate points so path data and dot offsets stay valid. */
 function dedupePoints(points: Point[]): Point[] {
   const out: Point[] = [];
@@ -215,6 +220,37 @@ export function animateEdgeReveal(runtime: EdgeRuntime, startMs: number, durMs: 
   return anims;
 }
 
+export function computeFrameTransform(
+  targetIds: string[],
+  nodes: PositionedNode[],
+  bounds: { width: number; height: number },
+  requestedZoom = DEFAULT_FRAME_ZOOM,
+): string | undefined {
+  const targets = new Set(targetIds);
+  const selected = nodes.filter((node) => targets.has(node.id));
+  if (selected.length === 0) return undefined;
+
+  // Framing every node means "show the whole diagram", so reset the camera.
+  const framesEveryNode = selected.length === nodes.length && nodes.every((node) => targets.has(node.id));
+  if (framesEveryNode) return INITIAL_CAMERA_TRANSFORM;
+
+  const zoom = Number.isFinite(requestedZoom) && requestedZoom > 0 ? requestedZoom : DEFAULT_FRAME_ZOOM;
+
+  const minX = Math.min(...selected.map((node) => node.x));
+  const minY = Math.min(...selected.map((node) => node.y));
+  const maxX = Math.max(...selected.map((node) => node.x + node.width));
+  const maxY = Math.max(...selected.map((node) => node.y + node.height));
+  const frameWidth = Math.max(1, maxX - minX + FRAME_PADDING * 2);
+  const frameHeight = Math.max(1, maxY - minY + FRAME_PADDING * 2);
+  const fitScale = Math.min(bounds.width / frameWidth, bounds.height / frameHeight);
+  const scale = Math.max(1, Math.min(zoom, fitScale, MAX_FRAME_ZOOM));
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+  const tx = Math.round((bounds.width / 2 - centerX * scale) * 10) / 10;
+  const ty = Math.round((bounds.height / 2 - centerY * scale) * 10) / 10;
+  return `translate(${tx}px, ${ty}px) scale(${Math.round(scale * 1000) / 1000})`;
+}
+
 export function buildCueAnimations(
   cues: TimedCue[],
   nodeEls: Map<string, HTMLElement>,
@@ -232,6 +268,9 @@ export function buildCueAnimations(
   const laneByPair = new Map<string, number>();
   const svg = ensureEdgeLayer(scene);
   const sceneId = `md-${Math.random().toString(36).slice(2, 8)}`;
+  let cameraTransform = scene.style.transform || INITIAL_CAMERA_TRANSFORM;
+  scene.style.transformOrigin = "0 0";
+  scene.style.transform = cameraTransform;
 
   // Title reveal at start
   anims.push(
@@ -286,17 +325,36 @@ export function buildCueAnimations(
     }
 
     if (cue.kind === "focus") {
+      const zoom = typeof cue.params.zoom === "number" && cue.params.zoom > 0 ? cue.params.zoom : 1.03;
       for (const id of cue.targets) {
         const el = nodeEls.get(id);
         if (!el) continue;
         el.dataset.focused = "1";
         anims.push(
           el.animate(
-            [{ transform: "scale(1)" }, { transform: "scale(1.03)" }, { transform: "scale(1)" }],
+            [{ transform: "scale(1)" }, { transform: `scale(${zoom})` }, { transform: "scale(1)" }],
             { duration: durMs, delay: startMs, fill: "forwards" },
           ),
         );
       }
+      continue;
+    }
+
+    if (cue.kind === "frame") {
+      const nextTransform = computeFrameTransform(
+        cue.targets,
+        nodes,
+        bounds,
+        typeof cue.params.zoom === "number" ? cue.params.zoom : DEFAULT_FRAME_ZOOM,
+      );
+      if (!nextTransform) continue;
+      anims.push(
+        scene.animate(
+          [{ transform: cameraTransform }, { transform: nextTransform }],
+          { duration: durMs, delay: startMs, fill: "forwards", easing: "ease-in-out" },
+        ),
+      );
+      cameraTransform = nextTransform;
       continue;
     }
 

--- a/packages/renderer-dom/src/nodes.ts
+++ b/packages/renderer-dom/src/nodes.ts
@@ -124,6 +124,7 @@ export function ensureNodeStyles(doc: Document): void {
   left: 44px;
   top: 26px;
   right: 44px;
+  z-index: 130;
   font-size: 32px;
   font-weight: 700;
   line-height: 1.2;
@@ -367,6 +368,28 @@ function createNodeMediaEl(doc: Document, node: PositionedNode, assets?: Record<
   return wrap;
 }
 
+function applyDeclaredNodeStyle(el: HTMLElement, style?: Record<string, unknown>): void {
+  if (!style) return;
+  const fill = typeof style.fill === "string" ? style.fill : undefined;
+  const surface = typeof style.surface === "string" ? style.surface : fill;
+  // Derive a slightly lighter top tone so custom fills keep the premium card gradient.
+  const surfaceRaised =
+    typeof style.surfaceRaised === "string"
+      ? style.surfaceRaised
+      : surface
+        ? `color-mix(in srgb, ${surface} 90%, #ffffff 10%)`
+        : undefined;
+  const stroke = typeof style.stroke === "string" ? style.stroke : undefined;
+  const text = typeof style.text === "string" ? style.text : undefined;
+  const accent = typeof style.accent === "string" ? style.accent : undefined;
+
+  if (surface) el.style.setProperty("--md-node-surface", surface);
+  if (surfaceRaised) el.style.setProperty("--md-node-surface-raised", surfaceRaised);
+  if (stroke) el.style.setProperty("--md-hairline", stroke);
+  if (text) el.style.color = text;
+  if (accent) el.style.setProperty("--md-role-color", accent);
+}
+
 export function createNodeEl(node: PositionedNode, theme: ThemeTokens, assets?: Record<string, string>): HTMLElement {
   const el = document.createElement("div");
   el.className = "markdy-node markdy-scene-node";
@@ -378,6 +401,7 @@ export function createNodeEl(node: PositionedNode, theme: ThemeTokens, assets?: 
   el.style.setProperty("--md-node-h", `${node.height}px`);
   const roleColor = theme.roles[node.role] ?? theme.accent;
   el.style.setProperty("--md-role-color", roleColor);
+  applyDeclaredNodeStyle(el, node.style);
   const typeText = node.kind.replace(/_/g, " ");
   el.dataset.kind = node.kind;
   el.dataset.icon = iconKeyForNode(node);

--- a/packages/renderer-dom/src/theme.ts
+++ b/packages/renderer-dom/src/theme.ts
@@ -35,10 +35,45 @@ export function ensureSceneStyles(doc: Document): void {
   opacity: 0.62;
 }
 .markdy-scene-content { z-index: 2; }
+.markdy-camera-layer {
+  position: absolute;
+  inset: 0;
+  overflow: visible;
+  transform-origin: 0 0;
+  transform: translate(0px, 0px) scale(1);
+}
 .markdy-scene-node-layer {
   position: absolute;
   inset: 0;
   overflow: visible;
+}
+.markdy-beat-caption-layer {
+  position: absolute;
+  left: 44px;
+  right: 44px;
+  bottom: 30px;
+  z-index: 140;
+  display: grid;
+  justify-items: center;
+  align-items: end;
+  pointer-events: none;
+}
+.markdy-beat-caption {
+  grid-area: 1 / 1;
+  max-width: min(720px, 100%);
+  padding: 10px 16px;
+  border-radius: 999px;
+  color: var(--md-text);
+  background: color-mix(in srgb, var(--md-surface-raised) 88%, transparent);
+  backdrop-filter: blur(6px);
+  box-shadow:
+    0 14px 32px -20px var(--md-shadow, rgba(2, 6, 23, 0.55)),
+    inset 0 0 0 1px var(--md-hairline, color-mix(in srgb, var(--md-border) 50%, transparent));
+  font: 600 14px/1.3 Inter, ui-sans-serif, system-ui, sans-serif;
+  text-align: center;
+  opacity: 0;
+  transform: translateY(8px);
+  will-change: opacity, transform;
 }
 `;
   doc.head.appendChild(style);

--- a/packages/renderer-dom/tests/diagram.smoke.test.ts
+++ b/packages/renderer-dom/tests/diagram.smoke.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDiagram } from "../src/index";
+
+/**
+ * jsdom does not implement the Web Animations API or ResizeObserver, so we
+ * stub just enough to assemble a real diagram and drive its timeline. This
+ * guards the createDiagram wiring (camera layer, captions, cue animations)
+ * that the pure unit tests do not touch.
+ */
+const animateStub = vi.fn(function animate(this: Element) {
+  return {
+    currentTime: 0,
+    pause() {},
+    play() {},
+    cancel() {},
+  } as unknown as Animation;
+});
+
+const SCENE = `
+scene "Smoke" theme=paper
+layout LR
+
+browser Web
+service API
+database DB
+
+group backend: API DB
+
+beat intro "Reveal the system":
+  show $nodes stagger=60ms
+
+beat trace "Follow the request":
+  frame backend zoom=1.2 dur=400ms
+  Web -> API "GET /items" -> DB "query"
+  Web <- API "200 OK"
+
+beat finish:
+  glow backend color=#22c55e
+  frame $nodes dur=400ms
+`;
+
+describe("createDiagram integration", () => {
+  beforeEach(() => {
+    (Element.prototype as unknown as { animate: typeof animateStub }).animate = animateStub;
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    animateStub.mockClear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete (Element.prototype as unknown as { animate?: unknown }).animate;
+    delete (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver;
+  });
+
+  it("assembles a camera layer, node cards, and beat captions", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const diagram = createDiagram({ container, code: SCENE, autoplay: false, copyright: false });
+
+    expect(container.querySelector(".markdy-camera-layer")).not.toBeNull();
+    expect(container.querySelectorAll(".markdy-node")).toHaveLength(3);
+
+    const captions = container.querySelectorAll(".markdy-beat-caption");
+    expect([...captions].map((c) => c.textContent)).toEqual(["Reveal the system", "Follow the request"]);
+
+    // Nodes live inside the camera layer so frame cues move them together.
+    const camera = container.querySelector(".markdy-camera-layer")!;
+    expect(camera.querySelectorAll(".markdy-node")).toHaveLength(3);
+
+    expect(diagram.duration()).toBeGreaterThan(0);
+    expect(diagram.beats().map((b) => b.name)).toEqual(["intro", "trace", "finish"]);
+    expect(animateStub).toHaveBeenCalled();
+
+    // Seeking through the timeline must not throw with the stubbed animations.
+    expect(() => diagram.seek(diagram.duration() / 2)).not.toThrow();
+    diagram.destroy();
+    expect(container.querySelector(".markdy-scene-root")).toBeNull();
+  });
+});

--- a/packages/renderer-dom/tests/render.extended.test.ts
+++ b/packages/renderer-dom/tests/render.extended.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { parseAndCompile } from "@markdy/core";
+import { computeFrameTransform } from "../src/edges";
+import { createBeatCaptionLayer } from "../src/diagram";
 import { createNodeEl } from "../src/nodes";
 
 const SAMPLE = `
@@ -95,6 +97,27 @@ describe("diagram render plan", () => {
     expect(el.dataset.icon).toBe("database");
   });
 
+  it("applies declared style props to node CSS variables", () => {
+    const theme = { roles: { data: "#22c55e" }, accent: "#38bdf8" } as any;
+    const el = createNodeEl({
+      id: "Primary",
+      kind: "database",
+      role: "data",
+      label: "Primary",
+      x: 0,
+      y: 0,
+      width: 168,
+      height: 72,
+      opacity: 0,
+      style: { fill: "#f59e0b", stroke: "#92400e", text: "#111827", accent: "#ef4444" },
+    }, theme);
+    expect(el.style.getPropertyValue("--md-node-surface")).toBe("#f59e0b");
+    expect(el.style.getPropertyValue("--md-node-surface-raised")).toBe("color-mix(in srgb, #f59e0b 90%, #ffffff 10%)");
+    expect(el.style.getPropertyValue("--md-hairline")).toBe("#92400e");
+    expect(el.style.getPropertyValue("--md-role-color")).toBe("#ef4444");
+    expect(el.style.color).toBe("rgb(17, 24, 39)");
+  });
+
   it("renders an <img> for image= and applies the assets override", () => {
     const theme = { roles: { data: "#22c55e" }, accent: "#38bdf8" } as any;
     const el = createNodeEl({
@@ -133,5 +156,29 @@ describe("diagram render plan", () => {
     const img = el.querySelector<HTMLImageElement>(".markdy-node__icon img");
     expect(img?.getAttribute("src")).toBe("/logos/api.svg");
     expect(el.querySelector(".markdy-node__icon svg")).toBeNull();
+  });
+
+  it("computes deterministic camera transforms for frame cues", () => {
+    const nodes = [
+      { id: "A", kind: "service", role: "compute", label: "A", x: 100, y: 120, width: 168, height: 72, opacity: 1 },
+      { id: "B", kind: "database", role: "data", label: "B", x: 520, y: 340, width: 168, height: 72, opacity: 1 },
+    ];
+
+    expect(computeFrameTransform(["A", "B"], nodes, { width: 1280, height: 720 }, 1)).toBe("translate(0px, 0px) scale(1)");
+    expect(computeFrameTransform(["A", "B"], nodes, { width: 1280, height: 720 }, 1.4)).toBe("translate(0px, 0px) scale(1)");
+    expect(computeFrameTransform(["A"], nodes, { width: 1280, height: 720 }, 1.25)).toBe("translate(410px, 165px) scale(1.25)");
+    expect(computeFrameTransform(["Missing"], nodes, { width: 1280, height: 720 }, 1.25)).toBeUndefined();
+  });
+
+  it("builds beat captions only for labeled beats", () => {
+    const layer = createBeatCaptionLayer(document, [
+      { name: "intro", label: "Reveal the system", start: 0, end: 1 },
+      { name: "silent", start: 1, end: 2 },
+      { name: "finish", label: "Wrap up", start: 2, end: 3 },
+    ]);
+    const captions = layer.querySelectorAll(".markdy-beat-caption");
+    expect(captions).toHaveLength(2);
+    expect([...captions].map((c) => c.textContent)).toEqual(["Reveal the system", "Wrap up"]);
+    expect([...captions].map((c) => (c as HTMLElement).dataset.beat)).toEqual(["intro", "finish"]);
   });
 });

--- a/scripts/verify-examples.ts
+++ b/scripts/verify-examples.ts
@@ -9,6 +9,7 @@ const DIRS = ["examples", "examples/showcase"];
 
 async function verify(): Promise<number> {
   const failures: string[] = [];
+  const warnings: string[] = [];
   let total = 0;
 
   for (const dir of DIRS) {
@@ -21,19 +22,25 @@ async function verify(): Promise<number> {
         const ast = parse(source);
         const errors = ast.diagnostics.filter((d) => d.severity === "error");
         if (errors.length) failures.push(`${dir}/${file}: ${errors.map((e) => e.message).join("; ")}`);
+        for (const w of ast.diagnostics.filter((d) => d.severity === "warning")) {
+          warnings.push(`${dir}/${file}:${w.line} ${w.message}`);
+        }
       } catch (error) {
         failures.push(`${dir}/${file}: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
   }
 
-  if (failures.length) {
-    console.error(`verify-examples: FAIL — ${failures.length} problem(s):`);
-    for (const f of failures) console.error(`  • ${f}`);
+  // Shipped examples are curated: they must parse cleanly with zero warnings so
+  // the reference diagnostics stay meaningful and copy-paste friendly.
+  if (failures.length || warnings.length) {
+    const problems = [...failures, ...warnings];
+    console.error(`verify-examples: FAIL — ${problems.length} problem(s):`);
+    for (const p of problems) console.error(`  • ${p}`);
     return 1;
   }
 
-  console.log(`verify-examples: PASS — ${total} example file(s).`);
+  console.log(`verify-examples: PASS — ${total} example file(s), 0 warnings.`);
   return 0;
 }
 

--- a/website/src/layouts/ArticleLayout.astro
+++ b/website/src/layouts/ArticleLayout.astro
@@ -56,7 +56,7 @@ const {
       <h2>See it animate in your browser</h2>
       <p>Write a diagram in plain text and watch Markdy lay it out, route the edges, and play it back — no signup, no install.</p>
       <div class="article-cta-actions">
-        <a class="art-btn art-btn-primary" href="/#playground">Open the Playground</a>
+        <a class="art-btn art-btn-primary" href="/playground/">Open the Playground</a>
         <a class="art-btn art-btn-secondary" href="/docs/">Read the Docs</a>
         <a class="art-btn art-btn-ghost" href="https://github.com/HoangYell/markdy-com" target="_blank" rel="noopener noreferrer">Star on GitHub</a>
       </div>

--- a/website/src/pages/blog/ai-generated-architecture-diagrams.astro
+++ b/website/src/pages/blog/ai-generated-architecture-diagrams.astro
@@ -86,7 +86,7 @@ beat create:
 beat finish:
   glow storage color=#22c55e</code></pre>
   <p>
-    Paste it straight into the <a href="/#playground">playground</a> to verify it. If it doesn't parse, hand the
+    Paste it straight into the <a href="/playground/">playground</a> to verify it. If it doesn't parse, hand the
     line-numbered error back to the model and ask it to fix that line — the loop is fast and reliable.
   </p>
 

--- a/website/src/pages/blog/animated-diagrams-as-code.astro
+++ b/website/src/pages/blog/animated-diagrams-as-code.astro
@@ -68,7 +68,7 @@ beat main:
   Web -&gt; API "POST /order" -&gt; DB "persist"
   Web &lt;- API "201 Created"</code></pre>
   <p>
-    That's the whole diagram. Paste it into the <a href="/#playground">interactive playground</a> and it lays out
+    That's the whole diagram. Paste it into the <a href="/playground/">interactive playground</a> and it lays out
     left-to-right, routes the arrows around the boxes, and animates the request/response flow. Because it's plain
     text, a teammate can review the change in a pull request — a one-line diff instead of a re-exported image.
   </p>
@@ -102,7 +102,7 @@ beat main:
 
   <h2>Get started in two minutes</h2>
   <ol>
-    <li>Open the <a href="/#playground">playground</a>, pick a shipped architecture example, and edit the syntax-highlighted scene.</li>
+    <li>Open the <a href="/playground/">playground</a>, pick a shipped architecture example, and edit the syntax-highlighted scene.</li>
     <li>Copy the syntax you need from the <a href="/docs/">docs</a> or the <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">agent guide</a>.</li>
     <li>Drop the <code>.markdy</code> file in your repo and render it with <code>@markdy/renderer-dom</code>, Astro, or MDX.</li>
   </ol>

--- a/website/src/pages/blog/animated-diagrams-astro-mdx.astro
+++ b/website/src/pages/blog/animated-diagrams-astro-mdx.astro
@@ -98,7 +98,7 @@ beat main:
 
   <h2>A tidy docs workflow</h2>
   <ol>
-    <li>Draft the scene in the <a href="/#playground">playground</a> until it looks right.</li>
+    <li>Draft the scene in the <a href="/playground/">playground</a> until it looks right.</li>
     <li>Commit the <code>.markdy</code> source (or inline it) next to the doc.</li>
     <li>Lint diagrams in CI with <code>markdy lint</code> so a broken diagram fails the build.</li>
     <li>Let an <a href="/blog/ai-generated-architecture-diagrams/">AI agent</a> keep them updated as the system changes.</li>

--- a/website/src/pages/blog/animated-sequence-diagrams.astro
+++ b/website/src/pages/blog/animated-sequence-diagrams.astro
@@ -92,7 +92,7 @@ database DB "User DB"</code></pre>
     Because comprehension follows attention. In a talk, a launch post, or onboarding docs, revealing one step at a
     time keeps the reader with you. It's the same <a href="/blog/animated-diagrams-as-code/">diagram-as-code</a>
     workflow — reviewable in PRs, and <a href="/blog/ai-generated-architecture-diagrams/">easy for an AI to draft</a>.
-    Try the login example above in the <a href="/#playground">playground</a>, then read the
+    Try the login example above in the <a href="/playground/">playground</a>, then read the
     <a href="/docs/">docs</a> for the full cue reference.
   </p>
 </ArticleLayout>

--- a/website/src/pages/blog/browser-native-diagram-animation.astro
+++ b/website/src/pages/blog/browser-native-diagram-animation.astro
@@ -81,7 +81,7 @@ diagram.seek(1.2); // scrubbing just works`;
   <pre><code>{diagramExample}</code></pre>
   <p>
     Because playback is a controlled timeline rather than fire-and-forget CSS keyframes, you get reliable seeking and
-    a progress bar for free — the same machinery that powers the <a href="/#playground">playground</a> scrubber.
+    a progress bar for free — the same machinery that powers the <a href="/playground/">playground</a> scrubber.
   </p>
 
   <h2>A GSAP or Framer Motion alternative?</h2>

--- a/website/src/pages/blog/diagram-as-code-guide.astro
+++ b/website/src/pages/blog/diagram-as-code-guide.astro
@@ -94,7 +94,7 @@ beat main:
 
   <h2>How to start</h2>
   <ol>
-    <li>Sketch a scene in the <a href="/#playground">playground</a> — no install.</li>
+    <li>Sketch a scene in the <a href="/playground/">playground</a> — no install.</li>
     <li>Learn the grammar in the <a href="/docs/">docs</a> or the <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">agent guide</a>.</li>
     <li>Commit the <code>.markdy</code> file and render it in your app, <a href="/blog/animated-diagrams-astro-mdx/">Astro, or MDX</a>.</li>
     <li>Lint diagrams in CI with <code>markdy lint</code> so a broken diagram fails the build.</li>

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -11,6 +11,12 @@ const SECTIONS = [
         dek: "What it is, why teams adopt it, the main tools, and where animation fits.",
         tag: "Guide",
       },
+      {
+        slug: "markdy-playground",
+        title: "Markdy Playground: Learn, Test, and Share Animated Diagrams",
+        dek: "Use the dedicated browser workspace to edit MarkdyScript, preview motion, inspect diagnostics, and share scenes.",
+        tag: "Playground",
+      },
     ],
   },
   {
@@ -110,9 +116,9 @@ const blogStructuredData = [
 
 <Layout
   title="Markdy Articles — Animated Diagrams as Code"
-  description="Guides, comparisons, and use cases for animated architecture and system diagrams as code: diagram-as-code, Mermaid alternatives, Kubernetes, system design, AI, and Astro/MDX."
+  description="Guides, comparisons, and use cases for animated architecture and system diagrams as code: the Markdy playground, diagram-as-code, Mermaid alternatives, Kubernetes, system design, AI, and Astro/MDX."
   canonicalURL="https://markdy.com/blog/"
-  keywords="animated diagrams as code, diagram as code, mermaid alternative, markdy vs mermaid, kubernetes architecture diagram, system design diagram, animated sequence diagram, ai generated architecture diagram, astro diagrams, mdx diagrams"
+  keywords="Markdy playground, animated diagram playground, animated diagrams as code, diagram as code, mermaid alternative, markdy vs mermaid, kubernetes architecture diagram, system design diagram, animated sequence diagram, ai generated architecture diagram, astro diagrams, mdx diagrams"
   structuredData={blogStructuredData}
 >
   <main class="hub">
@@ -126,7 +132,7 @@ const blogStructuredData = [
       <h1>Animated diagrams as code — guides &amp; deep dives</h1>
       <p class="hub-dek">
         Practical articles on turning plain text into animated architecture and system diagrams.
-        Start with the <a href="/#playground">interactive playground</a> or the
+        Start with the <a href="/playground/">interactive playground</a> or the
         <a href="/docs/">documentation</a>, then dig into a topic below.
       </p>
     </header>
@@ -150,7 +156,7 @@ const blogStructuredData = [
     ))}
 
     <aside class="hub-cta">
-      <p>New to Markdy? The fastest way in is the <a href="/#playground">live playground</a> — choose a real architecture scene, inspect the source, and watch it animate.</p>
+      <p>New to Markdy? The fastest way in is the <a href="/playground/">dedicated playground</a> — choose a real architecture scene, inspect the source, resize the editor/preview split, and watch it animate.</p>
     </aside>
   </main>
 </Layout>

--- a/website/src/pages/blog/kubernetes-architecture-diagram.astro
+++ b/website/src/pages/blog/kubernetes-architecture-diagram.astro
@@ -92,6 +92,6 @@ beat highlight:
     diagram lives next to the manifests and updates in the same PR — real
     <a href="/blog/animated-diagrams-as-code/">diagrams as code</a>. For a broader systems example, see
     <a href="/blog/system-design-diagrams/">animated system design diagrams</a>, or open this one in the
-    <a href="/#playground">playground</a> and tweak it.
+    <a href="/playground/">playground</a> and tweak it.
   </p>
 </ArticleLayout>

--- a/website/src/pages/blog/markdy-playground.astro
+++ b/website/src/pages/blog/markdy-playground.astro
@@ -1,0 +1,138 @@
+---
+/*
+  SEO BRIEF — product/article page for: "Markdy playground"
+  Target keywords: Markdy playground, animated diagram playground,
+    architecture diagram playground, diagram as code playground,
+    Mermaid alternative playground, MarkdyScript editor
+  Search intent: users who want to try Markdy before installing it, learn the
+    DSL interactively, validate AI-generated scenes, or share runnable examples.
+*/
+import ArticleLayout from "../../layouts/ArticleLayout.astro";
+
+const canonicalURL = "https://markdy.com/blog/markdy-playground/";
+const structuredData = [
+  {
+    "@type": "BlogPosting",
+    "@id": `${canonicalURL}#article`,
+    headline: "Markdy Playground: Learn, Test, and Share Animated Architecture Diagrams",
+    description:
+      "Use the Markdy playground to edit MarkdyScript, preview animated architecture diagrams, jump between beats, inspect diagnostics, and share runnable scenes.",
+    inLanguage: "en",
+    url: canonicalURL,
+    mainEntityOfPage: canonicalURL,
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: [
+      { "@id": "https://markdy.com/#software" },
+      { "@id": "https://markdy.com/playground/#webpage" },
+    ],
+    author: { "@id": "https://markdy.com/#hoang-yell" },
+    publisher: { "@id": "https://markdy.com/#organization" },
+    keywords:
+      "Markdy playground, animated diagram playground, architecture diagram playground, diagram as code playground, MarkdyScript editor",
+  },
+  {
+    "@type": "HowTo",
+    "@id": `${canonicalURL}#howto`,
+    name: "How to use the Markdy playground",
+    step: [
+      { "@type": "HowToStep", name: "Choose an example", text: "Start from a shipped Markdy architecture scene." },
+      { "@type": "HowToStep", name: "Edit MarkdyScript", text: "Use the CodeMirror editor with MarkdyScript highlighting and autocomplete." },
+      { "@type": "HowToStep", name: "Preview and inspect", text: "Watch the animation, jump between beats, scrub the timeline, and fix diagnostics." },
+      { "@type": "HowToStep", name: "Share or copy", text: "Copy the scene source or share a URL with the encoded runnable diagram." },
+    ],
+  },
+];
+---
+
+<ArticleLayout
+  title="Markdy Playground — Learn, Test, and Share Animated Diagrams"
+  description="Use the Markdy playground to edit MarkdyScript, preview animated architecture diagrams, jump between beats, inspect diagnostics, and share runnable scenes."
+  keywords="Markdy playground, animated diagram playground, architecture diagram playground, diagram as code playground, Mermaid alternative playground, MarkdyScript editor"
+  canonicalURL={canonicalURL}
+  headline="Markdy Playground: Learn, Test, and Share Animated Architecture Diagrams"
+  dek="The dedicated Markdy playground is the fastest way to try animated diagrams as code: edit MarkdyScript, preview the motion, inspect diagnostics, and share runnable scenes without installing anything."
+  structuredData={structuredData}
+>
+  <p>
+    The <a href="/playground/">Markdy playground</a> is a browser workspace for learning and testing
+    <strong>animated architecture diagrams as code</strong>. It is built for the practical loop most developers
+    need: start from a real scene, edit the text, watch the animation, fix warnings, and share a link.
+  </p>
+
+  <h2>Why a dedicated playground?</h2>
+  <p>
+    A small homepage demo is useful for a first impression, but serious authoring needs room. The dedicated
+    playground gives the editor and preview the full width of the page, with an adjustable split so you can make
+    the code pane wider while learning syntax or make the preview larger while checking motion and labels.
+  </p>
+
+  <ul>
+    <li><strong>More space to read code.</strong> The MarkdyScript editor is one of the two main panes, not a sidebar.</li>
+    <li><strong>More space to inspect motion.</strong> The animated preview can be expanded by dragging the split.</li>
+    <li><strong>Examples stay nearby.</strong> Curated scenes live in a top strip so they do not steal editor or preview space.</li>
+    <li><strong>Learning snippets are one click away.</strong> Insert common patterns for reveal beats, frame cues, request/response flows, and loop resets.</li>
+  </ul>
+
+  <h2>What you can do in the playground</h2>
+  <p>
+    The playground is not just a static text box. It is a full MarkdyScript feedback loop:
+  </p>
+  <table>
+    <thead><tr><th>Task</th><th>How the playground helps</th></tr></thead>
+    <tbody>
+      <tr><td>Learn the DSL</td><td>Use syntax highlighting, autocomplete, examples, and insertable snippets.</td></tr>
+      <tr><td>Test AI-generated diagrams</td><td>Paste generated MarkdyScript and inspect parse errors or reference warnings.</td></tr>
+      <tr><td>Review animation timing</td><td>Play, pause, restart, scrub the timeline, and jump directly to named beats.</td></tr>
+      <tr><td>Share a scene</td><td>Copy a shareable URL with the scene encoded in the hash.</td></tr>
+    </tbody>
+  </table>
+
+  <h2>A small scene to try</h2>
+  <p>
+    Paste this into the <a href="/playground/">playground</a>. It demonstrates nodes, a group, a labeled beat,
+    a camera <code>frame</code>, a request flow, a response flow, and a clean reset back to the full diagram.
+  </p>
+  <pre><code>scene "Checkout Path" theme=paper
+layout LR
+
+browser Client
+service API
+database OrdersDb
+
+group backend: API OrdersDb
+
+beat reveal "Reveal the system":
+  show $nodes stagger=60ms
+
+beat request "Trace the request":
+  frame backend zoom=1.18 dur=600ms
+  Client -&gt; API "POST /orders" -&gt; OrdersDb "persist"
+  Client &lt;- API "201 Created"
+
+beat reset "Return to overview":
+  frame $nodes dur=600ms</code></pre>
+
+  <h2>Best practices while experimenting</h2>
+  <ol>
+    <li><strong>Keep labels short.</strong> Edge labels are easiest to read when they are specific but compact.</li>
+    <li><strong>Use beat labels.</strong> A beat label becomes a caption that explains what the viewer is seeing.</li>
+    <li><strong>Frame attention.</strong> Use <code>frame groupName</code> to guide the viewer through a complex system.</li>
+    <li><strong>Reset before looping.</strong> Add <code>frame $nodes</code> near the end so the next loop starts from the whole diagram.</li>
+    <li><strong>Fix diagnostics before sharing.</strong> Unknown node or group warnings usually mean a typo in a flow, group, or cue target.</li>
+  </ol>
+
+  <h2>How it fits with docs and local development</h2>
+  <p>
+    Use the playground for fast iteration. Once the scene feels right, copy the source into a <code>.markdy</code>
+    file and validate it with the CLI:
+  </p>
+  <pre><code>pnpm add -D @markdy/cli
+pnpm markdy lint architecture.markdy
+pnpm markdy render architecture.markdy --out architecture.html</code></pre>
+  <p>
+    For deeper syntax details, open the <a href="/docs/">docs</a> or the
+    <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">AI agent guide</a>.
+    For comparisons, read <a href="/blog/markdy-vs-mermaid/">Markdy vs Mermaid</a> and
+    <a href="/blog/diagram-as-code-guide/">Diagram as Code: The Complete Guide</a>.
+  </p>
+</ArticleLayout>

--- a/website/src/pages/blog/markdy-vs-mermaid.astro
+++ b/website/src/pages/blog/markdy-vs-mermaid.astro
@@ -96,6 +96,6 @@ beat main:
     If you're here because Mermaid feels too static, read <a href="/blog/mermaid-alternative/">the best Mermaid
     alternative for animated diagrams</a>, or see how the authoring model works in
     <a href="/blog/animated-diagrams-as-code/">animated diagrams as code</a>. You can also try the exact examples
-    above in the <a href="/#playground">playground</a>.
+    above in the <a href="/playground/">playground</a>.
   </p>
 </ArticleLayout>

--- a/website/src/pages/blog/mermaid-alternative.astro
+++ b/website/src/pages/blog/mermaid-alternative.astro
@@ -68,7 +68,7 @@ beat main:
   show $nodes stagger=80ms
   Web -&gt; API "POST /order" -&gt; DB "persist"
   Web &lt;- API "201 Created"</code></pre>
-  <p>Paste that into the <a href="/#playground">playground</a> and it animates immediately.</p>
+  <p>Paste that into the <a href="/playground/">playground</a> and it animates immediately.</p>
 
   <h2>Other diagram-as-code alternatives (and when they fit)</h2>
   <table>

--- a/website/src/pages/blog/system-design-diagrams.astro
+++ b/website/src/pages/blog/system-design-diagrams.astro
@@ -100,6 +100,6 @@ beat highlight:
   <p>
     Running on Kubernetes? See <a href="/blog/kubernetes-architecture-diagram/">animated Kubernetes architecture
     diagrams</a>. Explaining call order? See <a href="/blog/animated-sequence-diagrams/">animated sequence
-    diagrams</a>. Or open the example above in the <a href="/#playground">playground</a>.
+    diagrams</a>. Or open the example above in the <a href="/playground/">playground</a>.
   </p>
 </ArticleLayout>

--- a/website/src/pages/docs.astro
+++ b/website/src/pages/docs.astro
@@ -32,8 +32,9 @@ const docStructuredData = [
       { "@type": "ListItem", position: 1, name: "MarkdyScript Tutorial", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/TUTORIAL.md" },
       { "@type": "ListItem", position: 2, name: "MarkdyScript Syntax", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/SYNTAX.md" },
       { "@type": "ListItem", position: 3, name: "AI Agent Reference", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" },
-      { "@type": "ListItem", position: 4, name: "Getting Started", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/GETTING_STARTED.md" },
-      { "@type": "ListItem", position: 5, name: "Comparisons", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/COMPARISONS.md" },
+      { "@type": "ListItem", position: 4, name: "Markdy Playground", url: "https://markdy.com/playground/" },
+      { "@type": "ListItem", position: 5, name: "Getting Started", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/GETTING_STARTED.md" },
+      { "@type": "ListItem", position: 6, name: "Comparisons", url: "https://github.com/HoangYell/markdy-com/blob/main/docs/COMPARISONS.md" },
     ],
   },
 ];
@@ -69,6 +70,11 @@ const docStructuredData = [
         <span>AI Agents</span>
         <h2>Agent Generation Guide</h2>
         <p>A machine-readable reference optimized for Claude, ChatGPT, GitHub Copilot, Cursor, Windsurf, and other LLM coding agents.</p>
+      </a>
+      <a class="doc-card" href="/playground/">
+        <span>Playground</span>
+        <h2>Practice in the Browser</h2>
+        <p>Open a spacious MarkdyScript workspace with curated examples, autocomplete, timeline controls, beat jumping, warnings, and shareable links.</p>
       </a>
       <a class="doc-card" href="https://github.com/HoangYell/markdy-com/tree/main/examples" target="_blank" rel="noopener noreferrer">
         <span>Examples</span>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -257,7 +257,7 @@ markdy <span class="u-fn">check-all</span> examples`;
     </button>
     <div class="nav-links">
       <a href="#features">Features</a>
-      <a href="#playground">Playground</a>
+      <a href="/playground/">Playground</a>
       <a href="#learn">Learn</a>
       <a href="/docs/">Docs</a>
       <a href="/blog/">Articles</a>
@@ -296,7 +296,7 @@ markdy <span class="u-fn">check-all</span> examples`;
       Markdy renders browser-native motion graphics that stay reviewable, versioned, and AI-friendly.
     </p>
     <div class="hero-actions">
-      <a href="#playground" class="btn-primary">Try the Playground</a>
+      <a href="/playground/" class="btn-primary">Try the Playground</a>
       <a href="#learn" class="btn-secondary">Learn the Syntax</a>
     </div>
 
@@ -398,7 +398,7 @@ markdy <span class="u-fn">check-all</span> examples`;
     <div class="section-header">
       <span class="section-tag">Interactive</span>
       <h2>Animated Architecture Playground</h2>
-      <p>Start from a real shipped architecture-as-code example, tweak the script, and preview the motion instantly.</p>
+      <p>Start from a real shipped architecture-as-code example, tweak the script, and preview the motion instantly. Need more room? <a href="/playground/">Open the dedicated playground</a>.</p>
     </div>
 
     <div class="editor-layout">
@@ -1010,7 +1010,7 @@ beat finish:
           <h2 class="sr-only">Footer Links</h2>
           <div class="footer-col">
             <h3>Product</h3>
-            <a href="#playground">Playground</a>
+            <a href="/playground/">Playground</a>
             <a href="#learn">Syntax Reference</a>
             <a href="#packages">Packages</a>
             <a href="#ai-gen">AI Generation</a>

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -1,0 +1,1101 @@
+---
+import Layout from "../layouts/Layout.astro";
+import { join } from "node:path";
+import { loadExamples } from "../data/examples";
+
+const ROOT = join(process.cwd(), "..");
+const EXAMPLES = await loadExamples(ROOT);
+
+const PLAY_SNIPPETS = [
+  {
+    label: "Reveal all nodes",
+    code: `beat reveal "Reveal the system":\n  show $nodes stagger=60ms`,
+  },
+  {
+    label: "Frame a group",
+    code: `beat inspect "Inspect backend":\n  frame backend zoom=1.18 dur=600ms`,
+  },
+  {
+    label: "Request / response",
+    code: `beat request "Trace request":\n  Client -> API "GET /items"\n  Client <- API "200 OK"`,
+  },
+  {
+    label: "Loop reset",
+    code: `beat reset "Return to overview":\n  frame $nodes dur=600ms`,
+  },
+];
+
+const playgroundStructuredData = [
+  {
+    "@type": "WebPage",
+    "@id": "https://markdy.com/playground/#webpage",
+    url: "https://markdy.com/playground/",
+    name: "Markdy Playground",
+    description: "A spacious browser playground for writing, testing, learning, and sharing MarkdyScript animated architecture diagrams.",
+    isPartOf: { "@id": "https://markdy.com/#website" },
+    about: { "@id": "https://markdy.com/#software" },
+  },
+];
+---
+
+<Layout
+  title="Markdy Playground — Learn and Test Animated Architecture Diagrams"
+  description="A spacious MarkdyScript playground for trying examples, editing animated architecture diagrams, learning beats and frame cues, and sharing runnable scenes."
+  canonicalURL="https://markdy.com/playground/"
+  keywords="Markdy playground, MarkdyScript editor, animated architecture diagram playground, diagram as code playground, Mermaid alternative playground, AI diagram generator"
+  structuredData={playgroundStructuredData}
+>
+  <main class="playground-page">
+    <nav class="topbar" aria-label="Playground navigation">
+      <a class="brand" href="/" aria-label="Markdy home">
+        <span>🎬</span>
+        <strong>markdy</strong>
+      </a>
+      <div class="topbar-links">
+        <a href="/docs/">Docs</a>
+        <a href="https://github.com/HoangYell/markdy-com" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle theme">Theme</button>
+      </div>
+    </nav>
+
+    <header class="hero">
+      <div class="hero-copy">
+        <span class="eyebrow">Dedicated workspace</span>
+        <h1>Play, learn, test, and share MarkdyScript.</h1>
+        <p>
+          Use this spacious playground when the homepage demo feels too tight:
+          pick a real shipped scene, edit with autocomplete, jump between beats,
+          inspect warnings, and copy a shareable URL.
+        </p>
+      </div>
+      <div class="hero-actions">
+        <a class="btn btn-primary" href="#workspace">Start editing</a>
+        <a class="btn btn-secondary" href="/docs/">Read docs</a>
+      </div>
+    </header>
+
+    <section class="resource-strip" aria-label="Examples and learning helpers">
+      <section class="card examples-card">
+        <div class="panel-title">
+          <span>Examples</span>
+          <a id="example-source-link" href={EXAMPLES[0].sourceUrl} target="_blank" rel="noopener noreferrer">View source</a>
+        </div>
+        <div class="example-list">
+          {EXAMPLES.map((ex, i) => (
+            <button class="example-btn" type="button" data-index={i}>
+              <strong>{ex.title}</strong>
+              <span>{ex.pattern ?? ex.category}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section class="card learn-card">
+        <div class="panel-title">
+          <span>Learn by inserting</span>
+        </div>
+        <p>Drop a small pattern into the editor, adapt the node ids, then run.</p>
+        <div class="snippet-list">
+          {PLAY_SNIPPETS.map((snippet) => (
+            <button class="snippet-btn" type="button" data-snippet={snippet.code}>{snippet.label}</button>
+          ))}
+        </div>
+      </section>
+
+      <section class="card checklist">
+        <div class="panel-title">
+          <span>Fast feedback loop</span>
+        </div>
+        <ol>
+          <li>Choose a showcase scene.</li>
+          <li>Edit nodes, groups, beats, and flow labels.</li>
+          <li>Use <code>frame</code> to guide attention.</li>
+          <li>Fix warnings until the scene is clean.</li>
+        </ol>
+      </section>
+    </section>
+
+    <section id="workspace" class="workspace" aria-label="MarkdyScript playground workspace">
+      <section class="editor-panel" aria-label="Code editor">
+        <div class="panel-head">
+          <div>
+            <span class="panel-kicker">Editor</span>
+            <h2>MarkdyScript</h2>
+          </div>
+          <div class="toolbar">
+            <button id="copy-code-btn" class="tool-btn" type="button">Copy</button>
+            <button id="reset-btn" class="tool-btn" type="button">Reset</button>
+            <button id="run-btn" class="tool-btn tool-btn-primary" type="button">Run</button>
+          </div>
+        </div>
+        <div id="code-editor" class="code-editor" aria-label="MarkdyScript editor"></div>
+        <p class="hint">Auto-runs after typing. Use Cmd/Ctrl+Enter to run immediately.</p>
+        <div id="diagnostics" class="diagnostics" aria-live="polite"></div>
+      </section>
+
+      <button
+        id="splitter"
+        class="splitter"
+        type="button"
+        role="separator"
+        aria-label="Resize editor and preview panes"
+        aria-orientation="vertical"
+        aria-valuemin="30"
+        aria-valuemax="70"
+        aria-valuenow="50"
+        title="Drag to resize. Double-click to reset."
+      >
+        <span></span>
+      </button>
+
+      <section class="preview-panel" aria-label="Animated preview">
+        <div class="panel-head">
+          <div>
+            <span class="panel-kicker"><span id="status-dot" class="status-dot status-ok"></span>Preview</span>
+            <h2>Animated diagram</h2>
+          </div>
+          <div class="toolbar">
+            <button id="share-btn" class="tool-btn" type="button">Share</button>
+            <button id="restart-btn" class="tool-btn" type="button">Restart</button>
+            <button id="play-btn" class="tool-btn tool-btn-primary" type="button">Pause</button>
+          </div>
+        </div>
+
+        <div class="preview-toolbar">
+          <select id="beat-jump" class="beat-jump" aria-label="Jump to beat" hidden></select>
+          <div class="speed-group" role="group" aria-label="Playback speed">
+            <button class="speed-btn active" type="button" data-speed="1" aria-pressed="true">1x</button>
+            <button class="speed-btn" type="button" data-speed="1.5" aria-pressed="false">1.5x</button>
+            <button class="speed-btn" type="button" data-speed="2" aria-pressed="false">2x</button>
+            <button class="speed-btn" type="button" data-speed="0.5" aria-pressed="false">0.5x</button>
+          </div>
+        </div>
+
+        <div id="stage" class="stage"></div>
+
+        <div class="timeline">
+          <input id="timeline-range" type="range" min="0" max="0" step="0.01" value="0" aria-label="Scrub timeline" />
+          <span id="timeline-label">0:00 / 0:00</span>
+        </div>
+      </section>
+    </section>
+  </main>
+</Layout>
+
+<script define:vars={{ examples: EXAMPLES }}>
+  window.__MARKDY_PLAYGROUND_EXAMPLES = examples;
+</script>
+
+<script>
+  import { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter } from "@codemirror/view";
+  import { EditorState } from "@codemirror/state";
+  import { bracketMatching, indentOnInput } from "@codemirror/language";
+  import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+  import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
+  import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+
+  import { markdyLanguage, markdyAutocomplete, markdyHighlightLight, markdyHighlightDark } from "../editor/markdy-language";
+  import { baseTheme, lightTheme, darkTheme } from "../editor/editor-theme";
+  import { createDiagram } from "@markdy/renderer-dom";
+  import type { Diagram } from "@markdy/renderer-dom";
+  import type { Diagnostic } from "@markdy/core";
+  import type { ExampleEntry } from "../data/examples";
+
+  const STORAGE_KEY = "markdy-theme";
+  const examples: ExampleEntry[] = (window as any).__MARKDY_PLAYGROUND_EXAMPLES;
+
+  const editorHost = document.getElementById("code-editor") as HTMLDivElement;
+  const stage = document.getElementById("stage") as HTMLDivElement;
+  const diagnostics = document.getElementById("diagnostics") as HTMLDivElement;
+  const runBtn = document.getElementById("run-btn") as HTMLButtonElement;
+  const resetBtn = document.getElementById("reset-btn") as HTMLButtonElement;
+  const copyCodeBtn = document.getElementById("copy-code-btn") as HTMLButtonElement;
+  const shareBtn = document.getElementById("share-btn") as HTMLButtonElement;
+  const restartBtn = document.getElementById("restart-btn") as HTMLButtonElement;
+  const playBtn = document.getElementById("play-btn") as HTMLButtonElement;
+  const statusDot = document.getElementById("status-dot") as HTMLSpanElement;
+  const timelineRange = document.getElementById("timeline-range") as HTMLInputElement;
+  const timelineLabel = document.getElementById("timeline-label") as HTMLSpanElement;
+  const beatJump = document.getElementById("beat-jump") as HTMLSelectElement;
+  const exampleSourceLink = document.getElementById("example-source-link") as HTMLAnchorElement;
+  const exampleBtns = document.querySelectorAll<HTMLButtonElement>(".example-btn");
+  const speedBtns = document.querySelectorAll<HTMLButtonElement>(".speed-btn");
+  const themeToggle = document.getElementById("theme-toggle") as HTMLButtonElement;
+  const workspace = document.getElementById("workspace") as HTMLElement;
+  const splitter = document.getElementById("splitter") as HTMLButtonElement;
+
+  let editor: EditorView | null = null;
+  let diagram: Diagram | null = null;
+  let debounce: ReturnType<typeof setTimeout> | null = null;
+  let selectedExample = 0;
+  let playbackRate = 1;
+  let isScrubbing = false;
+
+  function isDarkMode(): boolean {
+    return document.documentElement.getAttribute("data-theme") === "dark";
+  }
+
+  function applyTheme(theme: "light" | "dark") {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+    themeToggle.textContent = theme === "dark" ? "Light" : "Dark";
+  }
+
+  function formatTime(seconds: number): string {
+    if (!Number.isFinite(seconds) || seconds <= 0) return "0:00";
+    const total = Math.floor(seconds);
+    return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
+  }
+
+  function setStatus(ok: boolean) {
+    statusDot.className = `status-dot ${ok ? "status-ok" : "status-error"}`;
+  }
+
+  function showDiagnostics(items: string[]) {
+    diagnostics.innerHTML = "";
+    if (items.length === 0) {
+      diagnostics.hidden = true;
+      return;
+    }
+    diagnostics.hidden = false;
+    const title = document.createElement("strong");
+    title.textContent = "Diagnostics";
+    diagnostics.appendChild(title);
+    const list = document.createElement("ul");
+    for (const item of items) {
+      const li = document.createElement("li");
+      li.textContent = item;
+      list.appendChild(li);
+    }
+    diagnostics.appendChild(list);
+  }
+
+  function setTimeline(current: number, duration: number) {
+    const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : 0;
+    const safeCurrent = safeDuration > 0 ? Math.min(Math.max(current, 0), safeDuration) : 0;
+    timelineRange.max = safeDuration.toFixed(2);
+    if (!isScrubbing) timelineRange.value = safeCurrent.toFixed(2);
+    timelineRange.disabled = safeDuration <= 0;
+    timelineLabel.textContent = `${formatTime(safeCurrent)} / ${formatTime(safeDuration)}`;
+  }
+
+  function populateBeatJump(beats: { name: string; label?: string; start: number }[]) {
+    beatJump.innerHTML = "";
+    if (beats.length === 0) {
+      beatJump.hidden = true;
+      return;
+    }
+    beatJump.hidden = false;
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = "Jump to beat...";
+    beatJump.appendChild(placeholder);
+    for (const beat of beats) {
+      const option = document.createElement("option");
+      option.value = beat.name;
+      option.textContent = beat.label ? `${beat.name} - ${beat.label}` : beat.name;
+      beatJump.appendChild(option);
+    }
+    beatJump.value = "";
+  }
+
+  function getCode(): string {
+    return editor?.state.doc.toString() ?? "";
+  }
+
+  function createEditor(code: string) {
+    editor?.destroy();
+    editor = new EditorView({
+      state: EditorState.create({
+        doc: code,
+        extensions: [
+          lineNumbers(),
+          highlightActiveLine(),
+          highlightActiveLineGutter(),
+          history(),
+          bracketMatching(),
+          closeBrackets(),
+          indentOnInput(),
+          highlightSelectionMatches(),
+          markdyLanguage,
+          markdyAutocomplete,
+          isDarkMode() ? markdyHighlightDark : markdyHighlightLight,
+          baseTheme,
+          isDarkMode() ? darkTheme : lightTheme,
+          keymap.of([
+            ...closeBracketsKeymap,
+            ...defaultKeymap,
+            ...searchKeymap,
+            ...historyKeymap,
+            indentWithTab,
+          ]),
+          EditorView.contentAttributes.of({ "aria-label": "MarkdyScript editor" }),
+          EditorView.updateListener.of((update) => {
+            if (!update.docChanged) return;
+            exampleBtns.forEach((btn) => btn.classList.remove("active"));
+            if (debounce) clearTimeout(debounce);
+            debounce = setTimeout(() => render(getCode()), 650);
+          }),
+        ],
+      }),
+      parent: editorHost,
+    });
+  }
+
+  function render(code: string) {
+    diagram?.destroy();
+    diagram = null;
+    stage.innerHTML = "";
+    const warnings: string[] = [];
+    try {
+      diagram = createDiagram({
+        container: stage,
+        code,
+        autoplay: true,
+        loop: true,
+        copyright: false,
+        sceneBoundaryProgress: false,
+        playbackRate,
+        onWarning(warning: Diagnostic) {
+          warnings.push(`line ${warning.line}: ${warning.message}`);
+        },
+        onTimeUpdate: setTimeline,
+        onPlayStateChange(playing) {
+          playBtn.textContent = playing ? "Pause" : "Play";
+        },
+      });
+      setStatus(true);
+      showDiagnostics(warnings);
+      setTimeline(diagram.currentTime(), diagram.duration());
+      populateBeatJump(diagram.beats());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      stage.innerHTML = `<div class="parse-error">${message}</div>`;
+      setStatus(false);
+      showDiagnostics([message]);
+      setTimeline(0, 0);
+      populateBeatJump([]);
+      playBtn.textContent = "Play";
+    }
+  }
+
+  function setActiveExample(index: number) {
+    selectedExample = index;
+    exampleBtns.forEach((btn, i) => btn.classList.toggle("active", i === index));
+    const example = examples[index];
+    if (example) {
+      exampleSourceLink.href = example.sourceUrl;
+      exampleSourceLink.textContent = "View source";
+    } else {
+      exampleSourceLink.href = "https://github.com/HoangYell/markdy-com/tree/main/examples";
+      exampleSourceLink.textContent = "Browse examples";
+    }
+  }
+
+  function loadExample(index: number) {
+    const example = examples[index];
+    if (!example) return;
+    setActiveExample(index);
+    createEditor(example.code);
+    render(example.code);
+  }
+
+  function encodeShare(code: string): string {
+    return btoa(encodeURIComponent(code));
+  }
+
+  function decodeShare(value: string): string | null {
+    try {
+      return decodeURIComponent(atob(value));
+    } catch {
+      return null;
+    }
+  }
+
+  async function writeClipboard(text: string, button: HTMLButtonElement, label: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      const old = button.textContent;
+      button.textContent = label;
+      setTimeout(() => { button.textContent = old; }, 1800);
+    } catch {
+      button.title = "Copy failed - select and copy manually";
+    }
+  }
+
+  function setWorkspaceSplit(percent: number) {
+    const next = Math.min(70, Math.max(30, percent));
+    workspace.style.setProperty("--editor-pane", `${next}%`);
+    splitter.setAttribute("aria-valuenow", String(Math.round(next)));
+  }
+
+  function setWorkspaceSplitFromClientX(clientX: number) {
+    const rect = workspace.getBoundingClientRect();
+    if (rect.width <= 0) return;
+    setWorkspaceSplit(((clientX - rect.left) / rect.width) * 100);
+  }
+
+  const params = new URLSearchParams(window.location.hash.slice(1));
+  const sharedCode = params.get("code");
+  const initialCode = sharedCode ? decodeShare(sharedCode) ?? examples[0].code : examples[0].code;
+
+  const savedTheme = localStorage.getItem(STORAGE_KEY);
+  applyTheme(
+    savedTheme === "dark" || savedTheme === "light"
+      ? savedTheme
+      : window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light",
+  );
+  createEditor(initialCode);
+  render(initialCode);
+  setActiveExample(sharedCode ? -1 : 0);
+
+  exampleBtns.forEach((btn) => {
+    btn.addEventListener("click", () => loadExample(Number(btn.dataset.index ?? "0")));
+  });
+
+  document.querySelectorAll<HTMLButtonElement>(".snippet-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const snippet = btn.dataset.snippet;
+      if (!editor || !snippet) return;
+      const doc = editor.state.doc;
+      const insert = `${doc.length > 0 ? "\n\n" : ""}${snippet}`;
+      editor.dispatch({
+        changes: { from: doc.length, insert },
+        selection: { anchor: doc.length + insert.length },
+      });
+      editor.focus();
+      render(getCode());
+    });
+  });
+
+  runBtn.addEventListener("click", () => render(getCode()));
+  resetBtn.addEventListener("click", () => loadExample(selectedExample >= 0 ? selectedExample : 0));
+  copyCodeBtn.addEventListener("click", () => writeClipboard(getCode(), copyCodeBtn, "Copied"));
+  shareBtn.addEventListener("click", () => {
+    const url = `${window.location.origin}${window.location.pathname}#code=${encodeShare(getCode())}`;
+    writeClipboard(url, shareBtn, "Copied");
+  });
+
+  restartBtn.addEventListener("click", () => {
+    if (!diagram) return;
+    diagram.seek(0);
+    diagram.play();
+  });
+
+  playBtn.addEventListener("click", () => {
+    if (!diagram) return;
+    if (diagram.isPlaying()) diagram.pause();
+    else diagram.play();
+  });
+
+  speedBtns.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      playbackRate = Number(btn.dataset.speed ?? "1");
+      speedBtns.forEach((item) => {
+        const active = item === btn;
+        item.classList.toggle("active", active);
+        item.setAttribute("aria-pressed", active ? "true" : "false");
+      });
+      diagram?.setPlaybackRate(playbackRate);
+    });
+  });
+
+  splitter.addEventListener("pointerdown", (event) => {
+    if (window.matchMedia("(max-width: 900px)").matches) return;
+    event.preventDefault();
+    splitter.setPointerCapture(event.pointerId);
+    document.body.classList.add("is-resizing-playground");
+
+    const onMove = (moveEvent: PointerEvent) => {
+      setWorkspaceSplitFromClientX(moveEvent.clientX);
+    };
+    const onUp = () => {
+      document.body.classList.remove("is-resizing-playground");
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp, { once: true });
+  });
+
+  splitter.addEventListener("dblclick", () => setWorkspaceSplit(50));
+
+  splitter.addEventListener("keydown", (event) => {
+    const current = Number(splitter.getAttribute("aria-valuenow") ?? "50");
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      setWorkspaceSplit(current - 4);
+    }
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      setWorkspaceSplit(current + 4);
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      setWorkspaceSplit(30);
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      setWorkspaceSplit(70);
+    }
+  });
+
+  timelineRange.addEventListener("input", () => {
+    if (!diagram) return;
+    isScrubbing = true;
+    diagram.seek(Number(timelineRange.value));
+  });
+
+  timelineRange.addEventListener("change", () => {
+    isScrubbing = false;
+    if (!diagram) return;
+    diagram.seek(Number(timelineRange.value));
+  });
+
+  beatJump.addEventListener("change", () => {
+    if (!diagram || !beatJump.value) return;
+    diagram.seekToBeat(beatJump.value);
+  });
+
+  themeToggle.addEventListener("click", () => {
+    const next = isDarkMode() ? "light" : "dark";
+    const code = getCode();
+    applyTheme(next);
+    createEditor(code);
+    render(code);
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault();
+      render(getCode());
+    }
+  });
+</script>
+
+<style>
+  :root,
+  :root[data-theme="light"] {
+    --bg-primary: #f8fafc;
+    --bg-secondary: #ffffff;
+    --bg-tertiary: #f1f5f9;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --text-muted: #6b7280;
+    --border: #e2e8f0;
+    --border-subtle: #eef2f7;
+    --accent: #047857;
+    --accent-hover: #065f46;
+    --accent-light: rgba(5, 150, 105, 0.12);
+    --danger: #dc2626;
+    --shadow-md: rgba(15, 23, 42, 0.08);
+    --selection-bg: #d1fae5;
+    --selection-text: #064e3b;
+    --cm-caret: #0f172a;
+    --cm-activeLine: rgba(5, 150, 105, 0.05);
+    --cm-selection: #d1fae5;
+    --cm-tooltipBg: #ffffff;
+    --cm-tooltipBorder: #e2e8f0;
+    --cm-tooltipShadow: rgba(0, 0, 0, 0.08);
+    --cm-tooltipSelected: #059669;
+    --cm-tooltipSelectedText: #ffffff;
+  }
+
+  :root[data-theme="dark"] {
+    --bg-primary: #0d1117;
+    --bg-secondary: #161b22;
+    --bg-tertiary: #1c2128;
+    --text-primary: #c9d1d9;
+    --text-secondary: #8b949e;
+    --text-muted: #8b949e;
+    --border: #30363d;
+    --border-subtle: #21262d;
+    --accent: #3fb950;
+    --accent-hover: #2ea043;
+    --accent-light: rgba(63, 185, 80, 0.15);
+    --danger: #f87171;
+    --shadow-md: rgba(0, 0, 0, 0.3);
+    --selection-bg: rgba(63, 185, 80, 0.15);
+    --selection-text: #c9d1d9;
+    --cm-caret: #c9d1d9;
+    --cm-activeLine: rgba(63, 185, 80, 0.08);
+    --cm-selection: rgba(63, 185, 80, 0.22);
+    --cm-tooltipBg: #161b22;
+    --cm-tooltipBorder: #30363d;
+    --cm-tooltipShadow: rgba(0, 0, 0, 0.4);
+    --cm-tooltipSelected: #238636;
+    --cm-tooltipSelectedText: #ffffff;
+  }
+
+  .playground-page {
+    min-height: 100vh;
+    padding: 1.25rem;
+    background:
+      radial-gradient(circle at top left, var(--accent-light), transparent 36rem),
+      var(--bg-primary);
+  }
+
+  .topbar,
+  .hero,
+  .resource-strip {
+    max-width: 1680px;
+    margin: 0 auto;
+  }
+
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 0 1.25rem;
+  }
+
+  .brand,
+  .topbar-links {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .brand {
+    color: var(--text-primary);
+    font-size: 1.05rem;
+    font-weight: 800;
+  }
+
+  .topbar-links a,
+  .theme-toggle {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    padding: 0.5rem 0.85rem;
+    font: inherit;
+    font-size: 0.88rem;
+    cursor: pointer;
+  }
+
+  .hero {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 2rem;
+    padding: 2.25rem 0 1.75rem;
+  }
+
+  .hero-copy {
+    max-width: 820px;
+  }
+
+  .eyebrow,
+  .panel-kicker {
+    color: var(--accent);
+    font-size: 0.75rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin-top: 0.45rem;
+    color: var(--text-primary);
+    font-size: clamp(2.7rem, 7vw, 5.8rem);
+    line-height: 0.94;
+    letter-spacing: -0.065em;
+  }
+
+  .hero p {
+    max-width: 720px;
+    margin-top: 1rem;
+    color: var(--text-secondary);
+    font-size: clamp(1rem, 2vw, 1.18rem);
+  }
+
+  .hero-actions,
+  .toolbar,
+  .preview-toolbar,
+  .speed-group {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+  }
+
+  .btn,
+  .tool-btn,
+  .speed-btn {
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    padding: 0.68rem 0.9rem;
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 700;
+    cursor: pointer;
+    box-shadow: 0 10px 26px -20px var(--shadow-md);
+  }
+
+  .btn-primary,
+  .tool-btn-primary,
+  .speed-btn.active {
+    border-color: var(--accent);
+    background: var(--accent);
+    color: #ffffff;
+  }
+
+  .btn-secondary {
+    color: var(--text-secondary);
+  }
+
+  .workspace {
+    display: grid;
+    grid-template-columns: minmax(360px, var(--editor-pane, 50%)) 14px minmax(420px, 1fr);
+    gap: 0.75rem;
+    align-items: stretch;
+    width: 100%;
+    max-width: none;
+    margin: 0;
+  }
+
+  .resource-strip {
+    display: grid;
+    grid-template-columns: minmax(0, 1.6fr) minmax(260px, 0.8fr) minmax(260px, 0.7fr);
+    gap: 1rem;
+    margin-bottom: 1rem;
+    align-items: stretch;
+  }
+
+  .examples-card {
+    min-width: 0;
+  }
+
+  .examples-card .example-list {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(210px, 1fr);
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    padding-bottom: 0.2rem;
+    scroll-snap-type: x proximity;
+  }
+
+  .examples-card .example-btn {
+    scroll-snap-align: start;
+  }
+
+  .learn-card,
+  .checklist {
+    display: grid;
+    align-content: start;
+  }
+
+  .checklist ol {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.35rem 0.85rem;
+  }
+
+  .card,
+  .editor-panel,
+  .preview-panel {
+    border: 1px solid var(--border);
+    border-radius: 1.35rem;
+    background: color-mix(in srgb, var(--bg-secondary) 94%, transparent);
+    box-shadow: 0 18px 56px -42px var(--shadow-md);
+  }
+
+  .card {
+    padding: 1rem;
+  }
+
+  .panel-title,
+  .panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .panel-title {
+    margin-bottom: 0.75rem;
+    color: var(--text-primary);
+    font-size: 0.86rem;
+    font-weight: 800;
+  }
+
+  .panel-title a {
+    color: var(--accent);
+    font-size: 0.78rem;
+  }
+
+  .example-list,
+  .snippet-list {
+    display: grid;
+    gap: 0.55rem;
+  }
+
+  .example-btn,
+  .snippet-btn {
+    width: 100%;
+    border: 1px solid var(--border-subtle);
+    border-radius: 0.95rem;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    padding: 0.75rem;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .example-btn strong,
+  .example-btn span {
+    display: block;
+  }
+
+  .example-btn span {
+    margin-top: 0.16rem;
+    color: var(--text-muted);
+    font-size: 0.78rem;
+  }
+
+  .example-btn.active {
+    border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+    background: var(--accent-light);
+  }
+
+  .learn-card p,
+  .checklist li,
+  .hint {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+  }
+
+  .checklist ol {
+    padding-left: 1.1rem;
+  }
+
+  .checklist li + li {
+    margin-top: 0.35rem;
+  }
+
+  .editor-panel,
+  .preview-panel {
+    min-width: 0;
+    padding: 1rem;
+  }
+
+  .splitter {
+    align-self: stretch;
+    width: 14px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    cursor: col-resize;
+    display: grid;
+    place-items: center;
+    padding: 0;
+    touch-action: none;
+  }
+
+  .splitter span {
+    width: 4px;
+    height: min(18rem, 46vh);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--border) 78%, var(--accent) 22%);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, #ffffff 18%, transparent);
+    transition: background 0.18s ease, transform 0.18s ease;
+  }
+
+  .splitter:hover span,
+  .splitter:focus-visible span,
+  :global(body.is-resizing-playground) .splitter span {
+    background: var(--accent);
+    transform: scaleX(1.35);
+  }
+
+  :global(body.is-resizing-playground) {
+    cursor: col-resize;
+    user-select: none;
+  }
+
+  .panel-head {
+    margin-bottom: 0.85rem;
+  }
+
+  .panel-head h2 {
+    margin-top: 0.1rem;
+    color: var(--text-primary);
+    font-size: 1.05rem;
+  }
+
+  .code-editor {
+    min-height: min(68vh, 760px);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    background: var(--bg-secondary);
+  }
+
+  :global(.code-editor .cm-editor) {
+    min-height: min(68vh, 760px);
+  }
+
+  :global(.code-editor .cm-scroller) {
+    min-height: min(68vh, 760px);
+  }
+
+  .hint {
+    margin-top: 0.65rem;
+  }
+
+  .diagnostics {
+    margin-top: 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--danger) 24%, var(--border));
+    border-radius: 0.9rem;
+    background: color-mix(in srgb, var(--danger) 8%, var(--bg-secondary));
+    color: var(--text-primary);
+    padding: 0.75rem 0.9rem;
+    font-size: 0.88rem;
+  }
+
+  .diagnostics[hidden] {
+    display: none;
+  }
+
+  .diagnostics ul {
+    margin-top: 0.4rem;
+    padding-left: 1rem;
+  }
+
+  .preview-toolbar {
+    justify-content: space-between;
+    margin-bottom: 0.85rem;
+  }
+
+  .beat-jump {
+    min-width: 190px;
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    padding: 0.62rem 0.75rem;
+  }
+
+  .stage {
+    min-height: min(68vh, 760px);
+    display: grid;
+    place-items: center;
+    overflow: auto;
+    border: 1px solid var(--border);
+    border-radius: 1rem;
+    background:
+      linear-gradient(45deg, color-mix(in srgb, var(--border) 22%, transparent) 25%, transparent 25%),
+      linear-gradient(-45deg, color-mix(in srgb, var(--border) 22%, transparent) 25%, transparent 25%),
+      var(--bg-tertiary);
+    background-size: 24px 24px;
+    padding: clamp(1rem, 2vw, 2rem);
+  }
+
+  .stage > div {
+    width: min(100%, 1280px);
+  }
+
+  .parse-error {
+    max-width: 720px;
+    border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border));
+    border-radius: 1rem;
+    background: color-mix(in srgb, var(--danger) 10%, var(--bg-secondary));
+    color: var(--danger);
+    padding: 1rem;
+    font-family: "JetBrains Mono", monospace;
+    white-space: pre-wrap;
+  }
+
+  .timeline {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.8rem;
+    align-items: center;
+    margin-top: 0.9rem;
+  }
+
+  .timeline input {
+    width: 100%;
+    accent-color: var(--accent);
+  }
+
+  .timeline span,
+  .status-dot {
+    color: var(--text-secondary);
+    font-size: 0.86rem;
+  }
+
+  .status-dot {
+    display: inline-block;
+    width: 0.62rem;
+    height: 0.62rem;
+    margin-right: 0.4rem;
+    border-radius: 999px;
+    vertical-align: middle;
+  }
+
+  .status-ok {
+    background: var(--accent);
+    box-shadow: 0 0 0 4px var(--accent-light);
+  }
+
+  .status-error {
+    background: var(--danger);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--danger) 16%, transparent);
+  }
+
+  @media (max-width: 1280px) {
+    .resource-strip {
+      grid-template-columns: 1fr;
+    }
+
+    .learn-card .snippet-list,
+    .checklist ol {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 900px) {
+    .playground-page {
+      padding: 0.9rem;
+    }
+
+    .topbar,
+    .hero,
+    .resource-strip,
+    .workspace {
+      display: grid;
+    }
+
+    .workspace {
+      grid-template-columns: 1fr;
+    }
+
+    .splitter {
+      display: none;
+    }
+
+    .hero-actions {
+      justify-content: stretch;
+    }
+
+    .btn {
+      text-align: center;
+    }
+
+    .stage,
+    .code-editor {
+      min-height: 58vh;
+    }
+
+    .learn-card .snippet-list,
+    .checklist ol {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- add MarkdyScript frame cues, beat captions, reference diagnostics, and renderer support for camera-guided storytelling
- add a dedicated /playground/ page with an adjustable editor/preview split, snippets, diagnostics, timeline controls, and share links
- add playground SEO article, update docs/blog links, and tighten example validation

## Validation
- pnpm run ci
- pnpm run typecheck
- pnpm --filter @markdy/website build