### PR TITLE
website: improve SEO and analytics disclosures

### DIFF
--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -143,8 +143,6 @@ const jsonLd = {
     <noscript>
       <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
     </noscript>
-    <script src="https://code.iconify.design/3/3.1.0/iconify.min.js" defer></script>
-
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -136,6 +136,13 @@ const PROMOTION_LINKS = [
   { label: "Read the agent guide", href: "/agent/", desc: "Give AI tools the current hosted grammar and cue reference." },
 ] as const;
 
+const FEATURED_ARTICLES = [
+  { href: "/blog/diagram-as-code-guide/", label: "Diagram-as-code guide" },
+  { href: "/blog/markdy-vs-mermaid/", label: "Markdy vs Mermaid" },
+  { href: "/blog/system-design-diagrams/", label: "System design use case" },
+  { href: "/blog/markdy-playground/", label: "Playground walkthrough" },
+] as const;
+
 const homepageStructuredData = [
   {
     "@type": "WebPage",
@@ -180,6 +187,17 @@ const homepageStructuredData = [
       position: index + 1,
       name: item.title,
       description: item.desc,
+    })),
+  },
+  {
+    "@type": "ItemList",
+    "@id": "https://markdy.com/#featured-articles",
+    name: "Featured Markdy articles",
+    itemListElement: FEATURED_ARTICLES.map((article, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: `https://markdy.com${article.href}`,
+      name: article.label,
     })),
   },
 ];
@@ -299,6 +317,17 @@ markdy <span class="u-fn">check-all</span> examples`;
       <a href="/playground/" class="btn-primary">Try the Playground</a>
       <a href="#learn" class="btn-secondary">Learn the Syntax</a>
     </div>
+    <p class="hero-crawl-links" aria-label="Featured articles">
+      <span>Featured guides:</span>
+      {FEATURED_ARTICLES.map((article, index) => (
+        <>
+          {index > 0 && <span aria-hidden="true"> · </span>}
+          <a href={article.href}>{article.label}</a>
+        </>
+      ))}
+      <span aria-hidden="true"> · </span>
+      <a href="/blog/">All articles</a>
+    </p>
 
     <!-- ─── Usage tabs ──────────────────────────────────────────────── -->
     <div class="usage-section">
@@ -1038,7 +1067,7 @@ beat finish:
       <div class="footer-bottom">
         <span>MIT License</span>
         <span class="dot">&middot;</span>
-        <a href="/privacy">Privacy Policy</a>
+        <a href="/privacy/">Privacy Policy</a>
         <span class="dot">&middot;</span>
         <span>Built by <a href="https://hoangyell.com" target="_blank" rel="noopener noreferrer">Hoang Yell</a></span>
       </div>
@@ -1405,9 +1434,6 @@ beat finish:
       setTimeline(diagram.currentTime(), diagram.duration());
       populateSceneJump(diagram.beats());
       setStatus(true);
-      if ((window as any).Iconify) {
-        (window as any).Iconify.scan(stage);
-      }
       resizeStage();
     } catch (e) {
       const msg = (e as Error).message ?? String(e);
@@ -1904,6 +1930,25 @@ beat finish:
     justify-content: center;
     gap: 0.75rem;
     flex-wrap: wrap;
+  }
+
+  .hero-crawl-links {
+    margin: 1rem auto 0;
+    max-width: 680px;
+    color: var(--text-secondary);
+    font-size: 0.88rem;
+    line-height: 1.6;
+  }
+
+  .hero-crawl-links a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+  }
+
+  .hero-crawl-links a:hover {
+    text-decoration: underline;
+    text-underline-offset: 2px;
   }
 
   .btn-primary {
@@ -3261,6 +3306,7 @@ beat finish:
     .hero { padding: 3rem 1rem 1.75rem; }
     .hero h1 { font-size: 2rem; line-height: 1.06; }
     .hero-sub { font-size: 0.95rem; line-height: 1.6; margin-bottom: 1.5rem; }
+    .hero-crawl-links { font-size: 0.8rem; margin-top: 0.85rem; }
     .usage-section { max-width: none; }
     .usage-tabs { overflow-x: auto; scrollbar-width: none; }
     .usage-tabs::-webkit-scrollbar { display: none; }
@@ -3345,6 +3391,12 @@ beat finish:
       align-items: stretch;
       max-width: 320px;
       margin: 0 auto;
+    }
+    .hero-crawl-links {
+      font-size: 0.74rem;
+      line-height: 1.5;
+      max-width: 340px;
+      margin-top: 0.75rem;
     }
     .btn-primary,
     .btn-secondary {

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -4,15 +4,15 @@ import Layout from '../layouts/Layout.astro';
 
 <Layout
   title="Privacy Policy — Markdy"
-  description="Privacy policy, local storage disclosures, and playground data handling for the Markdy documentation and animated diagram playground."
+  description="Privacy policy, Cloudflare Web Analytics disclosure, local storage details, and playground data handling for the Markdy documentation and animated diagram playground."
   canonicalURL="https://markdy.com/privacy/"
-  keywords="Markdy privacy, playground privacy, open-source documentation privacy, local storage disclosure"
+  keywords="Markdy privacy, Cloudflare Web Analytics, playground privacy, open-source documentation privacy, local storage disclosure"
 >
   <div class="legal-container">
     <div class="legal-content">
       <a href="/" class="back-link">← Back to Markdy</a>
       <h1>Privacy Policy</h1>
-      <p class="last-updated">Last Updated: April 2026</p>
+      <p class="last-updated">Last Updated: August 2026</p>
 
       <section>
         <h2>1. Overview</h2>
@@ -21,7 +21,8 @@ import Layout from '../layouts/Layout.astro';
 
       <section>
         <h2>2. Data Collection</h2>
-        <p>Markdy.com does not currently run analytics scripts, advertising pixels, or behavioral tracking. Static hosting infrastructure may still create standard server logs such as request URL, timestamp, user agent, and IP address for security and reliability.</p>
+        <p>Markdy.com uses Cloudflare Web Analytics to understand aggregate site traffic and Core Web Vitals. Cloudflare Web Analytics is cookie-free and reports metrics such as page URL, referrer, browser, country, device type, and performance timings. We do not run advertising pixels or behavioral tracking.</p>
+        <p>Static hosting infrastructure may also create standard server logs such as request URL, timestamp, user agent, and IP address for security and reliability.</p>
       </section>
 
       <section>
@@ -36,7 +37,7 @@ import Layout from '../layouts/Layout.astro';
 
       <section>
         <h2>5. Your Rights</h2>
-        <p>Because the site does not currently run analytics scripts or account systems, there is no analytics profile to opt out of on Markdy.com. You can clear the saved theme preference at any time by clearing this site's local storage in your browser.</p>
+        <p>Because Markdy.com does not operate accounts, advertising pixels, or user profiles, there is no Markdy account profile to export or delete. You can clear the saved theme preference at any time by clearing this site's local storage in your browser.</p>
       </section>
 
       <section>


### PR DESCRIPTION
## Summary
- normalize the privacy footer link to the canonical trailing-slash URL
- add curated homepage links and JSON-LD for featured articles to strengthen crawl paths
- remove unused Iconify CDN loading and the obsolete runtime scan hook
- update the privacy policy to disclose Cloudflare Web Analytics accurately

## Validation
- pnpm --filter @markdy/website build

## Review
- Reviewed the current diff before shipping; no actionable issues found.