### PR TITLE
fix: enable embedded viewport controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.18] — 2026-08-14
+
+### Changed
+- **Embedded controls enable viewport interaction** — `controls` now enables wheel zoom, drag pan, and view reset automatically so Astro/MDX embeds only need one flag for the full interactive toolbar experience.
 
 ## [0.8.17] — 2026-08-14
 

--- a/examples/astro-starter/src/pages/index.astro
+++ b/examples/astro-starter/src/pages/index.astro
@@ -33,7 +33,7 @@ beat response:
     <h1>Markdy + Astro Sandbox</h1>
     <p>Wait for the component to hydrate and see the animated diagram run!</p>
     <div class="container">
-      <Markdy code={code} width={800} height={400} bg="#07111f" autoplay />
+      <Markdy code={code} width={800} height={400} bg="#07111f" autoplay controls />
     </div>
   </body>
 </html>

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -47,7 +47,7 @@ const code = `
 `;
 ---
 
-<Markdy code={code} width={800} height={400} bg="#07111f" autoplay />
+<Markdy code={code} width={800} height={400} bg="#07111f" autoplay controls />
 ```
 
 ### In MDX
@@ -64,7 +64,7 @@ export const code = `
     Web -> API "GET /users"
 `;
 
-<Markdy code={code} width={600} height={300} bg="#07111f" autoplay />
+<Markdy code={code} width={600} height={300} bg="#07111f" autoplay controls />
 ```
 
 ## Props
@@ -83,7 +83,7 @@ export const code = `
 | `sceneBoundaryProgress` | `boolean` | `progressBar` | Preferred flag for the rainbow scene-boundary progress bar |
 | `playbackRate` | `number` | `1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
 | `interactiveViewport` | `boolean` | `false` | Enable wheel zoom and drag pan after hydration |
-| `controls` | `boolean` | `false` | Show a compact toolbar with play/pause, restart, speed, and view reset controls when viewport interaction is enabled |
+| `controls` | `boolean` | `false` | Show a compact toolbar with play/pause, restart, speed, and view reset controls; also enables viewport interaction |
 | `class` | `string` | — | CSS class for the outer wrapper |
 
 > **Tip:** Match `width`, `height`, and `bg` props to your `scene` declaration values to avoid a visual flash on hydration.

