### PR TITLE
feat: add interactive diagram viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.15] — 2026-08-14
+
+### Added
+- **Interactive diagram viewport** — `@markdy/renderer-dom` now supports opt-in wheel zoom and drag pan through `interactiveViewport`, with website demos enabling the Figma-like viewport controls while preserving click-to-pause.
+
+### Changed
+- **Calmer normal playback** — `1x` is now Markdy's normal playback speed, so `0.5x` is half of the new normal and `2x` is twice the new normal.
+
 ## [0.8.14] — 2026-08-11
 
 ### Fixed

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -81,7 +81,8 @@ export const code = `
 | `copyright` | `boolean` | `true` | Show a "Powered by Markdy" badge below the animation |
 | `progressBar` | `boolean` | `true` | Deprecated compatibility flag for the rainbow scene-boundary progress bar |
 | `sceneBoundaryProgress` | `boolean` | `progressBar` | Preferred flag for the rainbow scene-boundary progress bar |
-| `playbackRate` | `number` | `1` | Timeline speed multiplier |
+| `playbackRate` | `number` | `1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
+| `interactiveViewport` | `boolean` | `false` | Enable wheel zoom and drag pan after hydration |
 | `class` | `string` | — | CSS class for the outer wrapper |
 
 > **Tip:** Match `width`, `height`, and `bg` props to your `scene` declaration values to avoid a visual flash on hydration.

