### PR TITLE
fix: tolerate ai-generated markdy syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Human-first AI prompt examples** — Simplified public AI prompt examples so users describe the diagram idea in natural language while the agent guide handles Markdy-specific syntax choices.
+
+### Fixed
+- **AI-generated syntax tolerance** — The parser now accepts common LLM variants such as `#` comments, quote-safe `//` handling inside URLs, brace-delimited beat/pattern blocks, inline scene layout, quoted property values, and leading-`&` parallel cue continuations.
+- **Playground editor/preview visibility** — The dedicated playground editor now scrolls internally while the preview pane stays sticky beside it, so authors can keep watching the animation while typing longer MarkdyScript scenes.
+
 ## [0.8.6] — 2026-08-09
 
 ### Added

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -10,6 +10,7 @@ MarkdyScript 0.8 is **diagram-native**: you declare nodes, groups, and beats, an
 - Default theme is `paper`; default layout direction is `LR`.
 - Keep flow labels short (≤ ~28 chars) so they stay readable.
 - Use beat labels and `frame` when the scene should guide attention through a large diagram.
+- Canonical blocks use `beat name "Label":` with indented cues. The parser also accepts `{ ... }` beat/pattern blocks and `#` comments because many LLMs generate them, but prefer the canonical colon style in final docs.
 
 ## Minimal example
 
@@ -42,6 +43,8 @@ scene "Title" theme=paper width=1280 height=720 fps=60 duration=8
 | `width` / `height` | `1280` / `720` | Canvas size in px |
 | `fps` | `60` | Frame rate hint |
 | `duration` | auto | Force total seconds (otherwise derived from cues) |
+
+`layout LR` may be a separate statement (preferred) or inline on the `scene` line for AI-generated compatibility.
 
 ### `layout` — auto-layout direction
 
@@ -95,6 +98,8 @@ beat checkout "Process checkout":
 
 The optional quoted beat label is rendered as a caption during the beat.
 
+AI compatibility: `beat checkout "Process checkout" { ... }` is accepted and normalized internally, but `beat checkout "Process checkout":` is the recommended style.
+
 ### Flow operators
 
 Connect nodes with directed edges. Chain multiple hops on one line and add a `"label"` after any target.
@@ -117,6 +122,7 @@ Flows may appear inside a `beat` (animated) or at the top level as `edge id: A -
 ### Cues
 
 Cues live inside a beat. Put `&` between two cues to run them in parallel.
+You may put `&` at the start of the next line as a continuation when an AI generates that style.
 
 | Cue | Parameters | Description |
 |---|---|---|
@@ -248,6 +254,7 @@ beat main:
 - Keep repeated paths in `pattern` blocks and call them with `use`.
 - Use `frame groupName zoom=...` for attention, not manual coordinates or extra duplicate nodes.
 - Reset the camera with `frame $nodes` before a loop so the diagram returns to the full view.
+- Do not rely on Mermaid syntax. Markdy accepts brace blocks and `#` comments for compatibility, but flow/cue statements still need Markdy node ids, operators, and cue names.
 
 ## Validation checklist
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -74,8 +74,8 @@ markdy render path/to/scene.markdy --out preview.html
 
 ## 6. Prompt an AI coding agent
 
-Use `docs/AGENT.md` as the full grammar reference and ask for MarkdyScript directly.
+Use `docs/AGENT.md` as the full grammar reference, but prompt with your idea in normal product or architecture language. The AI should translate that idea into valid MarkdyScript.
 
 Example prompt:
 
-> Use the Markdy agent guide. Create a 1280x720 animated architecture diagram for a URL shortener. Include short-link creation, redirect resolution, Redis cache lookup, database fallback, beats, labeled flow edges (`->`, `<-`, `~>`), and a final `glow` on the hot path.
+> Use the Markdy agent guide to write one complete MarkdyScript scene. I want to explain a URL shortener: first a user creates a short link, then someone opens the short link and gets redirected. Show the API, URL service, Redis cache, and database. Make the animation clear enough for a short engineering demo.

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -12,6 +12,8 @@ scene "URL Shortener" theme=paper
 layout LR
 ```
 
+Canonical scenes put `layout LR|RL|TB|BT` on its own line. For AI-generated compatibility, the parser also accepts `layout LR` or `layout=LR` on the `scene` line.
+
 ### Nodes
 
 ```markdy
