### PR TITLE
fix: diagnose unsupported ai syntax and simplify prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Human-first AI prompt examples** — Simplified public AI prompt examples so users describe the diagram idea in natural language while the agent guide handles Markdy-specific syntax choices.
 
 ### Fixed
+- **Unsupported AI syntax diagnostics** — Non-Markdy drawing, timeline, and imperative camera output now fails with actionable guidance instead of misleading node-kind errors.
 - **AI-generated syntax tolerance** — The parser now accepts common LLM variants such as `#` comments, quote-safe `//` handling inside URLs, brace-delimited beat/pattern blocks, inline scene layout, quoted property values, and leading-`&` parallel cue continuations.
 - **Playground editor/preview visibility** — The dedicated playground editor now scrolls internally while the preview pane stays sticky beside it, so authors can keep watching the animation while typing longer MarkdyScript scenes.
 

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -10,7 +10,22 @@ MarkdyScript 0.8 is **diagram-native**: you declare nodes, groups, and beats, an
 - Default theme is `paper`; default layout direction is `LR`.
 - Keep flow labels short (≤ ~28 chars) so they stay readable.
 - Use beat labels and `frame` when the scene should guide attention through a large diagram.
-- Canonical blocks use `beat name "Label":` with indented cues. The parser also accepts `{ ... }` beat/pattern blocks and `#` comments because many LLMs generate them, but prefer the canonical colon style in final docs.
+- Canonical blocks use `beat name "Label":` with indented cues. The parser also accepts `{ ... }` beat/pattern blocks and `#` comments for compatibility, but prefer the canonical colon style in final docs.
+
+## Translate plain-English ideas into Markdy
+
+When the user describes an idea, infer a clean architecture scene and output one complete `.markdy` file. Do not require the user to know Markdy terms.
+
+| User asks for... | Generate MarkdyScript as... |
+|---|---|
+| people, browser, visitor | `user`, `client`, or `browser` nodes |
+| API gateway / service / cache / database | `gateway`, `service`, `cache`, `database` nodes |
+| steps, chapters, phases | multiple `beat name "Caption":` blocks |
+| camera zoom / focus on part of the system | `frame groupOrNodes zoom=...` |
+| emphasis / highlight | `glow target color=#...` or `focus target` |
+| messages, API calls, redirects | flow lines with `->`, `<-`, `~>` |
+
+If the user prompt is broad, choose sensible nodes, split the story into 3–5 labeled beats, keep labels short, and output only the completed scene unless asked for explanation.
 
 ## Minimal example
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -45,3 +45,11 @@ Check that package versions are aligned, assets are reachable, the container exi
 
 Give the model `docs/AGENT.md` and ask it to fix the exact line number, keep all nodes declared before flows, use only documented cues and flow operators, and shorten labels.
 