--- a/packages/astro/src/Markdy.astro
+++ b/packages/astro/src/Markdy.astro
@@ -44,8 +44,10 @@ export interface Props {
   progressBar?: boolean;
   /** Preferred flag to show/hide rainbow progress at scene boundary. Defaults to true. */
   sceneBoundaryProgress?: boolean;
-  /** Playback speed multiplier. Defaults to 1. */
+  /** Playback speed multiplier. Defaults to 1, where 1 is Markdy's normal pace. */
   playbackRate?: number;
+  /** Enable wheel zoom and drag pan after hydration. Defaults to false. */
+  interactiveViewport?: boolean;
   class?: string;
   /**
    * Short human-readable title for the animation.
@@ -72,6 +74,7 @@ const {
   progressBar = true,
   sceneBoundaryProgress,
   playbackRate = 1,
+  interactiveViewport = false,
   class: className,
   title = "Markdy animation",
   description,
@@ -95,6 +98,7 @@ const codeB64 =
   data-markdy-progress-bar={String(progressBar)}
   data-markdy-scene-boundary-progress={String(sceneBoundaryProgress ?? progressBar)}
   data-markdy-playback-rate={String(playbackRate)}
+  data-markdy-interactive-viewport={String(interactiveViewport)}
   role="img"
   aria-label={title}
   aria-busy="true"
@@ -271,6 +275,7 @@ const codeB64 =
     const progressBar = el.dataset.markdyProgressBar !== "false";
     const sceneBoundaryProgress = el.dataset.markdySceneBoundaryProgress !== "false";
     const playbackRate = Number(el.dataset.markdyPlaybackRate ?? "1");
+    const interactiveViewport = el.dataset.markdyInteractiveViewport === "true";
 
     // Code-split: renderer-dom is NOT part of the initial page bundle.
     const { createDiagram } = await import("@markdy/renderer-dom");
@@ -289,6 +294,7 @@ const codeB64 =
       progressBar,
       sceneBoundaryProgress,
       playbackRate: Number.isFinite(playbackRate) && playbackRate > 0 ? playbackRate : 1,
+      interactiveViewport,
     });
 
     el.dataset.markdyInit = "done";

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -73,4 +73,5 @@ Fenced block metadata is passed as props to `MarkdyDiagram`. Snake-case aliases 
 |---|---|---|
 | `progress_bar=false` | `progressBar={false}` | Deprecated compatibility flag for the scene-boundary progress bar |
 | `scene_boundary_progress=false` | `sceneBoundaryProgress={false}` | Preferred flag for the scene-boundary progress bar |
-| `playback_rate=0.5` | `playbackRate={0.5}` | Timeline speed multiplier |
+| `playback_rate=0.5` | `playbackRate={0.5}` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
+| `interactive_viewport=true` | `interactiveViewport={true}` | Enable wheel zoom and drag pan on the rendered viewport |

--- a/packages/mdx/src/diagram.tsx
+++ b/packages/mdx/src/diagram.tsx
@@ -14,6 +14,7 @@ type CreateDiagramInput = {
   progressBar: boolean;
   sceneBoundaryProgress: boolean;
   playbackRate: number;
+  interactiveViewport?: boolean;
 };
 
 export type MarkdyDiagramProps = {
@@ -28,6 +29,7 @@ export type MarkdyDiagramProps = {
   progressBar?: boolean | string;
   sceneBoundaryProgress?: boolean | string;
   playbackRate?: number | string;
+  interactiveViewport?: boolean | string;
   className?: string;
   title?: string;
   description?: string;
@@ -80,6 +82,7 @@ export function MarkdyDiagram({
   progressBar = false,
   sceneBoundaryProgress,
   playbackRate = 1,
+  interactiveViewport = false,
   className,
   title = "Markdy animation",
   description,
@@ -92,6 +95,7 @@ export function MarkdyDiagram({
   const resolvedProgressBar = coerceBoolean(progressBar, false);
   const resolvedSceneBoundaryProgress = coerceBoolean(sceneBoundaryProgress, resolvedProgressBar);
   const resolvedPlaybackRate = coerceNumber(playbackRate, 1);
+  const resolvedInteractiveViewport = coerceBoolean(interactiveViewport, false);
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const diagramRef = useRef<DiagramInstance | null>(null);
@@ -126,6 +130,7 @@ export function MarkdyDiagram({
               progressBar: resolvedProgressBar,
               sceneBoundaryProgress: resolvedSceneBoundaryProgress,
               playbackRate: resolvedPlaybackRate > 0 ? resolvedPlaybackRate : 1,
+              interactiveViewport: resolvedInteractiveViewport,
             });
             root.dataset.markdyInit = "done";
             root.removeAttribute("aria-busy");
@@ -179,6 +184,7 @@ export function MarkdyDiagram({
     resolvedProgressBar,
     resolvedSceneBoundaryProgress,
     resolvedPlaybackRate,
+    resolvedInteractiveViewport,
   ]);
 
   return (

--- a/packages/mdx/src/remark.ts
+++ b/packages/mdx/src/remark.ts
@@ -24,6 +24,8 @@ type MarkdyFenceDefaults = Partial<{
   loop: boolean;
   copyright: boolean;
   progressBar: boolean;
+  playbackRate: number;
+  interactiveViewport: boolean;
   title: string;
   description: string;
 }>;
@@ -51,6 +53,7 @@ function normalizeMetaKey(key: string): string {
   if (key === "progress_bar") return "progressBar";
   if (key === "scene_boundary_progress") return "sceneBoundaryProgress";
   if (key === "playback_rate") return "playbackRate";
+  if (key === "interactive_viewport") return "interactiveViewport";
   return key;
 }
 

--- a/packages/renderer-dom/README.md
+++ b/packages/renderer-dom/README.md
@@ -11,7 +11,8 @@ Web Animations API renderer for [MarkdyScript](../../docs/SYNTAX.md) scenes. Tra
 - **Focused diagram visuals** — flowchart shapes, tree buses, state self-loops, sequence lifelines/messages, constellation orbits, group zones, and annotations
 - **Semantic node cards** — compact SVG glyphs for browsers, services, gateways, queues, workers, databases, storage, CDN, security, platform, and more
 - **Seek-safe** — manual `currentTime` control enables reliable `seek()` in any direction
-- **Playback-rate controls** — set timeline speed to slow down or speed up diagrams without rebuilding animations
+- **Playback-rate controls** — set normalized timeline speed to slow down or speed up diagrams without rebuilding animations
+- **Interactive viewport** — opt into wheel zoom and drag pan while click-to-pause stays available
 - **Semantic themes** — `paper`, `editorial`, `nebula`, `midnight`, `blueprint`, and `graphite`, with per-role node and edge colors
 - **Single dependency** — only `@markdy/core`
 
@@ -73,7 +74,8 @@ diagram.destroy();    // clean up DOM + cancel animations
 | `copyright` | `boolean` | `true` | Show a small "Powered by Markdy" badge below the animation |
 | `progressBar` | `boolean` | `true` | Deprecated compatibility flag for the rainbow scene-boundary progress bar |
 | `sceneBoundaryProgress` | `boolean` | `progressBar ?? true` | Preferred flag for the rainbow scene-boundary progress bar |
-| `playbackRate` | `number` | `1` | Timeline speed multiplier |
+| `playbackRate` | `number` | `1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
+| `interactiveViewport` | `boolean` | `false` | Enable wheel zoom and drag pan on the rendered viewport |
 | `onWarning` | `(warning: Diagnostic) => void` | `console.warn` | Called for each soft parse warning |
 | `onTimeUpdate` | `(seconds: number, durationSeconds: number) => void` | — | Called whenever playback or seek changes the current time |
 | `onPlayStateChange` | `(playing: boolean) => void` | — | Called when playback starts or pauses |

--- a/packages/renderer-dom/src/diagram.ts
+++ b/packages/renderer-dom/src/diagram.ts
@@ -16,6 +16,13 @@ import { mountSequenceLayer } from "./sequence.js";
 import { mountTreeBuses } from "./tree.js";
 import { applyThemeToScene, ensureSceneStyles } from "./theme.js";
 
+const NORMAL_PLAYBACK_RATE = 4 / 5;
+const DEFAULT_PLAYBACK_RATE = 1;
+const MIN_VIEWPORT_ZOOM = 0.5;
+const MAX_VIEWPORT_ZOOM = 3;
+const VIEWPORT_ZOOM_STEP = 0.0015;
+const DRAG_CLICK_THRESHOLD_PX = 4;
+
 export interface DiagramOptions {
   container: HTMLElement;
   code: string;
@@ -32,8 +39,10 @@ export interface DiagramOptions {
   progressBar?: boolean;
   /** Show rainbow progress around scene boundary. Defaults to true. */
   sceneBoundaryProgress?: boolean;
-  /** Playback speed multiplier. Defaults to 1. */
+  /** Playback speed multiplier. Defaults to 1, where 1 is Markdy's normal pace. */
   playbackRate?: number;
+  /** Enable wheel zoom and drag pan on the rendered viewport. Defaults to false. */
+  interactiveViewport?: boolean;
   onWarning?: (warning: Diagnostic) => void;
   onTimeUpdate?: (seconds: number, durationSeconds: number) => void;
   onPlayStateChange?: (playing: boolean) => void;
@@ -101,7 +110,8 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     assets,
     progressBar,
     sceneBoundaryProgress,
-    playbackRate: initialPlaybackRate = 1,
+    playbackRate: initialPlaybackRate = DEFAULT_PLAYBACK_RATE,
+    interactiveViewport = false,
     onWarning = (w) => console.warn(`[markdy] line ${w.line}: ${w.message}`),
     onTimeUpdate,
     onPlayStateChange,
@@ -178,6 +188,16 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   ensureSceneStyles(document);
   ensureNodeStyles(document);
 
+  const viewportTransform = document.createElement("div");
+  viewportTransform.className = "markdy-viewport-transform";
+  Object.assign(viewportTransform.style, {
+    position: "absolute",
+    inset: "0",
+    transformOrigin: "0 0",
+    willChange: interactiveViewport ? "transform" : "auto",
+  });
+  viewport.appendChild(viewportTransform);
+
   const scene = document.createElement("div");
   scene.className = "markdy-scene-root";
   Object.assign(scene.style, {
@@ -191,7 +211,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     transformOrigin: "0 0",
   });
   applyThemeToScene(scene, plan.theme);
-  viewport.appendChild(scene);
+  viewportTransform.appendChild(scene);
 
   const sceneContent = document.createElement("div");
   sceneContent.className = "markdy-scene-content";
@@ -314,10 +334,79 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   }
 
   let sceneMs = 0;
