### PR TITLE
chore: release v1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] — 2026-08-17
+
+### Added
+- **Authoritative AGENT.md Refactor** — Redesigned the canonical AI reference guide with a universal 4-step mental model, canvas sizing math, and 8 production-ready golden architectural templates (Microservices, RAG/AI Agents, Kafka Fanout, Kubernetes, GitOps CI/CD, OAuth2 Auth, Multi-Region HA, and Decision Trees).
+- **Automated Documentation Quality Gate** — Extended `verify:examples` to automatically extract, parse, and validate all `markdy` code fences in `docs/AGENT.md` ensuring 100% of documentation examples remain syntactically valid and runnable.
+- **Docs Keyboard Search Shortcuts** — Added `Cmd+K`, `Ctrl+K`, and `/` keyboard shortcuts to immediately focus and select the documentation search bar.
+
+### Changed
+- **Article Typography & Link Contrast** — Standardized text block links and breadcrumbs with high-contrast palette values and distinct underlines.
+
 ## [1.0.7] — 2026-08-17
 
 ### Performance

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -2,9 +2,9 @@
 
 > ### CURRENT AUTHORITATIVE SPECIFICATION
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.7
+> - **Current Version**: v1.0.8
 > - **Specification Version**: 1.0.x
-> - **Time Updated**: 2026-08-17T14:51:08.668Z
+> - **Time Updated**: 2026-08-17T14:52:29.424Z
 > - **Last Updated**: 2026-08-17
 > - **Canonical URL**: <https://markdy.com/AGENT.md>
 > - **Human-Readable Mirror**: <https://markdy.com/agent/>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > ### INTERNAL ARCHITECTURE METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.7
+> - **Current Version**: v1.0.8
 > - **Specification Version**: 1.0.x
 > - **Last Updated**: 2026-08-17
 > - **Engine Boundary**: `@markdy/core` (AST & Layout) -> `@markdy/renderer-dom` (WAAPI)

--- a/docs/COMPARISONS.md
+++ b/docs/COMPARISONS.md
@@ -2,7 +2,7 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.7
+> - **Current Version**: v1.0.8
 > - **Specification Version**: 1.0.x
 > - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -2,7 +2,7 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.7
+> - **Current Version**: v1.0.8
 > - **Specification Version**: 1.0.x
 > - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>

--- a/docs/GUIDES.md
+++ b/docs/GUIDES.md
@@ -2,7 +2,7 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.7
+> - **Current Version**: v1.0.8
 > - **Specification Version**: 1.0.x
 > - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -2,7 +2,7 @@
 
 > ### SPECIFICATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.7
+> - **Current Version**: v1.0.8
 > - **Specification Version**: 1.0.x
 > - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.7
+> - **Current Version**: v1.0.8
 > - **Specification Version**: 1.0.x
 > - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -2,7 +2,7 @@
 
 > ### DOCUMENTATION METADATA
 > - **Status**: Active & Canonical
-> - **Current Version**: v1.0.7
+> - **Current Version**: v1.0.8
 > - **Specification Version**: 1.0.x
 > - **Last Updated**: 2026-08-17
 > - **Documentation Hub**: <https://markdy.com/docs/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdy",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "description": "Open-source diagram-as-code DSL for animated architecture and system diagrams. Write diagram-native MarkdyScript, get browser-native motion diagrams.",
   "license": "MIT",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/astro",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Astro island component for diagram-native animated MarkdyScript architecture diagrams.",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/cli",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "First-party CLI for diagram-native MarkdyScript diagrams: lint, format, explain, render, and preview.",
   "license": "MIT",
   "type": "module",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/compat",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "description": "Backwards-compatibility gate for MarkdyScript. Snapshots every fixture in packages/compat/fixtures with the current parser and diffs ASTs on every CI run.",
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/core",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Diagram-native MarkdyScript parser and compiler (auto-layout, edge routing, cue scheduling) — zero runtime dependencies.",
   "license": "MIT",
   "type": "module",

--- a/packages/markdy-language-server/package.json
+++ b/packages/markdy-language-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/language-server",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Language Server Protocol implementation for diagram-native MarkdyScript diagrams.",
   "license": "MIT",
   "type": "module",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/mcp-server",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Model Context Protocol server for Markdy diagram validation, transpilation, and generation.",
   "license": "MIT",
   "type": "module",

--- a/packages/mdx/package.json
+++ b/packages/mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/mdx",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "MDX plugin and lightweight React component for diagram-native animated Markdy diagrams.",
   "license": "MIT",
   "type": "module",

--- a/packages/renderer-dom/package.json
+++ b/packages/renderer-dom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/renderer-dom",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Browser renderer for diagram-native animated MarkdyScript architecture diagrams, built on the Web Animations API.",
   "license": "MIT",
   "type": "module",

--- a/packages/stdlib-systems/package.json
+++ b/packages/stdlib-systems/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@markdy/stdlib-systems",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Diagram-native system node vocabulary for MarkdyScript architecture diagrams.",
   "license": "MIT",
   "type": "module",

--- a/prompts/system-prompt.json
+++ b/prompts/system-prompt.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.7",
+  "version": "1.0.8",
   "specVersion": "1.0.x",
   "features": [
     {

--- a/website/public/prompts/system-prompt.json
+++ b/website/public/prompts/system-prompt.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.7",
+  "version": "1.0.8",
   "specVersion": "1.0.x",
   "features": [
     {


### PR DESCRIPTION
## Summary
- bump workspace/package versions to 1.0.8
- Authoritative AGENT.md refactor with 4-step mental model, canvas sizing math, and 8 golden templates
- Automated verify:examples gate for all documentation code blocks
- Docs search keyboard shortcuts (Cmd+K, /) and typography contrast polish

## Validation
- pnpm run build
- pnpm run lint
- pnpm run test