### PR TITLE
feat: broaden ai-friendly markdy syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`var` named constants** — Top-level `var name = value` declarations (colors, durations, etc.) can be referenced with `$name` and are substituted deterministically at parse time, so AI-generated scenes that reach for color variables now work.
+- **Multi-line group members** — `group name:` can list members on indented lines in addition to the inline `group name: A B C` form.
+- **Natural cue synonyms** — `pulse`, `highlight`, and `emphasize` are accepted and map to `focus`/`glow`, so common AI emphasis verbs produce valid scenes.
+
+### Fixed
+- **Flow labels with arrows** — Flow labels containing `->`, `<-`, `~>`, or `--` (for example `"STORE key -> value"`) no longer break the flow-chain parser; operators inside quoted labels are ignored when splitting.
+- **Hash comments vs hex colors** — `#` only starts a comment in the conventional `# text` form, so bare hex values like `var c = #3b82f6` are no longer mistaken for comments.
+- **Clearer AI-syntax errors** — `camera ...` statements and unknown cues now report actionable messages (pointing to `frame` and the valid cue list), and beat names may include digits/dots so timestamp-style names parse.
+
 ## [0.8.8] — 2026-08-09
 
 ### Changed

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -67,6 +67,21 @@ scene "Title" theme=paper width=1280 height=720 fps=60 duration=8
 layout LR   # LR (default), RL, TB, BT
 ```
 
+### `var` — named constants (optional)
+
+Declare reusable values (colors, durations) and reference them with `$name`. Substitution happens at parse time, so it stays deterministic.
+
+```markdy
+var hot = "#a6e3a1"
+var cool = #3b82f6
+
+beat main:
+  glow Redis color=$hot
+  glow DB color=$cool
+```
+
+Var names must not shadow reserved selectors (`nodes`, `title`, `edges`).
+
 ### Node declaration
 
 ```markdy
@@ -90,6 +105,14 @@ group storage: DB Redis
 group storage "Storage tier": DB Redis   # optional label
 ```
 
+Members may also be listed on indented lines:
+
+```markdy
+group storage "Storage tier":
+  DB
+  Redis
+```
+
 Target a group anywhere a node id is accepted (`show storage`, `glow storage`).
 
 ### `style` — reusable node styling
@@ -101,7 +124,7 @@ database Primary "Primary DB" style=hot
 
 ### `beat` — a named block of cues
 
-Cues inside a beat are scheduled in order. Beats run one after another.
+Cues inside a beat are scheduled in order. Beats run one after another. Beats are **sequential, not timestamped** — do not try to set absolute start times; ordering and cue durations determine timing. Use a short word name plus an optional caption label.
 
 ```markdy
 beat checkout "Process checkout":
@@ -147,6 +170,8 @@ You may put `&` at the start of the next line as a continuation when an AI gener
 | `focus` | `zoom`, `dur` | Pulse-scale a node to draw attention |
 | `frame` | `zoom`, `dur` | Move the scene camera to a node or group (`frame $nodes` resets to the whole diagram) |
 | `use` | pattern args | Expand a `pattern` |