-  let playbackRate = Number.isFinite(initialPlaybackRate) && initialPlaybackRate > 0 ? initialPlaybackRate : 1;
+  let playbackRate = Number.isFinite(initialPlaybackRate) && initialPlaybackRate > 0 ? initialPlaybackRate : DEFAULT_PLAYBACK_RATE;
   let lastRafTs: number | null = null;
   let isPlaying = false;
   let rafId: number | null = null;
+
+  let viewportScale = 1;
+  let viewportPanX = 0;
+  let viewportPanY = 0;
+  let activePointerId: number | null = null;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let dragLastX = 0;
+  let dragLastY = 0;
+  let dragMoved = false;
+  let suppressNextClick = false;
+
+  function applyViewportTransform(): void {
+    viewportTransform.style.transform = `translate(${viewportPanX}px, ${viewportPanY}px) scale(${viewportScale})`;
+  }
+
+  function handleViewportWheel(event: WheelEvent): void {
+    event.preventDefault();
+
+    const rect = viewport.getBoundingClientRect();
+    const pointerX = event.clientX - rect.left;
+    const pointerY = event.clientY - rect.top;
+    const nextScale = Math.min(MAX_VIEWPORT_ZOOM, Math.max(MIN_VIEWPORT_ZOOM, viewportScale * Math.exp(-event.deltaY * VIEWPORT_ZOOM_STEP)));
+    if (nextScale === viewportScale) return;
+
+    const sceneX = (pointerX - viewportPanX) / viewportScale;
+    const sceneY = (pointerY - viewportPanY) / viewportScale;
+    viewportScale = nextScale;
+    viewportPanX = pointerX - sceneX * viewportScale;
+    viewportPanY = pointerY - sceneY * viewportScale;
+    applyViewportTransform();
+  }
+
+  function handleViewportPointerDown(event: PointerEvent): void {
+    if (event.button !== 0 || activePointerId !== null) return;
+    activePointerId = event.pointerId;
+    dragStartX = event.clientX;
+    dragStartY = event.clientY;
+    dragLastX = event.clientX;
+    dragLastY = event.clientY;
+    dragMoved = false;
+    viewport.setPointerCapture(event.pointerId);
+    viewport.style.cursor = "grabbing";
+  }
+
+  function handleViewportPointerMove(event: PointerEvent): void {
+    if (event.pointerId !== activePointerId) return;
+
+    const deltaX = event.clientX - dragLastX;
+    const deltaY = event.clientY - dragLastY;
+    const totalX = event.clientX - dragStartX;
+    const totalY = event.clientY - dragStartY;
+    if (!dragMoved && Math.hypot(totalX, totalY) >= DRAG_CLICK_THRESHOLD_PX) dragMoved = true;
+
+    dragLastX = event.clientX;
+    dragLastY = event.clientY;
+    viewportPanX += deltaX;
+    viewportPanY += deltaY;
+    applyViewportTransform();
+  }
+
+  function handleViewportPointerEnd(event: PointerEvent): void {
+    if (event.pointerId !== activePointerId) return;
+    if (dragMoved) suppressNextClick = true;
+    if (viewport.hasPointerCapture(event.pointerId)) viewport.releasePointerCapture(event.pointerId);
+    activePointerId = null;
+    dragMoved = false;
+    viewport.style.cursor = interactiveViewport ? "grab" : "pointer";
+  }
 
   function applyCurrentTime(): void {
     for (const anim of allAnims) anim.currentTime = sceneMs;
@@ -325,7 +414,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   }
 
   function rafTick(timestamp: number): void {
-    if (lastRafTs !== null) sceneMs += (timestamp - lastRafTs) * playbackRate;
+    if (lastRafTs !== null) sceneMs += (timestamp - lastRafTs) * playbackRate * NORMAL_PLAYBACK_RATE;
     lastRafTs = timestamp;
 
     if (totalDurationMs > 0 && sceneMs >= totalDurationMs) {
@@ -400,8 +489,20 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     },
   };
 
