### PR TITLE
chore: release v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] — 2026-08-17
+
+### Performance
+- **Dynamic Module Code-Splitting** — Switched homepage interactive studio to dynamically load `@codemirror/*` and `@markdy/renderer-dom` inside `requestIdleCallback`, dropping initial page JavaScript bundle from 614 KB to 17 KB.
+- **100/100 Google Lighthouse Scores** — Reached 100/100 Performance, 100/100 Best Practices, and 100/100 SEO across all key routes (`/`, `/docs/`, `/agent/`, `/blog/`, `/playground/`).
+- **Zero Cumulative Layout Shift (CLS = 0.000)** — Stabilized hero stages and typography rendering with `display=optional` and reserved responsive dimension boundaries.
+
+### Added
+- **Playground Live Director Theatre Mode** — Added a 1-click fullscreen cinematic presentation theatre mode with frosted glass blur dock and auto-restart on stage focus.
+- **Playful Mascot Integrations** — Embedded axolotl mascots, 3D wordmark, and AI agent graphics with low-priority non-blocking lazy loading.
+
+### Accessibility
+- **WCAG 2.2 Compliance** — Sequential heading hierarchy (`h1` $\rightarrow$ `h2` $\rightarrow$ `h3`), `role="tablist"` / `role="tab"` / `aria-selected` state synchronization, distinct link underlines in text blocks, and touch target sizing.
+
 ## [1.0.6] — 2026-08-16
 
 ### Performance

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2,10 +2,10 @@
 
 > ### CURRENT AUTHORITATIVE SPECIFICATION
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.6
+> - **Current Version**: v1.0.7
 > - **Specification Version**: 1.0.x
-> - **Time Updated**: 2026-08-16T15:12:44.645Z
-> - **Last Updated**: 2026-08-16
+> - **Time Updated**: 2026-08-17T14:44:31.418Z
+> - **Last Updated**: 2026-08-17
 > - **Canonical URL**: <https://markdy.com/AGENT.md>
 > - **Human-Readable Mirror**: <https://markdy.com/agent/>
 > - **LLM Index**: <https://markdy.com/llms.txt>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,9 +2,9 @@
 
 > ### INTERNAL ARCHITECTURE METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.6
+> - **Current Version**: v1.0.7
 > - **Specification Version**: 1.0.x
-> - **Last Updated**: 2026-08-16
+> - **Last Updated**: 2026-08-17
 > - **Engine Boundary**: `@markdy/core` (AST & Layout) -> `@markdy/renderer-dom` (WAAPI)
 
 Technical deep dive into Markdy's design, data flow, and renderer internals.

--- a/docs/COMPARISONS.md
+++ b/docs/COMPARISONS.md
@@ -2,9 +2,9 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.6
+> - **Current Version**: v1.0.7
 > - **Specification Version**: 1.0.x
-> - **Last Updated**: 2026-08-16
+> - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>
 > - **Article Comparison**: <https://markdy.com/blog/markdy-vs-mermaid/>
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,9 +2,9 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.6
+> - **Current Version**: v1.0.7
 > - **Specification Version**: 1.0.x
-> - **Last Updated**: 2026-08-16
+> - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>
 > - **Quickstart Command**: `npm install -g @markdy/cli`
 

--- a/docs/GUIDES.md
+++ b/docs/GUIDES.md
@@ -2,9 +2,9 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.6
+> - **Current Version**: v1.0.7
 > - **Specification Version**: 1.0.x
-> - **Last Updated**: 2026-08-16
+> - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>
 > - **AI Reference**: <https://markdy.com/AGENT.md>
 

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -2,9 +2,9 @@
 
 > ### SPECIFICATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.6
+> - **Current Version**: v1.0.7
 > - **Specification Version**: 1.0.x
-> - **Last Updated**: 2026-08-16
+> - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>
 > - **AI Agent Guide**: <https://markdy.com/AGENT.md>
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,9 +2,9 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.6
+> - **Current Version**: v1.0.7
 > - **Specification Version**: 1.0.x
-> - **Last Updated**: 2026-08-16
+> - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>
 > - **AI Reference**: <https://markdy.com/AGENT.md>
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -2,9 +2,9 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.6
+> - **Current Version**: v1.0.7
 > - **Specification Version**: 1.0.x
-> - **Last Updated**: 2026-08-16
+> - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>
 > - **Playground**: <https://markdy.com/playground/>
 >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdy",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "description": "Open-source diagram-as-code DSL for animated architecture and system diagrams. Write diagram-native MarkdyScript, get browser-native motion diagrams.",
   "license": "MIT",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/astro",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Astro island component for diagram-native animated MarkdyScript architecture diagrams.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/cli",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "First-party CLI for diagram-native MarkdyScript diagrams: lint, format, explain, render, and preview.",
   "license": "MIT",
   "type": "module",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/compat",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "description": "Backwards-compatibility gate for MarkdyScript. Snapshots every fixture in packages/compat/fixtures with the current parser and diffs ASTs on every CI run.",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/core",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Diagram-native MarkdyScript parser and compiler (auto-layout, edge routing, cue scheduling) — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/markdy-language-server/package.json
+++ b/packages/markdy-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/language-server",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Language Server Protocol implementation for diagram-native MarkdyScript diagrams.",
   "license": "MIT",
   "type": "module",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/mcp-server",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Model Context Protocol server for Markdy diagram validation, transpilation, and generation.",
   "license": "MIT",
   "type": "module",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/mdx",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "MDX plugin and lightweight React component for diagram-native animated Markdy diagrams.",
   "license": "MIT",
   "type": "module",

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/renderer-dom",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Browser renderer for diagram-native animated MarkdyScript architecture diagrams, built on the Web Animations API.",
   "license": "MIT",
   "type": "module",

--- a/packages/stdlib-systems/package.json
+++ b/packages/stdlib-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/stdlib-systems",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Diagram-native system node vocabulary for MarkdyScript architecture diagrams.",
   "license": "MIT",
   "type": "module",

--- a/prompts/system-prompt.json
+++ b/prompts/system-prompt.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.6",
+  "version": "1.0.7",
   "specVersion": "1.0.x",
   "features": [
     {

--- a/website/public/prompts/system-prompt.json
+++ b/website/public/prompts/system-prompt.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.6",
+  "version": "1.0.7",
   "specVersion": "1.0.x",
   "features": [
     {


### PR DESCRIPTION
## Summary
- bump workspace/package versions to 1.0.7
- 100/100 Google Lighthouse performance, zero-CLS layout stabilization, and dynamic code splitting
- Playground Live Director Fullscreen Theatre Mode
- Axolotl mascot brand integration and accessibility enhancements

## Validation
- pnpm run build
- pnpm run lint
- pnpm run test