+If the model generates manual drawing, timestamp timeline, or imperative camera commands, ask it to translate the idea into Markdy 0.8:
+
+- one `scene` line
+- architecture nodes such as `browser`, `gateway`, `service`, `cache`, and `database`
+- multiple `beat name "Caption":` blocks
+- `frame` for camera-like attention
+- `glow` / `focus` for emphasis
+- flow lines with `->`, `<-`, `~>`

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -257,6 +257,13 @@ function parseCueLine(line: string, lineNo: number): Cue {
   const trimmed = line.trim();
   const props = parseProps(trimmed);
 
+  if (/^@\+?\d/.test(trimmed) || /^\w[\w.-]*\.\w+\(/.test(trimmed) || /^camera\./.test(trimmed)) {
+    throw new ParseError(
+      "unsupported timeline command; use beat cues like show, frame, focus, glow, and flow lines",
+      lineNo,
+    );
+  }
+
   const parallelParts = splitOutsideQuotes(trimmed, "&");
   if (parallelParts.length > 1) {
     return {
@@ -458,6 +465,22 @@ function normalizeCueBlocks(blocks: Block[]): Block[] {
   return normalized;
 }
 
+function unsupportedSyntaxMessage(line: string): string | null {
+  if (/^var\s+/.test(line)) {
+    return "unsupported variable declaration; use scene properties and style declarations instead";
+  }
+  if (/^actor\s+/.test(line) || /\bfigure\s*\(/.test(line) || /\bbox\s*\(/.test(line) || /\bat\s*\(/.test(line)) {
+    return "unsupported manual drawing syntax; declare architecture nodes like service API, cache Redis, and database DB";
+  }
+  if (/^@\+?\d/.test(line)) {
+    return "unsupported timeline command; put flow and cue lines inside beat blocks";
+  }
+  if (/^camera\./.test(line)) {
+    return "unsupported camera command; use frame NodeOrGroup zoom=... inside a beat";
+  }
+  return null;
+}
+
 function pushWarning(diagnostics: Diagnostic[], seen: Set<string>, line: number, message: string): void {
   const key = `${line}:${message}`;
   if (seen.has(key)) return;
@@ -554,8 +577,14 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
     const line = block.text;
     const lineNo = block.line;
 
+    const unsupportedMessage = unsupportedSyntaxMessage(line);
+    if (unsupportedMessage) throw new ParseError(unsupportedMessage, lineNo);
+
     if (line.startsWith("scene")) {
       const rest = line.slice(5).trim();
+      if (line.endsWith("{")) {
+        throw new ParseError(`nested scene blocks are not supported; use one scene with multiple beat blocks`, lineNo);
+      }
       let remainder = rest;
       const str = parseStringToken(rest);
       if (str) {

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -238,4 +238,29 @@ beat hot_path "Hot Path Optimization" {
       ],
     });
   });
+
+  it("rejects unsupported drawing/timeline syntax with actionable guidance", () => {
+    expect(() => parse(`
+scene width=1000 height=520
+var bg_color = "#0f172a"
+`)).toThrow("unsupported variable declaration");
+
+    expect(() => parse(`
+scene width=1000 height=520
+actor Alice = figure(#ffdbac, f, "dev") at (80, 200)
+`)).toThrow("unsupported manual drawing syntax");
+
+    expect(() => parse(`
+scene "Legacy Chapter" {
+  @0.0: header.say("Step 1")
+}
+`)).toThrow("nested scene blocks are not supported");
+
+    expect(() => parse(`
+scene "Demo"
+service API
+beat main:
+  @+1.0: camera.pan(to=(500, 260), dur=1.0)
+`)).toThrow("unsupported timeline command");
+  });
 });

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -921,9 +921,9 @@ beat finish:
             <span class="ai-prompt-label">You → Claude / ChatGPT / Copilot</span>
           </div>
           <blockquote class="ai-prompt-text">
-            Use <code>https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md</code> to turn this idea into one complete, valid MarkdyScript scene:
+            Follow <code>https://github.com/HoangYell/markdy-com/blob/main/docs/AGENT.md</code> and return one complete MarkdyScript scene:
             <br /><br />
-            <em>"I run a URL shortener. Show how a user creates a short link, then how another user opens that short link and gets redirected. Include the API, URL service, Redis cache, and database. Make it presentation-friendly for a short engineering demo, with clear steps and attention on the fast cache path."</em>
+            <em>"Animate a URL shortener: a user creates a short link, then another user opens it and gets redirected via the API, cache, and database. Use beats for each step and highlight the fast cache path."</em>
           </blockquote>
         </div>
         <p class="ai-hint">The AI reads the agent guide, chooses the right Markdy node kinds, beats, frame cues, and flow operators, then outputs a complete <code>.markdy</code> scene — ready to paste into the playground.</p>


### PR DESCRIPTION
## Summary
- reject non-Markdy drawing/timeline/camera commands with actionable parser errors
- keep the agent guide positive-only so prompts do not seed old syntax
- make the homepage example prompt more concise while staying effective for AI generation

## Validation
- pnpm run ci
- pnpm run typecheck
- pnpm --filter @markdy/website build