+
+This is the **complete** cue set — do not invent others (no `pulse`, `caption`, `dim`, `trail`, `camera`, `shake`, `say`, `walk`, …). Natural synonyms `pulse`, `highlight`, and `emphasize` are accepted and map to `focus`/`glow`. For attention use `frame`; for emphasis use `glow`/`focus`; to de-emphasize, reveal the important node with `glow` rather than dimming others.
 
 Selectors: `$nodes` targets every node; a group name targets its members.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export {
   NODE_KINDS,
   EDGE_OPERATORS,
   NODE_ALIASES,
+  CUE_ALIASES,
   BEAT_CUE_KEYWORDS,
   SCENE_KEYS,
   canonicalNodeKind,

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -20,6 +20,7 @@ import type {
 import {
   BEAT_CUE_KEYWORDS,
   canonicalNodeKind,
+  CUE_ALIASES,
   EDGE_OPERATORS,
   humanizeId,
   NODE_KINDS,
@@ -72,7 +73,15 @@ function stripComment(line: string): string {
     }
     if (inString) continue;
     if (ch === "/" && line[i + 1] === "/") return line.slice(0, i);
-    if (ch === "#" && (i === 0 || /\s/.test(line[i - 1]))) return line.slice(0, i);
+    // `#` starts a comment only in the conventional `# text` form (space/EOL
+    // after it), so bare hex colors like `= #3b82f6` are never eaten.
+    if (
+      ch === "#" &&
+      (i === 0 || /\s/.test(line[i - 1])) &&
+      (i + 1 >= line.length || /\s/.test(line[i + 1]))
+    ) {
+      return line.slice(0, i);
+    }
   }
   return line;
 }
@@ -210,9 +219,42 @@ function stripCueProps(raw: string, keys: string[]): string {
   return raw.trim();
 }
 
+function tokenizeFlowChain(line: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inString) {
+      current += ch;
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      current += ch;
+      continue;
+    }
+    const op = line.slice(i, i + 2);
+    if (op === "->" || op === "<-" || op === "~>" || op === "--") {
+      if (current.trim()) parts.push(current.trim());
+      parts.push(op);
+      current = "";
+      i += 1;
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) parts.push(current.trim());
+  return parts;
+}
+
 function parseFlowChain(line: string, lineNo: number): FlowSegment[] {
   const segments: FlowSegment[] = [];
-  const parts = line.split(FLOW_OP_RE).map((p) => p.trim()).filter(Boolean);
+  const parts = tokenizeFlowChain(line);
   if (parts.length < 3) {
     throw new ParseError(`expected flow chain like A -> B "label"`, lineNo);
   }
@@ -284,7 +326,8 @@ function parseCueLine(line: string, lineNo: number): Cue {
   }
 
   const [head, ...rest] = trimmed.split(/\s+/);
-  const keyword = head.toLowerCase();
+  const rawKeyword = head.toLowerCase();
+  const keyword = CUE_ALIASES[rawKeyword] ?? rawKeyword;
 
   if (keyword === "show" || keyword === "hide") {
     const targetRaw = stripCueProps(rest.join(" "), ["dur", "stagger"]);
@@ -353,7 +396,7 @@ function parseCueLine(line: string, lineNo: number): Cue {
     return { kind: "use", pattern: m[1], args, line: lineNo };
   }
 
-  throw new ParseError(`unknown cue '${head}'`, lineNo);
+  throw new ParseError(`unknown cue '${head}'; use show, hide, glow, focus, frame, or use`, lineNo);
 }
 
 function expandPatternCues(cues: Cue[], patterns: Record<string, PatternDecl>, line: number): Cue[] {
@@ -466,19 +509,56 @@ function normalizeCueBlocks(blocks: Block[]): Block[] {
 }
 
 function unsupportedSyntaxMessage(line: string): string | null {
-  if (/^var\s+/.test(line)) {
-    return "unsupported variable declaration; use scene properties and style declarations instead";
-  }
   if (/^actor\s+/.test(line) || /\bfigure\s*\(/.test(line) || /\bbox\s*\(/.test(line) || /\bat\s*\(/.test(line)) {
     return "unsupported manual drawing syntax; declare architecture nodes like service API, cache Redis, and database DB";
   }
   if (/^@\+?\d/.test(line)) {
     return "unsupported timeline command; put flow and cue lines inside beat blocks";
   }
-  if (/^camera\./.test(line)) {
+  if (/^camera\b/.test(line)) {
     return "unsupported camera command; use frame NodeOrGroup zoom=... inside a beat";
   }
   return null;
+}
+
+const RESERVED_VAR_NAMES = new Set(["nodes", "title", "edges"]);
+
+/**
+ * Pulls top-level `var name = value` declarations out of the block stream so
+ * their `$name` references can be substituted before parsing. Keeps AI-friendly
+ * named constants (colors, durations) DRY without a runtime.
+ */
+function extractVars(blocks: Block[], diagnostics: Diagnostic[]): { vars: Map<string, string>; rest: Block[] } {
+  const vars = new Map<string, string>();
+  const rest: Block[] = [];
+  for (const block of blocks) {
+    if (!/^var\b/.test(block.text)) {
+      rest.push(block);
+      continue;
+    }
+    const m = block.text.match(/^var\s+([A-Za-z_]\w*)\s*=\s*(.+)$/);
+    if (!m) throw new ParseError("expected var name = value", block.line);
+    const name = m[1];
+    if (RESERVED_VAR_NAMES.has(name)) {
+      diagnostics.push({ severity: "warning", message: `var '${name}' shadows a reserved selector and was ignored`, line: block.line });
+      continue;
+    }
+    const raw = m[2].trim();
+    const str = parseStringToken(raw);
+    vars.set(name, str && str.rest === "" ? str.value : raw);
+  }
+  return { vars, rest };
+}
+
+function applyVars(blocks: Block[], vars: Map<string, string>): Block[] {
+  if (vars.size === 0) return blocks;
+  return blocks.map((block) => {
+    let text = block.text;
+    for (const [name, value] of vars) {
+      text = text.replace(new RegExp(`\\$${name}(?![\\w])`, "g"), value);
+    }
+    return { ...block, text };
+  });
 }
 
 function pushWarning(diagnostics: Diagnostic[], seen: Set<string>, line: number, message: string): void {
@@ -569,7 +649,9 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
   let title = "";
   let edgeCounter = 0;
 
-  const blocks = readBlocks(lines.map(stripComment));
+  const rawBlocks = readBlocks(lines.map(stripComment));
+  const { vars, rest } = extractVars(rawBlocks, diagnostics);
+  const blocks = applyVars(rest, vars);
   let i = 0;
 
   while (i < blocks.length) {
@@ -637,16 +719,32 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
     }
 
     if (line.startsWith("group ")) {
-      const m = line.match(/^group\s+(\w+)(?:\s+"([^"]*)")?\s*:\s*(.+)$/);
-      if (!m) throw new ParseError(`expected group name: A B C`, lineNo);
-      groups[m[1]] = {
-        id: m[1],
-        label: m[2],
-        members: splitTargets(m[3]),
+      const inline = line.match(/^group\s+(\w+)(?:\s+"([^"]*)")?\s*:\s*(.+)$/);
+      if (inline) {
+        groups[inline[1]] = {
+          id: inline[1],
+          label: inline[2],
+          members: splitTargets(inline[3]),
+          props: {},
+          line: lineNo,
+        };
+        i++;
+        continue;
+      }
+      // Multi-line form: `group name ["Label"]:` followed by indented members.
+      const header = line.match(/^group\s+(\w+)(?:\s+"([^"]*)")?\s*:\s*$/);
+      if (!header) throw new ParseError(`expected group name: A B C`, lineNo);
+      const { body, nextIdx } = readIndentedBody(blocks, i + 1, block.indent);
+      const members = body.flatMap((b) => splitTargets(b.text));
+      if (members.length === 0) throw new ParseError(`group '${header[1]}' has no members`, lineNo);
+      groups[header[1]] = {
+        id: header[1],
+        label: header[2],
+        members,
         props: {},
         line: lineNo,
       };
-      i++;
+      i = nextIdx;
       continue;
     }
 
@@ -670,7 +768,7 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
     }
 
     if (line.startsWith("beat ")) {
-      const m = line.match(/^beat\s+(\w+)(?:\s+"([^"]*)")?\s*(?::|\{)\s*$/);
+      const m = line.match(/^beat\s+([\w.-]+)(?:\s+"([^"]*)")?\s*(?::|\{)\s*$/);
       if (!m) throw new ParseError(`expected beat name:`, lineNo);
       const { body, nextIdx } = readBody(blocks, i + 1, block.indent, line.endsWith("{"));
       let cues = normalizeCueBlocks(body).map((b) => parseCueLine(b.text, b.line));

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -11,7 +11,22 @@ export const EDGE_OPERATORS: Record<string, "request" | "response" | "event" | "
 
 export const RESERVED_SELECTORS = new Set(["$title", "$nodes", "$edges"]);
 
-export const BEAT_CUE_KEYWORDS = new Set(["show", "hide", "glow", "focus", "frame", "use"]);
+/** Natural-language cue synonyms that AIs reach for, mapped to real cues. */
+export const CUE_ALIASES: Record<string, string> = {
+  pulse: "focus",
+  highlight: "glow",
+  emphasize: "glow",
+};
+
+export const BEAT_CUE_KEYWORDS = new Set([
+  "show",
+  "hide",
+  "glow",
+  "focus",
+  "frame",
+  "use",
+  ...Object.keys(CUE_ALIASES),
+]);
 
 export const SCENE_KEYS = new Set(["width", "height", "fps", "theme", "duration", "direction", "layout"]);
 

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -102,6 +102,27 @@ cdn CdnEdge
     expect(response).toMatchObject({ from: "UrlShortener", to: "WebClient", label: "short.ly/a7" });
   });
 
+  it("keeps flow operators inside quoted labels out of the chain split", () => {
+    const ast = parse(`
+scene "Arrows in labels" theme=midnight
+layout LR
+service API
+database DB
+
+beat main:
+  API -> DB "STORE xyz123 -> long URL"
+  API <- DB "301 -> redirect"
+  API -> DB "a -> b" -> DB "next"
+`);
+    const beat = ast.beats[0];
+    const segments = beat.cues.filter(isFlow).flatMap((c) => c.segments);
+    expect(ast.diagnostics).toEqual([]);
+    expect(segments[0]).toMatchObject({ from: "API", op: "request", to: "DB", label: "STORE xyz123 -> long URL" });
+    expect(segments[1]).toMatchObject({ from: "DB", op: "response", to: "API", label: "301 -> redirect" });
+    expect(segments[2]).toMatchObject({ from: "API", op: "request", to: "DB", label: "a -> b" });
+    expect(segments[3]).toMatchObject({ from: "DB", op: "request", to: "DB", label: "next" });
+  });
+
   it("only references declared nodes in compiled flow cues", () => {
     const plan = compile(parse(URL_SHORTENER));
     const nodeIds = new Set(plan.nodes.map((n) => n.id));
@@ -242,11 +263,6 @@ beat hot_path "Hot Path Optimization" {
   it("rejects unsupported drawing/timeline syntax with actionable guidance", () => {
     expect(() => parse(`
 scene width=1000 height=520
-var bg_color = "#0f172a"
-`)).toThrow("unsupported variable declaration");
-
-    expect(() => parse(`
-scene width=1000 height=520
 actor Alice = figure(#ffdbac, f, "dev") at (80, 200)
 `)).toThrow("unsupported manual drawing syntax");
 
@@ -262,5 +278,87 @@ service API
 beat main:
   @+1.0: camera.pan(to=(500, 260), dur=1.0)
 `)).toThrow("unsupported timeline command");
+  });
+
+  it("supports var declarations with $name substitution", () => {
+    const ast = parse(`
+scene "Vars" theme=midnight
+var hot = "#a6e3a1"
+var cool = #3b82f6
+
+service API
+cache Redis
+database DB
+
+beat main:
+  show $nodes
+  API -> Redis "lookup"
+  glow Redis color=$hot & focus Redis
+  glow DB color=$cool
+`);
+    expect(ast.diagnostics).toEqual([]);
+    const cues = ast.beats[0].cues;
+    const parallel = cues.find((c) => c.kind === "parallel") as Extract<Cue, { kind: "parallel" }>;
+    const glowHot = parallel.cues.find((c) => c.kind === "glow") as Extract<Cue, { kind: "glow" }>;
+    expect(glowHot.color).toBe("#a6e3a1");
+    const glowCool = cues.find((c) => c.kind === "glow" && c.color === "#3b82f6");
+    expect(glowCool).toBeTruthy();
+  });
+
+  it("maps natural emphasis synonyms to real cues", () => {
+    const ast = parse(`
+scene "Aliases" theme=midnight
+service API
+cache Redis
+
+beat main:
+  pulse API
+  highlight Redis color=#22c55e
+  emphasize API
+`);
+    expect(ast.diagnostics).toEqual([]);
+    const cues = ast.beats[0].cues;
+    expect(cues[0]).toMatchObject({ kind: "focus", targets: ["API"] });
+    expect(cues[1]).toMatchObject({ kind: "glow", targets: ["Redis"], color: "#22c55e" });
+    expect(cues[2]).toMatchObject({ kind: "glow", targets: ["API"] });
+  });
+
+  it("supports multi-line group members", () => {
+    const ast = parse(`
+scene "Groups" theme=midnight
+user Creator
+browser Web
+service API
+database DB
+
+group client:
+  Creator Web
+
+group backend "Backend tier":
+  API
+  DB
+
+beat main:
+  show client
+  show backend
+`);
+    expect(ast.diagnostics).toEqual([]);
+    expect(ast.groups.client.members).toEqual(["Creator", "Web"]);
+    expect(ast.groups.backend.members).toEqual(["API", "DB"]);
+    expect(ast.groups.backend.label).toBe("Backend tier");
+  });
+
+  it("warns and ignores a var that shadows a reserved selector", () => {
+    const ast = parse(`
+scene "Shadow" theme=midnight
+var nodes = "#fff"
+service API
+
+beat main:
+  show $nodes
+`);
+    expect(ast.diagnostics.some((d) => d.message.includes("reserved selector"))).toBe(true);
+    // The var was ignored, so `$nodes` stays the all-nodes selector (not "#fff").
+    expect(ast.beats[0].cues[0]).toMatchObject({ kind: "show", targets: ["$nodes"] });
   });
 });

--- a/packages/markdy-language-server/src/index.ts
+++ b/packages/markdy-language-server/src/index.ts
@@ -23,6 +23,7 @@ const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
 const KEYWORDS = [
   "scene",
   "layout",
+  "var",
   "group",
   "beat",
   "style",
@@ -50,7 +51,7 @@ function extractNodes(text: string): Array<{ name: string; kind: string; line: n
     const raw = lines[i].trim();
     const m = /^(\w[\w.-]*)\s+(\w[\w.-]*)/.exec(raw);
     if (!m) continue;
-    if (["scene", "layout", "group", "beat", "style", "pattern", "edge", "use"].includes(m[1])) continue;
+    if (["scene", "layout", "var", "group", "beat", "style", "pattern", "edge", "use"].includes(m[1])) continue;
     if (NODE_KINDS.has(m[1].toLowerCase())) {
       nodes.push({ kind: m[1], name: m[2], line: i });
     }


### PR DESCRIPTION
## Summary
- add `var name = value` named constants with `$name` substitution (deterministic, parse-time)
- add multi-line `group` members
- add `pulse`/`highlight`/`emphasize` cue synonyms mapping to focus/glow
- fix flow labels containing arrows (`"STORE key -> value"`)
- fix `#`-comment vs bare hex color conflict
- clearer errors for `camera`, unknown cues, and timestamp-style beat names
- tightened AGENT.md (beats are sequential; closed cue set)

## Validation
- pnpm run ci
- pnpm run typecheck
- pnpm --filter @markdy/website build