### PR TITLE
fix(core): detect flow-edge cycles that collapse the ranked layout

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -70,6 +70,13 @@ scene "Title" theme=paper width=1280 height=720 fps=60 duration=8
 
 `layout LR` may be a separate statement (preferred) or inline on the `scene` line for AI-generated compatibility.
 
+**Size the canvas for how dense the diagram is.** The default 1280×720 only comfortably fits small diagrams. Auto-layout spaces nodes evenly across ranks (columns in `LR`/`RL`, rows in `TB`/`BT`) and rows within a rank — it does not grow the canvas or shrink nodes to make room. Before finalizing a scene, count (a) the number of distinct ranks (roughly the longest chain of forward edges from any source node) and (b) the busiest rank (the most nodes sharing the same depth, e.g. one service fanning out to many dependents). Nodes are ~168×72px, so as a rule of thumb pick:
+
+- `width` ≳ 180px × (rank count)
+- `height` ≳ 100px × (max nodes in the busiest rank)
+
+For anything beyond ~4 ranks or ~5 nodes in one rank, bump `width`/`height` well past the default (e.g. `width=1600-1800 height=850-960`) rather than leaving it implicit.
+
 ### `layout` — auto-layout direction
 
 ```markdy
@@ -165,6 +172,21 @@ Web <- API "201 Created"
 ```
 
 Flows may appear inside a `beat` (animated) or at the top level as `edge id: A -> B "label"` (static declaration).
+
+**Layout is derived from `->`/`~>`/`--` edges, so getting the direction wrong causes overlapping nodes.** The auto-layout ranks nodes by longest path through forward edges (`->`, `~>`, `--`); `<-` edges are excluded from ranking because they represent a reply, not a new hop. If you model a reply, callback, or return value with `->` instead of `<-` — even several beats later, even between nodes that already have a forward edge the other way — you create a cycle. The layout engine has no cycle detection: it will keep pushing the looped nodes (and everything downstream of them) to a deeper and deeper rank until most of the diagram is crushed into one or two columns and every node overlaps. Always use `<-` for anything that is conceptually "handing a result back," no matter how far downstream:
+
+```markdy
+# WRONG — Store -> Runner here closes a loop with the earlier Runner -> Store,
+# so Runner and Store (and everything after them) collapse onto each other.
+beat prompt:
+  Runner -> Store "get_prompt"
+  Store -> Runner "compiled prompt"
+
+# RIGHT — the reply uses <-, so it's excluded from ranking and the cycle never forms.
+beat prompt:
+  Runner -> Store "get_prompt"
+  Runner <- Store "compiled prompt"
+```
 
 ### Cues
 
@@ -304,6 +326,8 @@ beat main:
 - Use `frame groupName zoom=...` for attention, not manual coordinates or extra duplicate nodes.
 - Reset the camera with `frame $nodes` before a loop so the diagram returns to the full view.
 - Do not rely on Mermaid syntax. Markdy accepts brace blocks and `#` comments for compatibility, but flow/cue statements still need Markdy node ids, operators, and cue names.
+- Never write a reply/callback/return value as `->`. If B already led to A (directly or through a chain), the edge back to A must be `<-`, or you create a cycle that collapses the layout and overlaps nodes.
+- For dense diagrams (roughly >4 ranks deep or >5 nodes at the same depth), explicitly set a larger `width`/`height` — don't leave the 1280×720 default to a diagram it can't fit.
 
 ## Validation checklist
 
@@ -312,6 +336,8 @@ beat main:
 - [ ] Flow operators are one of `->`, `<-`, `~>`, `--`.
 - [ ] Cues and flows are inside `beat` blocks.
 - [ ] Theme is `paper`, `midnight`, `blueprint`, or `graphite`; layout is `LR`/`RL`/`TB`/`BT`.
+- [ ] No pair of nodes is connected by `->`/`~>`/`--` in both directions, directly or through a longer chain (that's a cycle — the reply leg must be `<-`).
+- [ ] Canvas is sized for the diagram's depth/fan-out (see sizing rule of thumb above), not left at the 1280×720 default for a large scene.
 
 ## Integration code
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -7,7 +7,6 @@ import type {
   DiagramAST,
   Diagnostic,
   EdgeDecl,
-  EdgeKind,
   FlowSegment,
   GroupDecl,
   LayoutDirection,
@@ -630,6 +629,72 @@ function validateReferences(ast: DiagramAST): void {
   }
 }
 
+/**
+ * Auto-layout ranks nodes by longest path through forward edges (`->`, `~>`, `--`);
+ * `<-` is excluded because it represents a reply, not a new hop. A forward edge that
+ * closes a loop (often a reply/return value mislabeled as `->` instead of `<-`) has no
+ * bound in the ranking pass, so it keeps pushing the looped nodes to a deeper rank
+ * until the diagram collapses into a couple of overlapping columns. Surface it early.
+ */
+function detectFlowCycles(ast: DiagramAST): void {
+  const seen = new Set<string>();
+  const adj = new Map<string, { to: string; line: number }[]>();
+  const ensure = (id: string) => {
+    if (!adj.has(id)) adj.set(id, []);
+  };
+  for (const id of Object.keys(ast.nodes)) ensure(id);
+
+  const addEdge = (from: string, to: string, line: number) => {
+    if (!ast.nodes[from] || !ast.nodes[to]) return;
+    ensure(from);
+    adj.get(from)!.push({ to, line });
+  };
+
+  for (const edge of ast.edges) {
+    if (edge.kind !== "response") addEdge(edge.from, edge.to, edge.line);
+  }
+  for (const beat of ast.beats) {
+    visitCues(beat.cues, (cue) => {
+      if (cue.kind !== "flow") return;
+      for (const segment of cue.segments) {
+        if (segment.op !== "response") addEdge(segment.from, segment.to, cue.line);
+      }
+    });
+  }
+
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map<string, number>();
+  for (const id of adj.keys()) color.set(id, WHITE);
+  const stack: string[] = [];
+
+  const dfs = (node: string) => {
+    color.set(node, GRAY);
+    stack.push(node);
+    for (const { to, line } of adj.get(node) ?? []) {
+      if (color.get(to) === GRAY) {
+        const idx = stack.indexOf(to);
+        const cyclePath = [...stack.slice(idx), to].join(" -> ");
+        pushWarning(
+          ast.diagnostics,
+          seen,
+          line,
+          `flow cycle detected: ${cyclePath} — if '${to}' is receiving a reply/return value here, use '<-' for this edge instead of '->'/'~>'/'--' (an unmarked cycle can crush the ranked layout and overlap nodes)`,
+        );
+      } else if (color.get(to) === WHITE) {
+        dfs(to);
+      }
+    }
+    stack.pop();
+    color.set(node, BLACK);
+  };
+
+  for (const id of adj.keys()) {
+    if (color.get(id) === WHITE) dfs(id);
+  }
+}
+
 export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
   const lines = source.replace(/\r\n/g, "\n").split("\n");
   const diagnostics: Diagnostic[] = [];
@@ -827,6 +892,7 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
   };
 
   validateReferences(ast);