-  viewport.style.cursor = "pointer";
+  viewport.style.cursor = interactiveViewport ? "grab" : "pointer";
+  if (interactiveViewport) {
+    viewport.style.touchAction = "none";
+    viewport.addEventListener("wheel", handleViewportWheel, { passive: false });
+    viewport.addEventListener("pointerdown", handleViewportPointerDown);
+    viewport.addEventListener("pointermove", handleViewportPointerMove);
+    viewport.addEventListener("pointerup", handleViewportPointerEnd);
+    viewport.addEventListener("pointercancel", handleViewportPointerEnd);
+  }
   viewport.addEventListener("click", () => {
+    if (suppressNextClick) {
+      suppressNextClick = false;
+      return;
+    }
     if (isPlaying) diagram.pause();
     else {
       if (!loop && sceneMs >= totalDurationMs) sceneMs = 0;

--- a/packages/renderer-dom/tests/diagram.smoke.test.ts
+++ b/packages/renderer-dom/tests/diagram.smoke.test.ts
@@ -16,6 +16,19 @@ const animateStub = vi.fn(function animate(this: Element) {
   } as unknown as Animation;
 });
 
+let animationFrameCallbacks: FrameRequestCallback[] = [];
+
+function pointerEvent(type: string, props: { pointerId?: number; clientX: number; clientY: number; button?: number }): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    pointerId: { value: props.pointerId ?? 1 },
+    clientX: { value: props.clientX },
+    clientY: { value: props.clientY },
+    button: { value: props.button ?? 0 },
+  });
+  return event;
+}
+
 const SCENE = `
 scene "Smoke" theme=paper
 layout LR
@@ -41,7 +54,16 @@ beat finish:
 
 describe("createDiagram integration", () => {
   beforeEach(() => {
+    animationFrameCallbacks = [];
     (Element.prototype as unknown as { animate: typeof animateStub }).animate = animateStub;
+    (HTMLElement.prototype as unknown as { setPointerCapture: (pointerId: number) => void }).setPointerCapture = vi.fn();
+    (HTMLElement.prototype as unknown as { releasePointerCapture: (pointerId: number) => void }).releasePointerCapture = vi.fn();
+    (HTMLElement.prototype as unknown as { hasPointerCapture: (pointerId: number) => boolean }).hasPointerCapture = vi.fn(() => true);
+    vi.stubGlobal("requestAnimationFrame", vi.fn((callback: FrameRequestCallback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    }));
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
     (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
       observe() {}
       unobserve() {}
@@ -53,6 +75,10 @@ describe("createDiagram integration", () => {
   afterEach(() => {
     document.body.innerHTML = "";
     delete (Element.prototype as unknown as { animate?: unknown }).animate;
+    delete (HTMLElement.prototype as unknown as { setPointerCapture?: unknown }).setPointerCapture;
+    delete (HTMLElement.prototype as unknown as { releasePointerCapture?: unknown }).releasePointerCapture;
+    delete (HTMLElement.prototype as unknown as { hasPointerCapture?: unknown }).hasPointerCapture;
+    vi.unstubAllGlobals();
     delete (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver;
   });
 
@@ -80,5 +106,71 @@ describe("createDiagram integration", () => {
     expect(() => diagram.seek(diagram.duration() / 2)).not.toThrow();
     diagram.destroy();
     expect(container.querySelector(".markdy-scene-root")).toBeNull();
+  });
+
+  it("defaults playback to normalized 1x and falls back to 1x for invalid initial rates", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const diagram = createDiagram({ container, code: SCENE, autoplay: false, copyright: false });
+    expect(diagram.playbackRate()).toBe(1);
+    diagram.destroy();
+
+    const invalidRateDiagram = createDiagram({ container, code: SCENE, autoplay: false, copyright: false, playbackRate: -1 });
+    expect(invalidRateDiagram.playbackRate()).toBe(1);
+    invalidRateDiagram.destroy();
+  });
+
+  it("treats normalized 1x as Markdy's normal pace", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const diagram = createDiagram({ container, code: SCENE, autoplay: false, copyright: false });
+
+    diagram.play();
+    animationFrameCallbacks[0](1000);
+    animationFrameCallbacks[1](2000);
+    expect(diagram.currentTime()).toBeCloseTo(4 / 5);
+
+    diagram.seek(0);
+    diagram.setPlaybackRate(0.5);
+    animationFrameCallbacks = [];
+    diagram.pause();
+    diagram.play();
+    animationFrameCallbacks[0](1000);
+    animationFrameCallbacks[1](2000);
+    expect(diagram.currentTime()).toBeCloseTo(0.4);
+
+    diagram.destroy();
+  });
+
+  it("keeps click-to-pause but suppresses the click produced by dragging the interactive viewport", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const diagram = createDiagram({
+      container,
+      code: SCENE,
+      autoplay: false,
+      copyright: false,
+      interactiveViewport: true,
+    });
+    const viewport = container.firstElementChild as HTMLElement;
+
+    viewport.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.isPlaying()).toBe(true);
+
+    viewport.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.isPlaying()).toBe(false);
+
+    viewport.dispatchEvent(pointerEvent("pointerdown", { clientX: 20, clientY: 20 }));
+    viewport.dispatchEvent(pointerEvent("pointermove", { clientX: 40, clientY: 25 }));
+    viewport.dispatchEvent(pointerEvent("pointerup", { clientX: 40, clientY: 25 }));
+    viewport.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(diagram.isPlaying()).toBe(false);
+    expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).toContain("translate(20px, 5px)");
+
+    diagram.destroy();
   });
 });

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1425,6 +1425,7 @@ beat finish:
         copyright: false,
         sceneBoundaryProgress: false,
         playbackRate: selectedPlaybackRate,
+        interactiveViewport: true,
         onTimeUpdate: setTimeline,
         onPlayStateChange: setPlayState,
       });

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -356,6 +356,7 @@ const playgroundStructuredData = [
         copyright: false,
         sceneBoundaryProgress: false,
         playbackRate,
+        interactiveViewport: true,
         onWarning(warning: Diagnostic) {
           warnings.push(`line ${warning.line}: ${warning.message}`);
         },


### PR DESCRIPTION
## Summary
- make 1x the new normalized normal playback pace without exposing the internal calibration
- add opt-in wheel zoom and drag pan via interactiveViewport
- enable Figma-like viewport controls on homepage and playground diagrams
- update Astro/MDX wrappers, docs, tests, and changelog for 0.8.15

## Validation
- pnpm run ci
- pnpm --filter @markdy/renderer-dom run typecheck
- pnpm --filter @markdy/mdx run typecheck
- pnpm --filter @markdy/website run build
- git diff --check