@@ -40,6 +42,8 @@ beat create "Create a short URL":
 ```
 
 The optional beat label is rendered as a short caption during that beat.
+
+Canonical beat and pattern blocks end with `:` and use indentation. The parser also accepts `{ ... }` block delimiters and `#` comments because LLMs often emit that style, but generated documentation should prefer the colon form above.
 
 Flow operators:
 - `->` — request
@@ -77,3 +81,5 @@ beat main:
 | `use` | Expand a pattern | pattern args |
 
 `frame $nodes` returns the camera to the full diagram — a good final cue for looping scenes.
+
+For parallel cues, prefer `cue A & cue B` on one line. A leading `& cue B` continuation on the next line is accepted for AI-generated compatibility.

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -43,7 +43,7 @@ The playground is the fastest feedback loop: it keeps the editor syntax-highligh
 
 AI prompt starter:
 
-> Use `docs/AGENT.md`. Create a 1280x720 animated architecture diagram for an OAuth login flow. Use semantic node kinds, labeled beats, `frame` cues for attention, flow edges (`->`, `<-`, `~>`), short labels, and a final `focus` on the token exchange.
+> Use `docs/AGENT.md` to write one complete MarkdyScript scene. I want to explain OAuth login to frontend and backend engineers: the user clicks sign in, the app redirects to the identity provider, the provider returns a code, the backend exchanges it for tokens, then the app shows the signed-in session. Make it clear, presentation-friendly, and easy to paste into the Markdy playground.
 
 ---
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -52,26 +52,82 @@ export type ParseOptions = {
 };
 
 const FLOW_OP_RE = /(->|<-|~>|--)/;