+  detectFlowCycles(ast);
 
   const errors = ast.diagnostics.filter((d) => d.severity === "error");
   if (errors.length) {

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -108,11 +108,12 @@ scene "Arrows in labels" theme=midnight
 layout LR
 service API
 database DB
+cache Cache
 
 beat main:
   API -> DB "STORE xyz123 -> long URL"
   API <- DB "301 -> redirect"
-  API -> DB "a -> b" -> DB "next"
+  API -> DB "a -> b" -> Cache "next"
 `);
     const beat = ast.beats[0];
     const segments = beat.cues.filter(isFlow).flatMap((c) => c.segments);
@@ -120,7 +121,38 @@ beat main:
     expect(segments[0]).toMatchObject({ from: "API", op: "request", to: "DB", label: "STORE xyz123 -> long URL" });
     expect(segments[1]).toMatchObject({ from: "DB", op: "response", to: "API", label: "301 -> redirect" });
     expect(segments[2]).toMatchObject({ from: "API", op: "request", to: "DB", label: "a -> b" });
-    expect(segments[3]).toMatchObject({ from: "DB", op: "request", to: "DB", label: "next" });
+    expect(segments[3]).toMatchObject({ from: "DB", op: "request", to: "Cache", label: "next" });
+  });
+
+  it("warns when a forward edge closes a cycle instead of using a response arrow", () => {
+    const ast = parse(`
+scene "Mislabeled reply" theme=paper
+layout LR
+service Runner
+module Store
+
+beat main:
+  Runner -> Store "get_prompt"
+  Store -> Runner "compile(**vars)"
+`);
+    expect(ast.diagnostics).toHaveLength(1);
+    expect(ast.diagnostics[0]).toMatchObject({ severity: "warning" });
+    expect(ast.diagnostics[0].message).toMatch(/flow cycle detected: Runner -> Store -> Runner/);
+    expect(ast.diagnostics[0].message).toMatch(/use '<-'/);
+  });
+
+  it("does not flag a correctly marked request/response pair as a cycle", () => {
+    const ast = parse(`
+scene "Request response" theme=paper
+layout LR
+service Runner
+module Store
+
+beat main:
+  Runner -> Store "get_prompt"
+  Runner <- Store "compile(**vars)"
+`);
+    expect(ast.diagnostics).toEqual([]);
   });
 
   it("only references declared nodes in compiled flow cues", () => {


### PR DESCRIPTION
## Description
Auto-layout ranks nodes by longest path through forward edges (`->`, `~>`, `--`); `<-` is excluded since it represents a reply, not a new hop. A reply/return-value edge mislabeled as `->` instead of `<-` closes a cycle that the ranking pass (`assignRanks` in `compiler.ts`) has no bound for — it keeps pushing every node reachable from the loop to a deeper rank each sweep, until most of the diagram collapses into a couple of overlapping columns.

This showed up while debugging a real scene where several reply edges (e.g. `Store -> Runner "compile(**vars)"` instead of `Runner <- Store "compile(**vars)"`) silently produced a garbled, illegible render with no error.

Adds a DFS-based cycle check (`detectFlowCycles` in `parser.ts`) over the same forward-edge graph the compiler uses for layout, so this now surfaces as a lint/parse-time warning naming the exact loop and the fix, instead of only as a bad render discovered visually. Also documents the same rule — plus a canvas-sizing rule of thumb for dense diagrams — in `docs/AGENT.md`, the reference used for AI-generated scenes.

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm test`)

## Test plan
- [x] `pnpm -r run test` — 65 tests pass across core/renderer-dom/cli
- [x] `pnpm -r run typecheck` — clean
- [x] `npx tsx scripts/verify-examples.ts` — 11 shipped examples still pass with 0 warnings (no false positives from the new cycle check)
- [x] Added two new parser tests: one confirming a mislabeled reply edge is flagged, one confirming a correctly-marked `<-` reply is not