--- a/packages/astro/src/Markdy.astro
+++ b/packages/astro/src/Markdy.astro
@@ -48,7 +48,7 @@ export interface Props {
   playbackRate?: number;
   /** Enable wheel zoom and drag pan after hydration. Defaults to false. */
   interactiveViewport?: boolean;
-  /** Show built-in playback and viewport controls. Defaults to false. */
+  /** Show built-in playback and viewport controls. Also enables viewport interaction. Defaults to false. */
   controls?: boolean;
   class?: string;
   /**
@@ -76,8 +76,8 @@ const {
   progressBar = true,
   sceneBoundaryProgress,
   playbackRate = 1,
-  interactiveViewport = false,
   controls = false,
+  interactiveViewport = controls,
   class: className,
   title = "Markdy animation",
   description,
@@ -279,8 +279,8 @@ const codeB64 =
     const progressBar = el.dataset.markdyProgressBar !== "false";
     const sceneBoundaryProgress = el.dataset.markdySceneBoundaryProgress !== "false";
     const playbackRate = Number(el.dataset.markdyPlaybackRate ?? "1");
-    const interactiveViewport = el.dataset.markdyInteractiveViewport === "true";
     const controls = el.dataset.markdyControls === "true";
+    const interactiveViewport = controls || el.dataset.markdyInteractiveViewport === "true";
 
     // Code-split: renderer-dom is NOT part of the initial page bundle.
     const { createDiagram } = await import("@markdy/renderer-dom");

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -75,4 +75,4 @@ Fenced block metadata is passed as props to `MarkdyDiagram`. Snake-case aliases 
 | `scene_boundary_progress=false` | `sceneBoundaryProgress={false}` | Preferred flag for the scene-boundary progress bar |
 | `playback_rate=0.5` | `playbackRate={0.5}` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
 | `interactive_viewport=true` | `interactiveViewport={true}` | Enable wheel zoom and drag pan on the rendered viewport |
-| `controls=true` | `controls={true}` | Show a compact toolbar with play/pause, restart, speed, and view reset controls when viewport interaction is enabled |
+| `controls=true` | `controls={true}` | Show a compact toolbar with play/pause, restart, speed, and view reset controls; also enables viewport interaction |

--- a/packages/mdx/src/diagram.tsx
+++ b/packages/mdx/src/diagram.tsx
@@ -84,8 +84,8 @@ export function MarkdyDiagram({
   progressBar = false,
   sceneBoundaryProgress,
   playbackRate = 1,
-  interactiveViewport = false,
   controls = false,
+  interactiveViewport = controls,
   className,
   title = "Markdy animation",
   description,
@@ -98,8 +98,8 @@ export function MarkdyDiagram({
   const resolvedProgressBar = coerceBoolean(progressBar, false);
   const resolvedSceneBoundaryProgress = coerceBoolean(sceneBoundaryProgress, resolvedProgressBar);
   const resolvedPlaybackRate = coerceNumber(playbackRate, 1);
-  const resolvedInteractiveViewport = coerceBoolean(interactiveViewport, false);
   const resolvedControls = coerceBoolean(controls, false);
+  const resolvedInteractiveViewport = resolvedControls || coerceBoolean(interactiveViewport, false);
 
   const rootRef = useRef<HTMLDivElement | null>(null);
   const diagramRef = useRef<DiagramInstance | null>(null);

--- a/packages/renderer-dom/README.md
+++ b/packages/renderer-dom/README.md
@@ -77,7 +77,7 @@ diagram.destroy();    // clean up DOM + cancel animations
 | `sceneBoundaryProgress` | `boolean` | `progressBar ?? true` | Preferred flag for the rainbow scene-boundary progress bar |
 | `playbackRate` | `number` | `1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
 | `interactiveViewport` | `boolean` | `false` | Enable wheel zoom and drag pan on the rendered viewport |
-| `controls` | `boolean` | `false` | Show a compact toolbar with play/pause, restart, speed, and view reset controls when viewport interaction is enabled |
+| `controls` | `boolean` | `false` | Show a compact toolbar with play/pause, restart, speed, and view reset controls; also enables viewport interaction |
 | `onWarning` | `(warning: Diagnostic) => void` | `console.warn` | Called for each soft parse warning |
 | `onTimeUpdate` | `(seconds: number, durationSeconds: number) => void` | — | Called whenever playback or seek changes the current time |
 | `onPlayStateChange` | `(playing: boolean) => void` | — | Called when playback starts or pauses |

--- a/packages/renderer-dom/src/diagram.ts
+++ b/packages/renderer-dom/src/diagram.ts
@@ -43,7 +43,7 @@ export interface DiagramOptions {
   playbackRate?: number;
   /** Enable wheel zoom and drag pan on the rendered viewport. Defaults to false. */
   interactiveViewport?: boolean;
-  /** Show built-in playback and viewport controls. Defaults to false. */
+  /** Show built-in playback and viewport controls. Also enables viewport interaction. Defaults to false. */
   controls?: boolean;
   onWarning?: (warning: Diagnostic) => void;
   onTimeUpdate?: (seconds: number, durationSeconds: number) => void;
@@ -113,8 +113,8 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     progressBar,
     sceneBoundaryProgress,
     playbackRate: initialPlaybackRate = DEFAULT_PLAYBACK_RATE,
-    interactiveViewport = false,
     controls = false,
+    interactiveViewport = controls,
     onWarning = (w) => console.warn(`[markdy] line ${w.line}: ${w.message}`),
     onTimeUpdate,
     onPlayStateChange,

--- a/packages/renderer-dom/tests/diagram.smoke.test.ts
+++ b/packages/renderer-dom/tests/diagram.smoke.test.ts
@@ -188,7 +188,6 @@ describe("createDiagram integration", () => {
       autoplay: false,
       copyright: false,
       controls: true,
-      interactiveViewport: true,
     });
     const viewport = container.firstElementChild as HTMLElement;
     const toolbar = container.querySelector<HTMLElement>(".markdy-controls");
@@ -209,6 +208,8 @@ describe("createDiagram integration", () => {
     viewport.dispatchEvent(pointerEvent("pointerdown", { clientX: 20, clientY: 20 }));
     viewport.dispatchEvent(pointerEvent("pointermove", { clientX: 40, clientY: 25 }));
     viewport.dispatchEvent(pointerEvent("pointerup", { clientX: 40, clientY: 25 }));
+    viewport.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.isPlaying()).toBe(true);
     expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).toContain("translate(20px, 5px)");
     resetButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).toBe("translate(0px, 0px) scale(1)");


### PR DESCRIPTION
## Summary
- make renderer controls enable viewport drag, wheel zoom, and reset automatically
- normalize Astro and MDX wrappers so embedded controls imply viewport interaction
- update docs/examples and add regression coverage

## Validation
- pnpm run ci