-const PROP_RE = /(\w[\w.-]*)=(\S+)/g;
 
 function stripComment(line: string): string {
-  const idx = line.indexOf("//");
-  return idx >= 0 ? line.slice(0, idx) : line;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString && ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "/" && line[i + 1] === "/") return line.slice(0, i);
+    if (ch === "#" && (i === 0 || /\s/.test(line[i - 1]))) return line.slice(0, i);
+  }
+  return line;
+}
+
+function parsePropValue(raw: string): unknown {
+  let val: unknown = raw;
+  if (raw.startsWith('"')) {
+    const parsed = parseStringToken(raw);
+    if (parsed && parsed.rest === "") val = parsed.value;
+  }
+  if (typeof val === "string") {
+    if (/^\d+(\.\d+)?$/.test(val)) val = Number(val);
+    else if (val === "true") val = true;
+    else if (val === "false") val = false;
+    else if (/^\d+ms$/.test(val)) val = Number(val.slice(0, -2)) / 1000;
+    else if (/^\d+(\.\d+)?s$/.test(val)) val = Number(val.slice(0, -1));
+  }
+  return val;
 }
 
 function parseProps(raw: string): Record<string, unknown> {
   const props: Record<string, unknown> = {};
-  for (const match of raw.matchAll(PROP_RE)) {
-    const key = match[1];
-    let val: unknown = match[2];
-    if (typeof val === "string") {
-      if (/^\d+(\.\d+)?$/.test(val)) val = Number(val);
-      else if (val === "true") val = true;
-      else if (val === "false") val = false;
-      else if (/^\d+ms$/.test(val)) val = Number(val.slice(0, -2)) / 1000;
-      else if (/^\d+(\.\d+)?s$/.test(val)) val = Number(val.slice(0, -1));
+  let i = 0;
+  while (i < raw.length) {
+    const ch = raw[i];
+    if (ch === '"') {
+      const parsed = parseStringToken(raw.slice(i));
+      if (!parsed) break;
+      i = raw.length - parsed.rest.length;
+      continue;
     }
-    props[key] = val;
+    const keyMatch = raw.slice(i).match(/^(\w[\w.-]*)=/);
+    if (!keyMatch) {
+      i++;
+      continue;
+    }
+    const key = keyMatch[1];
+    i += key.length + 1;
+    let value = "";
+    if (raw[i] === '"') {
+      const start = i;
+      const parsed = parseStringToken(raw.slice(i));
+      if (!parsed) {
+        value = raw.slice(i);
+        i = raw.length;
+      } else {
+        i = raw.length - parsed.rest.length;
+        value = raw.slice(start, i).trim();
+      }
+    } else {
+      const start = i;
+      while (i < raw.length && !/\s/.test(raw[i])) i++;
+      value = raw.slice(start, i);
+    }
+    props[key] = parsePropValue(value);
   }
   return props;
 }
@@ -100,6 +156,58 @@ function splitTargets(raw: string): string[] {
     .split(/[\s,]+/)
     .map((t) => t.trim())
     .filter(Boolean);
+}
+
+function splitOutsideQuotes(raw: string, separator: "&"): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString && ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (!inString && ch === separator && /\s/.test(raw[i - 1] ?? "") && /\s/.test(raw[i + 1] ?? "")) {
+      parts.push(raw.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  parts.push(raw.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+function stripCueProps(raw: string, keys: string[]): string {
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (inString && ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString || !/\s/.test(ch)) continue;
+    const rest = raw.slice(i + 1);
+    if (keys.some((key) => rest.startsWith(`${key}=`))) return raw.slice(0, i).trim();
+  }
+  return raw.trim();
 }
 
 function parseFlowChain(line: string, lineNo: number): FlowSegment[] {
@@ -149,17 +257,17 @@ function parseCueLine(line: string, lineNo: number): Cue {
   const trimmed = line.trim();
   const props = parseProps(trimmed);
 
-  if (trimmed.includes(" & ")) {
-    const parts = trimmed.split(/\s+&\s+/);
+  const parallelParts = splitOutsideQuotes(trimmed, "&");
+  if (parallelParts.length > 1) {
     return {
       kind: "parallel",
-      cues: parts.map((p, idx) => parseCueLine(p, lineNo + idx * 0.001)),
+      cues: parallelParts.map((p, idx) => parseCueLine(p, lineNo + idx * 0.001)),
       line: lineNo,
     };
   }
 
   if (FLOW_OP_RE.test(trimmed)) {
-    const chainPart = trimmed.split(/\s+(?:dur|stagger|color|strength|zoom|after)=/)[0].trim();
+    const chainPart = stripCueProps(trimmed, ["dur", "stagger", "color", "strength", "zoom", "after"]);
     return {
       kind: "flow",
       segments: parseFlowChain(chainPart, lineNo),
@@ -172,7 +280,7 @@ function parseCueLine(line: string, lineNo: number): Cue {
   const keyword = head.toLowerCase();
 
   if (keyword === "show" || keyword === "hide") {
-    const targetRaw = rest.join(" ").split(/\s+(?:dur|stagger)=/)[0];
+    const targetRaw = stripCueProps(rest.join(" "), ["dur", "stagger"]);
     return {
       kind: keyword,
       targets: splitTargets(targetRaw),
@@ -183,7 +291,7 @@ function parseCueLine(line: string, lineNo: number): Cue {
   }
 
   if (keyword === "glow") {
-    const targetRaw = rest.join(" ").split(/\s+(?:color|strength|dur)=/)[0];
+    const targetRaw = stripCueProps(rest.join(" "), ["color", "strength", "dur"]);
     return {
       kind: "glow",
       targets: splitTargets(targetRaw),
@@ -195,7 +303,7 @@ function parseCueLine(line: string, lineNo: number): Cue {
   }
 
   if (keyword === "focus") {
-    const targetRaw = rest.join(" ").split(/\s+(?:zoom|dur)=/)[0];
+    const targetRaw = stripCueProps(rest.join(" "), ["zoom", "dur"]);
     return {
       kind: "focus",
       targets: splitTargets(targetRaw),
@@ -206,7 +314,7 @@ function parseCueLine(line: string, lineNo: number): Cue {
   }
 
   if (keyword === "frame") {
-    const targetRaw = rest.join(" ").split(/\s+(?:zoom|dur)=/)[0];
+    const targetRaw = stripCueProps(rest.join(" "), ["zoom", "dur"]);
     const targets = splitTargets(targetRaw);
     if (targets.length === 0) throw new ParseError(`expected frame target`, lineNo);
     return {
@@ -324,6 +432,32 @@ function readIndentedBody(blocks: Block[], startIdx: number, parentIndent: numbe
   return { body, nextIdx: i };
 }
 
+function readBody(blocks: Block[], startIdx: number, parentIndent: number, braceDelimited: boolean): { body: Block[]; nextIdx: number } {
+  if (!braceDelimited) return readIndentedBody(blocks, startIdx, parentIndent);
+  const body: Block[] = [];
+  let i = startIdx;
+  while (i < blocks.length) {
+    if (blocks[i].text === "}") return { body, nextIdx: i + 1 };
+    body.push(blocks[i]);
+    i++;
+  }
+  return { body, nextIdx: i };
+}
+
+function normalizeCueBlocks(blocks: Block[]): Block[] {
+  const normalized: Block[] = [];
+  for (const block of blocks) {
+    if (block.text.startsWith("& ")) {
+      const prev = normalized[normalized.length - 1];
+      if (!prev) throw new ParseError(`parallel continuation must follow a cue`, block.line);
+      prev.text = `${prev.text} ${block.text}`;
+      continue;
+    }
+    normalized.push({ ...block });
+  }
+  return normalized;
+}
+
 function pushWarning(diagnostics: Diagnostic[], seen: Set<string>, line: number, message: string): void {
   const key = `${line}:${message}`;
   if (seen.has(key)) return;
@@ -428,6 +562,11 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
         title = str.value;
         remainder = str.rest;
       }
+      const inlineLayout = remainder.match(/\blayout\s+(LR|RL|TB|BT)\b/i);
+      if (inlineLayout) {
+        meta.direction = inlineLayout[1].toUpperCase() as LayoutDirection;
+        remainder = remainder.replace(/\blayout\s+(LR|RL|TB|BT)\b/i, " ");
+      }
       const props = parseProps(remainder);
       for (const [k, v] of Object.entries(props)) {
         if (!SCENE_KEYS.has(k)) {
@@ -437,7 +576,7 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
         if (k === "width" || k === "height" || k === "fps") (meta as Record<string, unknown>)[k] = Number(v);
         else if (k === "duration") meta.duration = Number(v);
         else if (k === "theme") meta.theme = String(v);
-        else if (k === "direction") meta.direction = String(v).toUpperCase() as LayoutDirection;
+        else if (k === "direction" || k === "layout") meta.direction = String(v).toUpperCase() as LayoutDirection;
       }
       i++;
       continue;
@@ -458,11 +597,11 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
     }
 
     if (line.startsWith("pattern ")) {
-      const m = line.match(/^pattern\s+(\w+)\s*\(([^)]*)\)\s*:\s*$/);
+      const m = line.match(/^pattern\s+(\w+)\s*\(([^)]*)\)\s*(?::|\{)\s*$/);
       if (!m) throw new ParseError(`expected pattern name(params):`, lineNo);
       const params = m[2].trim() ? m[2].split(",").map((p) => p.trim()) : [];
-      const { body, nextIdx } = readIndentedBody(blocks, i + 1, block.indent);
-      const cues = body.map((b) => parseCueLine(b.text, b.line));
+      const { body, nextIdx } = readBody(blocks, i + 1, block.indent, line.endsWith("{"));
+      const cues = normalizeCueBlocks(body).map((b) => parseCueLine(b.text, b.line));
       patterns[m[1]] = { name: m[1], params, body: cues, line: lineNo };
       i = nextIdx;
       continue;
@@ -502,10 +641,10 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
     }
 
     if (line.startsWith("beat ")) {
-      const m = line.match(/^beat\s+(\w+)(?:\s+"([^"]*)")?\s*:\s*$/);
+      const m = line.match(/^beat\s+(\w+)(?:\s+"([^"]*)")?\s*(?::|\{)\s*$/);
       if (!m) throw new ParseError(`expected beat name:`, lineNo);
-      const { body, nextIdx } = readIndentedBody(blocks, i + 1, block.indent);
-      let cues = body.map((b) => parseCueLine(b.text, b.line));
+      const { body, nextIdx } = readBody(blocks, i + 1, block.indent, line.endsWith("{"));
+      let cues = normalizeCueBlocks(body).map((b) => parseCueLine(b.text, b.line));
       cues = expandPatternCues(cues, patterns, lineNo);
       beats.push({ name: m[1], label: m[2], cues, line: lineNo });
       i = nextIdx;

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -13,7 +13,7 @@ export const RESERVED_SELECTORS = new Set(["$title", "$nodes", "$edges"]);
 
 export const BEAT_CUE_KEYWORDS = new Set(["show", "hide", "glow", "focus", "frame", "use"]);
 
-export const SCENE_KEYS = new Set(["width", "height", "fps", "theme", "duration", "direction"]);
+export const SCENE_KEYS = new Set(["width", "height", "fps", "theme", "duration", "direction", "layout"]);
 
 export function nodeRole(kind: string): string {
   return (TECHNICAL_NODE_KINDS as Record<string, string>)[kind] ?? "compute";

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -174,4 +174,68 @@ beat main:
     expect(cues[1]).toMatchObject({ kind: "flow", segments: [{ from: "C", to: "D" }] });
     expect(cues[2]).toMatchObject({ kind: "frame", targets: ["E"] });
   });
+
+  it("accepts common AI-generated brace blocks, hash comments, and inline scene layout", () => {
+    const ast = parse(`
+scene "URL Shortener Architecture" width=1280 height=720 fps=60 layout LR theme=midnight
+
+# System Nodes
+client Client "Client / Browser"
+api_gateway Gateway "API Gateway"
+service URLService "URL Shortener Service"
+cache Cache "Redis Cache"
+database DB "Primary Database"
+
+# Beat 1: Initial Reveal
+beat reveal "System Initialization" {
+  show $nodes stagger=60ms
+}
+
+# Beat 2: Write Path (Shortening a URL)
+beat write_path "Write Path: Shorten URL" {
+  Client -> Gateway "POST /api/v1/shorten"
+  Gateway -> URLService "Route request"
+  URLService -> DB "Insert original URL & generate hash"
+  URLService ~> Cache "Async write-through / cache populate"
+  Gateway <- URLService "201 Created (shortCode)"
+  Client <- Gateway "201 Created (https://short.url/xyz)"
+}
+
+# Beat 4: Hot Path Emphasis & Focus
+beat hot_path "Hot Path Optimization" {
+  glow Cache color="#00E5FF" strength=1.5 dur=0.8s
+  & focus Cache zoom=1.15 dur=0.8s
+}
+`);
+
+    expect(ast.meta).toMatchObject({
+      title: "URL Shortener Architecture",
+      width: 1280,
+      height: 720,
+      fps: 60,
+      direction: "LR",
+      theme: "midnight",
+    });
+    expect(ast.diagnostics).toEqual([]);
+    expect(ast.beats.map((beat) => beat.name)).toEqual(["reveal", "write_path", "hot_path"]);
+    const writePath = ast.beats.find((beat) => beat.name === "write_path")!;
+    const dbFlow = writePath.cues
+      .filter(isFlow)
+      .flatMap((cue) => cue.segments)
+      .find((segment) => segment.to === "DB");
+    expect(dbFlow?.label).toBe("Insert original URL & generate hash");
+    const response = writePath.cues
+      .filter(isFlow)
+      .flatMap((cue) => cue.segments)
+      .find((segment) => segment.to === "Client");
+    expect(response?.label).toBe("201 Created (https://short.url/xyz)");
+    const hotPath = ast.beats.find((beat) => beat.name === "hot_path")!;
+    expect(hotPath.cues[0]).toMatchObject({
+      kind: "parallel",
+      cues: [
+        { kind: "glow", targets: ["Cache"], color: "#00E5FF", strength: 1.5, dur: 0.8 },
+        { kind: "focus", targets: ["Cache"], zoom: 1.15, dur: 0.8 },
+      ],
+    });
+  });
 });

--- a/website/src/pages/blog/ai-generated-architecture-diagrams.astro
+++ b/website/src/pages/blog/ai-generated-architecture-diagrams.astro
@@ -59,12 +59,13 @@ const structuredData = [
   <h2>How to prompt for a Markdy diagram</h2>
   <p>
     Point the model at the <a href="https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md" target="_blank" rel="noopener noreferrer">Markdy agent guide</a>
-    (grammar, node kinds, examples) and describe the system in plain English:
+    (grammar, node kinds, examples), then describe the system in plain English. You should not need to mention
+    Markdy cue names, node kinds, or flow operators:
   </p>
   <blockquote>
-    Use the Markdy agent guide. Create a 1280×720 animated architecture diagram for a URL shortener. Use semantic
-    node kinds, beats, labeled flow edges (<code>-&gt;</code>, <code>&lt;-</code>, <code>~&gt;</code>), short labels,
-    and a final <code>glow</code> on the hot path.
+    Use the Markdy agent guide to write one complete MarkdyScript scene. I want to explain a URL shortener to my
+    engineering team: first a user creates a short link, then someone opens that short link and gets redirected.
+    Include the API, URL service, Redis cache, and database. Make it clear enough for a short demo.
   </blockquote>
   <p>You get back a complete, runnable scene:</p>
   <pre><code>scene "URL Shortener" theme=paper

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -905,7 +905,7 @@ beat finish:
           </li>
           <li>
             <strong>Describe your scene in plain English</strong>
-            <p>Tell the AI what you want to visualize: architecture flows, product steps, training scenarios, or tutorial sequences.</p>
+            <p>Tell the AI the story you want to explain. You do not need to know node kinds, cue names, or flow operators.</p>
           </li>
           <li>
             <strong>Get valid MarkdyScript back</strong>
@@ -921,12 +921,12 @@ beat finish:
             <span class="ai-prompt-label">You → Claude / ChatGPT / Copilot</span>
           </div>
           <blockquote class="ai-prompt-text">
-            Use <code>https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md</code> as a complete reference (grammar, actions, patterns, examples), then write a Markdy scene:
+            Use <code>https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md</code> to turn this idea into one complete, valid MarkdyScript scene:
             <br /><br />
-            <em>"Create a presentation-quality 1280x720, 60fps system architecture diagram for a URL shortener. Use systems nodes like <code>client</code>, <code>api_gateway</code>, <code>service</code>, <code>cache</code>, and <code>database</code>; set <code>layout LR</code> so auto-layout spreads them left→right; reveal them with <code>show $nodes stagger=60ms</code>; then narrate the write path and read/redirect path across named <code>beat</code> blocks using labeled <code>-&gt;</code>, <code>&lt;-</code>, and <code>~&gt;</code> flow edges; finish with a <code>glow</code> on the hot path and a <code>focus</code> on the cache."</em>
+            <em>"I run a URL shortener. Show how a user creates a short link, then how another user opens that short link and gets redirected. Include the API, URL service, Redis cache, and database. Make it presentation-friendly for a short engineering demo, with clear steps and attention on the fast cache path."</em>
           </blockquote>
         </div>
-        <p class="ai-hint">The AI reads the docs, understands the grammar, and outputs a complete <code>.markdy</code> scene with nodes, groups, routed flow edges, and beat-by-beat choreography — ready to render.</p>
+        <p class="ai-hint">The AI reads the agent guide, chooses the right Markdy node kinds, beats, frame cues, and flow operators, then outputs a complete <code>.markdy</code> scene — ready to paste into the playground.</p>
       </div>
     </div>
 

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -753,7 +753,7 @@ const playgroundStructuredData = [
     display: grid;
     grid-template-columns: minmax(360px, var(--editor-pane, 50%)) 14px minmax(420px, 1fr);
     gap: 0.75rem;
-    align-items: stretch;
+    align-items: start;
     width: 100%;
     max-width: none;
     margin: 0;
@@ -882,6 +882,16 @@ const playgroundStructuredData = [
   .preview-panel {
     min-width: 0;
     padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .preview-panel {
+    position: sticky;
+    top: 1rem;
+    max-height: calc(100vh - 2rem);
+    z-index: 2;
   }
 
   .splitter {
@@ -929,7 +939,8 @@ const playgroundStructuredData = [
   }
 
   .code-editor {
-    min-height: min(68vh, 760px);
+    height: clamp(560px, calc(100vh - 14rem), 920px);
+    min-height: 0;
     overflow: hidden;
     border: 1px solid var(--border);
     border-radius: 1rem;
@@ -937,11 +948,14 @@ const playgroundStructuredData = [
   }
 
   :global(.code-editor .cm-editor) {
-    min-height: min(68vh, 760px);
+    height: 100%;
+    min-height: 0;
   }
 
   :global(.code-editor .cm-scroller) {
-    min-height: min(68vh, 760px);
+    height: 100%;
+    min-height: 0;
+    overflow: auto;
   }
 
   .hint {
@@ -982,7 +996,8 @@ const playgroundStructuredData = [
   }
 
   .stage {
-    min-height: min(68vh, 760px);
+    height: clamp(420px, calc(100vh - 15.25rem), 820px);
+    min-height: 0;
     display: grid;
     place-items: center;
     overflow: auto;
@@ -1090,7 +1105,13 @@ const playgroundStructuredData = [
 
     .stage,
     .code-editor {
+      height: auto;
       min-height: 58vh;
+    }
+
+    .preview-panel {
+      position: static;
+      max-height: none;
     }
 
     .learn-card .snippet-list,


### PR DESCRIPTION
## Summary
- accept common LLM-generated syntax variants: hash comments, brace beat blocks, inline scene layout, quoted props, and leading parallel continuations
- simplify public AI prompt examples to be human idea-first instead of Markdy-term-heavy
- keep the playground preview sticky while the editor scrolls internally

## Validation
- pnpm run ci
- pnpm run typecheck
- pnpm --filter @markdy/website build