### PR TITLE
docs: update indent recovery wording

### DIFF
--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -21,7 +21,7 @@ When generating MarkdyScript, fetch the current hosted guide instead of relying 
 - Keep flow labels short (≤ ~28 chars) so they stay readable.
 - Use beat labels and `frame` when the scene should guide attention through a large diagram.
 - Canonical blocks use `beat name "Label":` with indented cues. The parser also accepts `{ ... }` beat/pattern blocks and `#` comments for compatibility, but prefer the canonical colon style in final docs.
-- If a host strips indentation (MDX/JSX template literals), the parser recovers colon bodies until the next top-level statement and emits a warning. Prefer real indentation, brace blocks, or a raw `.markdy` import when you control the embed.
+- If a host strips indentation (MDX/JSX template literals), the parser recovers colon bodies until the next top-level statement. Prefer real indentation or a raw `.markdy` import when you control the embed; use brace blocks only when the host cannot preserve indentation.
 
 ## Translate plain-English ideas into Markdy
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,7 +81,7 @@ for each block in source:
 **Key implementation details:**
 
 - **Strict grammar:** Statements outside the diagram grammar raise a line-numbered `ParseError`
-- **Indent recovery:** Soft-body fallback for de-indented colon groups/beats/patterns emits a diagnostic warning instead of failing empty
+- **Indent recovery:** Soft-body fallback silently recovers de-indented colon groups/beats/patterns instead of failing empty
 - **Comment stripping:** `//` line comments are removed before parsing
 - **Flow labels:** A trailing quoted string on a flow target becomes the edge label; response (`<-`) segments are stored in data-flow direction
 - **Pattern expansion:** `use name(args)` expands a `pattern` body with `$param` substitution

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -45,7 +45,7 @@ The optional beat label is rendered as a short caption during that beat.
 
 Canonical beat and pattern blocks end with `:` and use indentation. The parser also accepts `{ ... }` block delimiters and `#` comments because LLMs often emit that style, but generated documentation should prefer the colon form above.
 
-When a host strips indentation (common with MDX/JSX template literals), the parser recovers colon bodies by reading until the next top-level statement and emits a diagnostic warning. Prefer keeping real indentation, using brace blocks, or loading MarkdyScript from a raw `.markdy` file when you control the embed path.
+When a host strips indentation (common with MDX/JSX template literals), the parser recovers colon bodies by reading until the next top-level statement. Prefer keeping real indentation or loading MarkdyScript from a raw `.markdy` file when you control the embed path; use brace blocks only when a host cannot preserve indentation.
 
 Flow operators:
 - `->` — request


### PR DESCRIPTION
## Summary
- update docs to say host-stripped indentation recovery is silent
- keep canonical guidance on preserving indentation or using raw .markdy imports

## Validation
- docs-only change