### PR TITLE
fix: pan diagram content behind viewport frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.16] — 2026-08-14
+
+### Fixed
+- **Fixed-frame viewport panning** — Dragging an interactive diagram now pans the content behind the scene frame instead of moving the whole scene surface out of view.
+
 ## [0.8.15] — 2026-08-14
 
 ### Added

--- a/packages/renderer-dom/src/diagram.ts
+++ b/packages/renderer-dom/src/diagram.ts
@@ -188,16 +188,6 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   ensureSceneStyles(document);
   ensureNodeStyles(document);
 
-  const viewportTransform = document.createElement("div");
-  viewportTransform.className = "markdy-viewport-transform";
-  Object.assign(viewportTransform.style, {
-    position: "absolute",
-    inset: "0",
-    transformOrigin: "0 0",
-    willChange: interactiveViewport ? "transform" : "auto",
-  });
-  viewport.appendChild(viewportTransform);
-
   const scene = document.createElement("div");
   scene.className = "markdy-scene-root";
   Object.assign(scene.style, {
@@ -211,12 +201,22 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     transformOrigin: "0 0",
   });
   applyThemeToScene(scene, plan.theme);
-  viewportTransform.appendChild(scene);
+  viewport.appendChild(scene);
+
+  const viewportTransform = document.createElement("div");
+  viewportTransform.className = "markdy-viewport-transform";
+  Object.assign(viewportTransform.style, {
+    position: "absolute",
+    inset: "0",
+    transformOrigin: "0 0",
+    willChange: interactiveViewport ? "transform" : "auto",
+  });
+  scene.appendChild(viewportTransform);
 
   const sceneContent = document.createElement("div");
   sceneContent.className = "markdy-scene-content";
   Object.assign(sceneContent.style, { position: "absolute", inset: "0" });
-  scene.appendChild(sceneContent);
+  viewportTransform.appendChild(sceneContent);
 
   const titleEl = createTitleEl(plan.title);
   sceneContent.appendChild(titleEl);
@@ -286,9 +286,12 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     nodeEls.set(node.id, el);
   }
 
+  let fitScale = 1;
+
   function scaleScene(): void {
-    const s = viewport.clientWidth / plan.meta.width;
-    scene.style.transform = `scale(${s})`;
+    const width = viewport.clientWidth || plan.meta.width;
+    fitScale = width / plan.meta.width;
+    scene.style.transform = `scale(${fitScale})`;
   }
   scaleScene();
   const resizeObserver = new ResizeObserver(scaleScene);
@@ -358,8 +361,8 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     event.preventDefault();
 
     const rect = viewport.getBoundingClientRect();
-    const pointerX = event.clientX - rect.left;
-    const pointerY = event.clientY - rect.top;
+    const pointerX = (event.clientX - rect.left) / fitScale;
+    const pointerY = (event.clientY - rect.top) / fitScale;
     const nextScale = Math.min(MAX_VIEWPORT_ZOOM, Math.max(MIN_VIEWPORT_ZOOM, viewportScale * Math.exp(-event.deltaY * VIEWPORT_ZOOM_STEP)));
     if (nextScale === viewportScale) return;
 
@@ -386,8 +389,8 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   function handleViewportPointerMove(event: PointerEvent): void {
     if (event.pointerId !== activePointerId) return;
 
-    const deltaX = event.clientX - dragLastX;
-    const deltaY = event.clientY - dragLastY;
+    const deltaX = (event.clientX - dragLastX) / fitScale;
+    const deltaY = (event.clientY - dragLastY) / fitScale;
     const totalX = event.clientX - dragStartX;
     const totalY = event.clientY - dragStartY;
     if (!dragMoved && Math.hypot(totalX, totalY) >= DRAG_CLICK_THRESHOLD_PX) dragMoved = true;

--- a/packages/renderer-dom/tests/diagram.smoke.test.ts
+++ b/packages/renderer-dom/tests/diagram.smoke.test.ts
@@ -169,6 +169,7 @@ describe("createDiagram integration", () => {
     viewport.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(diagram.isPlaying()).toBe(false);
+    expect(container.querySelector<HTMLElement>(".markdy-scene-root")?.style.transform).not.toContain("translate");
     expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).toContain("translate(20px, 5px)");
 
     diagram.destroy();


### PR DESCRIPTION
## Summary
- keep the scene root anchored as the fixed viewport frame
- move manual pan/zoom to the inner diagram content layer
- add regression coverage so drag does not translate the scene root
- add 0.8.16 changelog notes

## Validation
- pnpm run ci
- pnpm --filter @markdy/renderer-dom run typecheck
- pnpm --filter @markdy/website run build
- git diff --check