### PR TITLE
feat: add embedded diagram controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.17] — 2026-08-14
+
+### Added
+- **Embedded diagram controls** — Added an opt-in `controls` flag for renderer, Astro, and MDX embeds that shows play/pause, restart, speed, and view reset controls.
+
 ## [0.8.16] — 2026-08-14
 
 ### Fixed

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -83,6 +83,7 @@ export const code = `
 | `sceneBoundaryProgress` | `boolean` | `progressBar` | Preferred flag for the rainbow scene-boundary progress bar |
 | `playbackRate` | `number` | `1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
 | `interactiveViewport` | `boolean` | `false` | Enable wheel zoom and drag pan after hydration |
+| `controls` | `boolean` | `false` | Show a compact toolbar with play/pause, restart, speed, and view reset controls when viewport interaction is enabled |
 | `class` | `string` | — | CSS class for the outer wrapper |
 
 > **Tip:** Match `width`, `height`, and `bg` props to your `scene` declaration values to avoid a visual flash on hydration.

--- a/packages/astro/src/Markdy.astro
+++ b/packages/astro/src/Markdy.astro
@@ -48,6 +48,8 @@ export interface Props {
   playbackRate?: number;
   /** Enable wheel zoom and drag pan after hydration. Defaults to false. */
   interactiveViewport?: boolean;
+  /** Show built-in playback and viewport controls. Defaults to false. */
+  controls?: boolean;
   class?: string;
   /**
    * Short human-readable title for the animation.
@@ -75,6 +77,7 @@ const {
   sceneBoundaryProgress,
   playbackRate = 1,
   interactiveViewport = false,
+  controls = false,
   class: className,
   title = "Markdy animation",
   description,
@@ -99,6 +102,7 @@ const codeB64 =
   data-markdy-scene-boundary-progress={String(sceneBoundaryProgress ?? progressBar)}
   data-markdy-playback-rate={String(playbackRate)}
   data-markdy-interactive-viewport={String(interactiveViewport)}
+  data-markdy-controls={String(controls)}
   role="img"
   aria-label={title}
   aria-busy="true"
@@ -276,6 +280,7 @@ const codeB64 =
     const sceneBoundaryProgress = el.dataset.markdySceneBoundaryProgress !== "false";
     const playbackRate = Number(el.dataset.markdyPlaybackRate ?? "1");
     const interactiveViewport = el.dataset.markdyInteractiveViewport === "true";
+    const controls = el.dataset.markdyControls === "true";
 
     // Code-split: renderer-dom is NOT part of the initial page bundle.
     const { createDiagram } = await import("@markdy/renderer-dom");
@@ -295,6 +300,7 @@ const codeB64 =
       sceneBoundaryProgress,
       playbackRate: Number.isFinite(playbackRate) && playbackRate > 0 ? playbackRate : 1,
       interactiveViewport,
+      controls,
     });
 
     el.dataset.markdyInit = "done";

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -75,3 +75,4 @@ Fenced block metadata is passed as props to `MarkdyDiagram`. Snake-case aliases 
 | `scene_boundary_progress=false` | `sceneBoundaryProgress={false}` | Preferred flag for the scene-boundary progress bar |
 | `playback_rate=0.5` | `playbackRate={0.5}` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
 | `interactive_viewport=true` | `interactiveViewport={true}` | Enable wheel zoom and drag pan on the rendered viewport |
+| `controls=true` | `controls={true}` | Show a compact toolbar with play/pause, restart, speed, and view reset controls when viewport interaction is enabled |

--- a/packages/mdx/src/diagram.tsx
+++ b/packages/mdx/src/diagram.tsx
@@ -15,6 +15,7 @@ type CreateDiagramInput = {
   sceneBoundaryProgress: boolean;
   playbackRate: number;
   interactiveViewport?: boolean;
+  controls?: boolean;
 };
 
 export type MarkdyDiagramProps = {
@@ -30,6 +31,7 @@ export type MarkdyDiagramProps = {
   sceneBoundaryProgress?: boolean | string;
   playbackRate?: number | string;
   interactiveViewport?: boolean | string;
+  controls?: boolean | string;
   className?: string;
   title?: string;
   description?: string;
@@ -83,6 +85,7 @@ export function MarkdyDiagram({
   sceneBoundaryProgress,
   playbackRate = 1,
   interactiveViewport = false,
+  controls = false,
   className,
   title = "Markdy animation",
   description,
@@ -96,6 +99,7 @@ export function MarkdyDiagram({
   const resolvedSceneBoundaryProgress = coerceBoolean(sceneBoundaryProgress, resolvedProgressBar);
   const resolvedPlaybackRate = coerceNumber(playbackRate, 1);
   const resolvedInteractiveViewport = coerceBoolean(interactiveViewport, false);
+  const resolvedControls = coerceBoolean(controls, false);
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const diagramRef = useRef<DiagramInstance | null>(null);
@@ -131,6 +135,7 @@ export function MarkdyDiagram({
               sceneBoundaryProgress: resolvedSceneBoundaryProgress,
               playbackRate: resolvedPlaybackRate > 0 ? resolvedPlaybackRate : 1,
               interactiveViewport: resolvedInteractiveViewport,
+              controls: resolvedControls,
             });
             root.dataset.markdyInit = "done";
             root.removeAttribute("aria-busy");
@@ -185,6 +190,7 @@ export function MarkdyDiagram({
     resolvedSceneBoundaryProgress,
     resolvedPlaybackRate,
     resolvedInteractiveViewport,
+    resolvedControls,
   ]);
 
   return (

--- a/packages/mdx/src/remark.ts
+++ b/packages/mdx/src/remark.ts
@@ -26,6 +26,7 @@ type MarkdyFenceDefaults = Partial<{
   progressBar: boolean;
   playbackRate: number;
   interactiveViewport: boolean;
+  controls: boolean;
   title: string;
   description: string;
 }>;

--- a/packages/renderer-dom/README.md
+++ b/packages/renderer-dom/README.md
@@ -13,6 +13,7 @@ Web Animations API renderer for [MarkdyScript](../../docs/SYNTAX.md) scenes. Tra
 - **Seek-safe** — manual `currentTime` control enables reliable `seek()` in any direction
 - **Playback-rate controls** — set normalized timeline speed to slow down or speed up diagrams without rebuilding animations
 - **Interactive viewport** — opt into wheel zoom and drag pan while click-to-pause stays available
+- **Embed controls** — opt into a compact playback toolbar with restart, speed, and view reset controls
 - **Semantic themes** — `paper`, `editorial`, `nebula`, `midnight`, `blueprint`, and `graphite`, with per-role node and edge colors
 - **Single dependency** — only `@markdy/core`
 
@@ -76,6 +77,7 @@ diagram.destroy();    // clean up DOM + cancel animations
 | `sceneBoundaryProgress` | `boolean` | `progressBar ?? true` | Preferred flag for the rainbow scene-boundary progress bar |
 | `playbackRate` | `number` | `1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
 | `interactiveViewport` | `boolean` | `false` | Enable wheel zoom and drag pan on the rendered viewport |
+| `controls` | `boolean` | `false` | Show a compact toolbar with play/pause, restart, speed, and view reset controls when viewport interaction is enabled |
 | `onWarning` | `(warning: Diagnostic) => void` | `console.warn` | Called for each soft parse warning |
 | `onTimeUpdate` | `(seconds: number, durationSeconds: number) => void` | — | Called whenever playback or seek changes the current time |
 | `onPlayStateChange` | `(playing: boolean) => void` | — | Called when playback starts or pauses |

--- a/packages/renderer-dom/src/diagram.ts
+++ b/packages/renderer-dom/src/diagram.ts
@@ -43,6 +43,8 @@ export interface DiagramOptions {
   playbackRate?: number;
   /** Enable wheel zoom and drag pan on the rendered viewport. Defaults to false. */
   interactiveViewport?: boolean;
+  /** Show built-in playback and viewport controls. Defaults to false. */
+  controls?: boolean;
   onWarning?: (warning: Diagnostic) => void;
   onTimeUpdate?: (seconds: number, durationSeconds: number) => void;
   onPlayStateChange?: (playing: boolean) => void;
@@ -112,6 +114,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     sceneBoundaryProgress,
     playbackRate: initialPlaybackRate = DEFAULT_PLAYBACK_RATE,
     interactiveViewport = false,
+    controls = false,
     onWarning = (w) => console.warn(`[markdy] line ${w.line}: ${w.message}`),
     onTimeUpdate,
     onPlayStateChange,
@@ -352,9 +355,18 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   let dragLastY = 0;
   let dragMoved = false;
   let suppressNextClick = false;
+  let controlsPlayButton: HTMLButtonElement | null = null;
+  let controlsRateButtons: HTMLButtonElement[] = [];
 
   function applyViewportTransform(): void {
     viewportTransform.style.transform = `translate(${viewportPanX}px, ${viewportPanY}px) scale(${viewportScale})`;
+  }
+
+  function resetViewportTransform(): void {
+    viewportScale = 1;
+    viewportPanX = 0;
+    viewportPanY = 0;
+    applyViewportTransform();
   }
 
   function handleViewportWheel(event: WheelEvent): void {
@@ -411,6 +423,31 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     viewport.style.cursor = interactiveViewport ? "grab" : "pointer";
   }
 
+  function handleViewportDoubleClick(event: MouseEvent): void {
+    event.preventDefault();
+    suppressNextClick = false;
+    resetViewportTransform();
+  }
+
+  function syncControls(): void {
+    if (controlsPlayButton) {
+      controlsPlayButton.textContent = isPlaying ? "Pause" : "Play";
+      controlsPlayButton.setAttribute("aria-label", isPlaying ? "Pause diagram" : "Play diagram");
+    }
+    for (const button of controlsRateButtons) {
+      const rate = Number(button.dataset.rate ?? "1");
+      const active = Math.abs(rate - playbackRate) < 0.001;
+      button.setAttribute("aria-pressed", active ? "true" : "false");
+      button.style.background = active ? "rgba(15, 23, 42, 0.92)" : "rgba(255, 255, 255, 0.92)";
+      button.style.color = active ? "#ffffff" : "#111827";
+    }
+  }
+
+  function emitPlayStateChange(playing: boolean): void {
+    onPlayStateChange?.(playing);
+    syncControls();
+  }
+
   function applyCurrentTime(): void {
     for (const anim of allAnims) anim.currentTime = sceneMs;
     onTimeUpdate?.(sceneMs / 1000, durationSeconds);
@@ -426,7 +463,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
         sceneMs = totalDurationMs;
         applyCurrentTime();
         isPlaying = false;
-        onPlayStateChange?.(false);
+        emitPlayStateChange(false);
         lastRafTs = null;
         rafId = null;
         return;
@@ -442,14 +479,14 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     play() {
       if (isPlaying) return;
       isPlaying = true;
-      onPlayStateChange?.(true);
+      emitPlayStateChange(true);
       lastRafTs = null;
       rafId = requestAnimationFrame(rafTick);
     },
     pause() {
       if (!isPlaying) return;
       isPlaying = false;
-      onPlayStateChange?.(false);
+      emitPlayStateChange(false);
       if (rafId !== null) cancelAnimationFrame(rafId);
       rafId = null;
       lastRafTs = null;
@@ -462,6 +499,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     setPlaybackRate(rate: number) {
       if (!Number.isFinite(rate) || rate <= 0) return;
       playbackRate = rate;
+      syncControls();
     },
     playbackRate() {
       return playbackRate;
@@ -492,6 +530,99 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     },
   };
 
+  function togglePlayback(): void {
+    if (isPlaying) diagram.pause();
+    else {
+      if (!loop && sceneMs >= totalDurationMs) sceneMs = 0;
+      diagram.play();
+    }
+  }
+
+  function makeControlButton(label: string, ariaLabel: string): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = label;
+    button.setAttribute("aria-label", ariaLabel);
+    button.title = ariaLabel;
+    Object.assign(button.style, {
+      appearance: "none",
+      border: "1px solid rgba(15, 23, 42, 0.16)",
+      borderRadius: "6px",
+      background: "rgba(255, 255, 255, 0.92)",
+      color: "#111827",
+      cursor: "pointer",
+      font: "600 11px/1.2 system-ui, sans-serif",
+      padding: "6px 8px",
+      minWidth: "34px",
+      whiteSpace: "nowrap",
+      boxShadow: "0 1px 2px rgba(15, 23, 42, 0.08)",
+    });
+    return button;
+  }
+
+  function mountControls(): void {
+    const toolbar = document.createElement("div");
+    toolbar.className = "markdy-controls";
+    toolbar.setAttribute("role", "toolbar");
+    toolbar.setAttribute("aria-label", "Diagram controls");
+    Object.assign(toolbar.style, {
+      position: "absolute",
+      left: "50%",
+      bottom: "10px",
+      zIndex: "10000",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flexWrap: "wrap",
+      gap: "6px",
+      maxWidth: "calc(100% - 20px)",
+      padding: "6px",
+      border: "1px solid rgba(15, 23, 42, 0.12)",
+      borderRadius: "8px",
+      background: "rgba(255, 255, 255, 0.78)",
+      boxShadow: "0 10px 28px rgba(15, 23, 42, 0.16)",
+      backdropFilter: "blur(10px)",
+      transform: "translateX(-50%)",
+      pointerEvents: "auto",
+    });
+    for (const eventName of ["click", "dblclick", "pointerdown", "pointermove", "pointerup", "wheel"]) {
+      toolbar.addEventListener(eventName, (event) => event.stopPropagation());
+    }
+
+    controlsPlayButton = makeControlButton("Play", "Play diagram");
+    controlsPlayButton.className = "markdy-control-play";
+    controlsPlayButton.addEventListener("click", togglePlayback);
+    toolbar.appendChild(controlsPlayButton);
+
+    const restartButton = makeControlButton("Restart", "Restart diagram");
+    restartButton.className = "markdy-control-restart";
+    restartButton.addEventListener("click", () => {
+      diagram.seek(0);
+      diagram.play();
+    });
+    toolbar.appendChild(restartButton);
+
+    controlsRateButtons = [0.5, 1, 2].map((rate) => {
+      const button = makeControlButton(`${rate}x`, `Set playback speed to ${rate}x`);
+      button.className = "markdy-control-rate";
+      button.dataset.rate = String(rate);
+      button.setAttribute("aria-pressed", "false");
+      button.addEventListener("click", () => diagram.setPlaybackRate(rate));
+      toolbar.appendChild(button);
+      return button;
+    });
+
+    if (interactiveViewport) {
+      const resetButton = makeControlButton("Reset", "Reset diagram view");
+      resetButton.className = "markdy-control-reset-view";
+      resetButton.addEventListener("click", resetViewportTransform);
+      toolbar.appendChild(resetButton);
+    }
+
+    viewport.appendChild(toolbar);
+    syncControls();
+  }
+
   viewport.style.cursor = interactiveViewport ? "grab" : "pointer";
   if (interactiveViewport) {
     viewport.style.touchAction = "none";
@@ -500,17 +631,15 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     viewport.addEventListener("pointermove", handleViewportPointerMove);
     viewport.addEventListener("pointerup", handleViewportPointerEnd);
     viewport.addEventListener("pointercancel", handleViewportPointerEnd);
+    viewport.addEventListener("dblclick", handleViewportDoubleClick);
   }
+  if (controls) mountControls();
   viewport.addEventListener("click", () => {
     if (suppressNextClick) {
       suppressNextClick = false;
       return;
     }
-    if (isPlaying) diagram.pause();
-    else {
-      if (!loop && sceneMs >= totalDurationMs) sceneMs = 0;
-      diagram.play();
-    }
+    togglePlayback();
   });
 
   if (autoplay) diagram.play();

--- a/packages/renderer-dom/tests/diagram.smoke.test.ts
+++ b/packages/renderer-dom/tests/diagram.smoke.test.ts
@@ -172,6 +172,52 @@ describe("createDiagram integration", () => {
     expect(container.querySelector<HTMLElement>(".markdy-scene-root")?.style.transform).not.toContain("translate");
     expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).toContain("translate(20px, 5px)");
 
+    viewport.dispatchEvent(new MouseEvent("dblclick", { bubbles: true, cancelable: true }));
+    expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).toBe("translate(0px, 0px) scale(1)");
+
+    diagram.destroy();
+  });
+
+  it("mounts optional controls for playback, speed, and viewport reset", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const diagram = createDiagram({
+      container,
+      code: SCENE,
+      autoplay: false,
+      copyright: false,
+      controls: true,
+      interactiveViewport: true,
+    });
+    const viewport = container.firstElementChild as HTMLElement;
+    const toolbar = container.querySelector<HTMLElement>(".markdy-controls");
+    const playButton = container.querySelector<HTMLButtonElement>(".markdy-control-play")!;
+    const restartButton = container.querySelector<HTMLButtonElement>(".markdy-control-restart")!;
+    const halfSpeedButton = [...container.querySelectorAll<HTMLButtonElement>(".markdy-control-rate")].find((button) => button.dataset.rate === "0.5")!;
+    const resetButton = container.querySelector<HTMLButtonElement>(".markdy-control-reset-view")!;
+
+    expect(toolbar).not.toBeNull();
+    playButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.isPlaying()).toBe(true);
+    expect(playButton.textContent).toBe("Pause");
+
+    halfSpeedButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.playbackRate()).toBe(0.5);
+    expect(halfSpeedButton.getAttribute("aria-pressed")).toBe("true");
+
+    viewport.dispatchEvent(pointerEvent("pointerdown", { clientX: 20, clientY: 20 }));
+    viewport.dispatchEvent(pointerEvent("pointermove", { clientX: 40, clientY: 25 }));
+    viewport.dispatchEvent(pointerEvent("pointerup", { clientX: 40, clientY: 25 }));
+    expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).toContain("translate(20px, 5px)");
+    resetButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).toBe("translate(0px, 0px) scale(1)");
+
+    diagram.seek(1);
+    restartButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.currentTime()).toBe(0);
+    expect(diagram.isPlaying()).toBe(true);
+
     diagram.destroy();
   });
 });


### PR DESCRIPTION
## Summary
- add opt-in `controls` for renderer, Astro, and MDX embeds
- include play/pause, restart, normalized speed, and reset-view controls
- keep controls off by default and stop toolbar events from toggling the diagram canvas
- add renderer smoke coverage and docs/changelog updates

## Validation
- pnpm --filter @markdy/renderer-dom run test
- pnpm --filter @markdy/renderer-dom run typecheck
- pnpm --filter @markdy/mdx run typecheck
- pnpm --filter @markdy/website run build
- pnpm run ci
- git diff --check