### PR TITLE
feat(core,renderer-dom): unify player configuration under a grouped `player:` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.11] — 2026-08-19
+
+### Added
+- **Unified `player:` block (`@markdy/core`)** — One declarative home for everything outside the diagram scene itself, organised into four groups so every leaf belongs to exactly one concern:
+
+  ```markdy
+  player:
+    playback:
+      autoplay false
+      loop true
+      rate 1.5
+    controls:
+      play true
+      restart true
+      prev_beat true
+      next_beat true
+      seek true
+      speed true
+      speeds "0.5 1 2"
+      fit true
+      reset_view true
+      svg true
+      share true
+    interaction:
+      zoom true
+      pan true
+      click_to_play true
+      double_click_to_reset true
+      keyboard true
+    chrome:
+      badge false
+      progress boundary
+      color "#3b82f6"
+  ```
+
+  - **Opt-in by declaration**: declaring a group turns it on and every affordance inside defaults to on, so authors only list what they want to switch off. A group disables itself when all of its affordances are `false`, which removes the need for a separate `enabled` flag to keep in sync.
+  - **Scope-local aliases**: `speed` means playback rate at the player root but the speed buttons inside `controls:`, which the previous flat model could not express. Keys accept camel case or snake case and `key value`, `key: value`, or `key = value`.
+- **New player controls (`@markdy/renderer-dom`)**:
+  - **Fit** — frames every item in the scene using real content bounds and pins the camera, so `frame`/`focus` zoom cues (e.g. `zoom=1.18`) stop moving the view while active. Implemented with an inline `!important` transform that outranks cue animations in the cascade.
+  - **Prev/Next beat** — time-aware beat stepping that mounts only when a scene has more than one beat.
+  - **Seek bar**, **configurable speed options** (`speeds "0.25 1 3"`), **SVG export**, and **Share**.
+  - **SVG** exports the settled final frame so no revealed node is missing, and loads the exporter through a dynamic import to keep the default bundle lean. **Share** copies a compressed `#code=` link, aimed at the Markdy playground by default and redirectable with the new `shareUrl` option.
+- **Keyboard shortcuts** — <kbd>←</kbd>/<kbd>→</kbd> step beats, <kbd>Space</kbd> toggles playback, <kbd>Home</kbd> restarts. Opt-in through `interaction: keyboard true` because the listener is window-level and captures space and arrow keys.
+- **`Diagram.nextBeat()` / `Diagram.prevBeat()`** — public beat navigation derived from the current playhead.
+
+### Changed
+- **`@markdy/core` owns player resolution** — new `player.ts` module holds the schema, a single alias registry, `applyPlayerSetting`, and `resolvePlayer`. The parser's `player:` block, `scene` properties, top-level directives, `SCENE_KEYS`, and the language-server keyword list all derive from that one source instead of four hand-maintained lists, and hosts resolve behaviour through `resolvePlayer` rather than re-deriving defaults.
+- **Live Studio and homepage now use the built-in player** — removed the duplicated transport UI (play, restart, rewind, speed buttons, timeline scrubber, step buttons, beat/scene jump selects, canvas "Fit", and the topbar SVG and Share buttons) along with their handlers and CSS. Auto-shuffle, grid, zoom in/out, Import, Live Director, PNG/GIF export, and theme remain, since they are not player duplicates.
+- **`@markdy/mdx` no longer overrides scene configuration** — `remarkMarkdy()` previously injected `autoplay=false`, `loop=false`, and `progressBar=false` as explicit props, which silently outranked a scene's own settings. The transform now adds no implicit props, so a diagram behaves the same in DOM, Astro, and MDX. Pass `remarkMarkdy({ defaults: { autoplay: false, loop: false, progressBar: false } })` to restore the previous static-page behaviour.
+
+### Deprecated
+- `SceneMeta.controls`, `interactiveViewport`, `autoplay`, `loop`, `copyright`, `playbackRate`, and `progressColor` are now mirrors of `meta.player`, kept populated for existing consumers. Legacy top-level directives, flat `player:` keys, and inline `scene` properties such as `controls true`, `interactive true`, and `speed 1.5` are normalised into the grouped model and continue to work.
+
 ## [1.0.10] — 2026-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -297,6 +297,48 @@ Cues live inside a `beat` and are scheduled in order; put `&` between two cues t
 
 Selectors: `$nodes` targets every node, `$edges` targets structural and animated edges, and a group name targets its members.
 
+### Player Configuration
+
+Everything outside the scene itself lives in one `player:` block, grouped by concern:
+
+```markdy
+player:
+  playback:
+    autoplay false
+    loop true
+    rate 1
+  controls:
+    play true
+    restart false
+    prev_beat true
+    next_beat true
+    seek true
+    speed true
+    speeds "0.5 1 2"
+    fit true
+    reset_view true
+    svg true
+    share true
+  interaction:
+    zoom true
+    pan true
+    click_to_play false
+    keyboard true
+  chrome:
+    badge false
+    progress boundary
+    color "#3b82f6"
+```
+
+| Group | Owns |
+|---|---|
+| `playback` | when and how fast the timeline runs |
+| `controls` | which toolbar affordances are mounted |
+| `interaction` | what pointer and key input do |
+| `chrome` | non-interactive decoration (badge, progress) |
+
+Declaring a group opts in and every affordance defaults on, so you only list what to turn off. A group turns itself off when all of its affordances are false. `fit` frames every item and pins the camera so `frame`/`focus` zoom cues stop moving the view; `prev_beat`/`next_beat` step through beats. `keyboard` is opt-in (<kbd>←</kbd>/<kbd>→</kbd> beats, <kbd>Space</kbd> play, <kbd>Home</kbd> restart) because it captures window key events. Legacy directives and flat keys are normalized into the same groups, and explicit renderer or component options override script settings.
+
 ### Themes & Layout Modes
 
 **Themes (`theme=`):**
@@ -371,7 +413,10 @@ interface Diagram {
   seek(seconds: number): void;  // Jump to time
   setPlaybackRate(rate: number): void; // Set timeline speed, e.g. 0.5 or 2
   playbackRate(): number;    // Current timeline speed multiplier
+  beats(): BeatRange[];         // Beat ranges in the compiled scene
   seekToBeat(name: string): void;  // Jump to a named beat
+  nextBeat(): void;         // Step to the next beat from the current time
+  prevBeat(): void;         // Step to the previous beat from the current time
   destroy(): void;          // Remove DOM + cancel animations
 }
 ```

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -15,10 +15,36 @@ MarkdyScript is diagram-native. Declare semantic nodes, groups, beats, flow oper
 ### Scene & Directives
 
 ```markdy
-controls true
-interactive true
-progressColor "#3b82f6"
-loop false
+player:
+  playback:
+    autoplay true
+    loop false
+    rate 1.5
+
+  controls:
+    play true
+    restart true
+    prev_beat true
+    next_beat true
+    seek true
+    speed true
+    speeds "0.5 1 2"
+    fit true
+    reset_view true
+    svg true
+    share true
+
+  interaction:
+    zoom true
+    pan true
+    click_to_play true
+    double_click_to_reset true
+    keyboard true
+
+  chrome:
+    badge false
+    progress boundary
+    color "#3b82f6"
 
 scene theme=paper
 layout LR
@@ -26,19 +52,26 @@ layout LR
 
 Canonical scenes put `layout LR|RL|TB|BT` on its own line. For AI-generated compatibility, the parser also accepts `layout LR` or `layout=LR` on the `scene` line.
 
-You can declare diagram runtime and presentation settings directly at the top of the file as standalone directives or inline on the `scene` line:
+`player:` owns everything outside the diagram scene itself, split into four groups:
 
-| Top-Level Directive | `scene` Prop | Description |
+| Group | Owns | Settings |
 |---|---|---|
-| `controls [true\|false\|on\|off]` | `controls=true` | Mount playback, speed, and reset view buttons in footer |
-| `interactive [true\|false\|on\|off]` | `interactive=true` | Enable wheel zoom and drag pan |
-| `progressColor <color>` | `progressColor="#3b82f6"` | Custom progress bar color or gradient (e.g. `progressColor="#ec4899, #8b5cf6"`) |
-| `speed <number>` | `playbackRate=1.5` | Timeline speed multiplier |
-| `autoplay [true\|false\|on\|off]` | `autoplay=true` | Start playback automatically on load |
-| `loop [true\|false\|on\|off]` | `loop=false` | Loop timeline playback when reaching the end |
-| `copyright [true\|false\|on\|off]` | `copyright=false` | Show/hide "Powered by Markdy" badge |
+| `playback:` | when and how fast the timeline runs | `autoplay`, `loop`, `rate` |
+| `controls:` | which toolbar affordances are mounted | `play`, `restart`, `prev_beat`, `next_beat`, `seek`, `speed`, `speeds`, `fit`, `reset_view`, `svg`, `share` |
+| `interaction:` | what pointer and key input do | `zoom`, `pan`, `click_to_play`, `double_click_to_reset`, `keyboard` |
+| `chrome:` | non-interactive decoration | `badge`, `progress` (`none\|bar\|boundary`), `color` |
 
-Directives support space, colon (`controls: true`), and equals (`controls = true`) syntax. Directives defined in the script allow `<Markdy code={code} />` embeds to be completely self-contained without needing wrapper props.
+Declaring a group opts in, and every affordance in it defaults on — so list only what you want to turn off. A group switches itself off when all of its affordances are false, which means there is no separate enable flag to keep in sync. `reset_view` additionally requires interaction, and `click_to_play` is independent of viewport gestures.
+
+`fit` mounts a toggle that frames every item in the scene and pins the camera, so `frame`/`focus` zoom cues stop moving the view while it is active. Toggling it off, pressing `reset_view`, or double-clicking restores normal camera motion.
+
+`prev_beat` and `next_beat` step through beats and only appear when the scene has more than one. `speeds` sets the multipliers offered by the speed buttons (`speeds "0.25 1 3"`).
+
+`keyboard` is the one affordance that stays **off** unless you ask for it, because it listens on the window and captures space and arrow keys: <kbd>←</kbd>/<kbd>→</kbd> step beats, <kbd>Space</kbd> toggles playback, and <kbd>Home</kbd> restarts.
+
+`svg` downloads the settled final frame as vector SVG. `share` copies a compressed share link; hosts can point it at their own editor with the renderer's `shareUrl` option, and it defaults to the Markdy playground.
+
+Settings accept camel case or snake case, and `key value`, `key: value`, or `key = value`. Explicit renderer, Astro, or MDX props override script configuration. Legacy top-level directives, flat `player:` keys, and inline scene properties such as `controls true`, `interactive true`, `speed 1.5`, and `scene autoplay=false` are normalized into the same groups.
 
 ### Nodes
 

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -86,8 +86,8 @@ export const code = `
 | `sceneBoundaryProgress` | `boolean \| string` | `true` | Show boundary progress bar, or pass a custom color/gradient string |
 | `progressColor` | `string` | `plan.meta.progressColor ?? "rainbow"` | Custom progress bar color (e.g. `"#3b82f6"`) or gradient (e.g. `"#ec4899, #8b5cf6"`) |
 | `playbackRate` | `number` | `plan.meta.playbackRate ?? 1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
-| `interactiveViewport` | `boolean` | `controls \|\| plan.meta.interactiveViewport` | Enable wheel zoom and drag pan after hydration |
-| `controls` | `boolean` | `plan.meta.controls ?? false` | Show left-aligned footer controls toolbar (play/pause, restart, speed, reset view); also enables viewport interaction |
+| `interactiveViewport` | `boolean` | `controls \|\| player.interaction` | Enable wheel zoom and drag pan after hydration |
+| `controls` | `boolean` | `player.controls` | Show the footer toolbar (play, prev/next beat, restart, seek, speed, fit, reset view, SVG, share); also enables viewport interaction |
 | `class` | `string` | — | CSS class for the outer wrapper |
 
 > **Self-Contained MarkdyScript:** You can declare `controls true`, `interactive true`, `progressColor "#3b82f6"`, `loop false`, etc. directly inside the `.markdy` code so you only need `<Markdy code={code} />`. Explicit props passed to `<Markdy />` will override in-script directives.

--- a/packages/core/src/ast.ts
+++ b/packages/core/src/ast.ts
@@ -29,6 +29,64 @@ export type DiagramType =
 
 export type NodeShape = "card" | "rounded" | "diamond" | "circle" | "pill" | "terminal" | "container";
 
+export type PlayerProgress = "none" | "bar" | "boundary";
+
+/** When and how fast the timeline runs. */
+export type PlayerPlaybackConfig = {
+  autoplay?: boolean;
+  loop?: boolean;
+  rate?: number;
+};
+
+/** Which toolbar affordances are mounted. Declaring the group opts in. */
+export type PlayerControlsConfig = {
+  play?: boolean;
+  restart?: boolean;
+  prevBeat?: boolean;
+  nextBeat?: boolean;
+  seek?: boolean;
+  speed?: boolean;
+  fit?: boolean;
+  resetView?: boolean;
+  svg?: boolean;
+  share?: boolean;
+  /** Speed multipliers offered by the speed buttons. */
+  speeds?: number[];
+};
+
+/** What pointer and key input do. Declaring the group opts in. */
+export type PlayerInteractionConfig = {
+  zoom?: boolean;
+  pan?: boolean;
+  clickToPlay?: boolean;
+  doubleClickToReset?: boolean;
+  /** Window-level shortcuts; opt-in because they capture space and arrows. */
+  keyboard?: boolean;
+};
+
+/** Non-interactive decoration drawn around the scene. */
+export type PlayerChromeConfig = {
+  badge?: boolean;
+  progress?: PlayerProgress;
+  progressColor?: string;
+};
+
+export type PlayerConfig = {
+  playback?: PlayerPlaybackConfig;
+  controls?: PlayerControlsConfig;
+  interaction?: PlayerInteractionConfig;
+  chrome?: PlayerChromeConfig;
+};
+
+/** Fully defaulted player behavior produced by `resolvePlayer`. `enabled` is
+ * derived: a group is on when at least one of its affordances is on. */
+export type ResolvedPlayer = {
+  playback: Required<PlayerPlaybackConfig>;
+  controls: Required<PlayerControlsConfig> & { enabled: boolean };
+  interaction: Required<PlayerInteractionConfig> & { enabled: boolean };
+  chrome: { badge: boolean; progress: PlayerProgress; progressColor?: string };
+};
+
 export type SceneMeta = {
   title?: string;
   width: number;
@@ -39,19 +97,21 @@ export type SceneMeta = {
   duration?: number;
   /** Opt-in diagram mode; defaults to architecture. */
   type?: DiagramType;
-  /** Optional custom progress bar color or gradient. Defaults to rainbow. */
+  /** Playback, controls, interaction, and chrome behavior. Source of truth. */
+  player?: PlayerConfig;
+  /** @deprecated Mirror of `player.chrome.progressColor`. */
   progressColor?: string;
-  /** Enable playback and view reset controls toolbar. */
+  /** @deprecated Mirror of `player.controls.enabled`. */
   controls?: boolean;
-  /** Enable wheel zoom and drag pan. */
+  /** @deprecated Mirror of `player.interaction.enabled`. */
   interactiveViewport?: boolean;
-  /** Autoplay timeline on load. */
+  /** @deprecated Mirror of `player.playback.autoplay`. */
   autoplay?: boolean;
-  /** Loop playback when reaching the end. */
+  /** @deprecated Mirror of `player.playback.loop`. */
   loop?: boolean;
-  /** Show copyright badge. */
+  /** @deprecated Mirror of `player.chrome.badge`. */
   copyright?: boolean;
-  /** Default playback speed multiplier. */
+  /** @deprecated Mirror of `player.playback.rate`. */
   playbackRate?: number;
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,13 @@ export type {
   NodeDecl,
   NodeShape,
   PatternDecl,
+  PlayerConfig,
+  PlayerChromeConfig,
+  PlayerControlsConfig,
+  PlayerInteractionConfig,
+  PlayerPlaybackConfig,
+  PlayerProgress,
+  ResolvedPlayer,
   PositionedNode,
   RenderPlan,
   RoutedEdge,
@@ -29,6 +36,9 @@ export type {
 
 export { parse, compile, parseAndCompile, ParseError, compilePlan } from "./parser.js";
 export type { ParseOptions, ParseResult } from "./parser.js";
+
+export { resolvePlayer, applyPlayerSetting, PLAYER_GROUPS, PLAYER_FLAT_KEYS } from "./player.js";
+export type { PlayerOverrides, PlayerScope } from "./player.js";
 
 export { resolveTheme, THEMES } from "./themes.js";
 export { generateThemeFromBrand } from "./theme-generator.js";

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -28,6 +28,12 @@ import {
   RESERVED_SELECTORS,
   SCENE_KEYS,
 } from "./registry.js";
+import {
+  applyPlayerSetting,
+  parseBooleanToken,
+  PLAYER_FLAT_KEYS,
+  type PlayerScope,
+} from "./player.js";
 import { compilePlan } from "./compiler.js";
 import { resolveTheme } from "./themes.js";
 
@@ -483,16 +489,39 @@ function readIndentedBody(blocks: Block[], startIdx: number, parentIndent: numbe
   return { body, nextIdx: i };
 }
 
-function parseBooleanToken(raw: unknown): boolean | undefined {
-  if (typeof raw === "boolean") return raw;
-  const s = String(raw).trim().toLowerCase();
-  if (["true", "on", "yes", "1"].includes(s)) return true;
-  if (["false", "off", "no", "0"].includes(s)) return false;
-  return undefined;
-}
+const PLAYER_KEYWORDS = [...PLAYER_FLAT_KEYS].sort((a, b) => b.length - a.length).join("|");
 
-const TOP_LEVEL_KEYWORDS_RE =
-  /^(scene|layout|pattern|group|annotation|edge|beat|var|style|controls|interactive|interactiveViewport|interactive_viewport|autoplay|loop|copyright|playbackRate|playback_rate|speed|progressColor|progressBarColor|progress_color|progress_bar_color|progress|progressBar)\b/;
+const TOP_LEVEL_KEYWORDS_RE = new RegExp(
+  `^(scene|player|layout|pattern|group|annotation|edge|beat|var|style|${PLAYER_KEYWORDS})\\b`,
+);
+
+const PLAYER_DIRECTIVE_RE = new RegExp(`^(${PLAYER_KEYWORDS})\\b(?:\\s*[:=]?\\s*(.+))?$`);
+
+const PLAYER_GROUP_RE = /^(playback|controls|interaction|chrome)\s*:\s*$/;
+
+const PLAYER_SETTING_RE = /^(\w+)(?:\s*[:=]\s*|\s+)?(.*)$/;
+
+const PLAYER_FLAT_KEY_SET = new Set(PLAYER_FLAT_KEYS);
+
+/** `player` is the source of truth; deprecated SceneMeta fields mirror it. */
+function mirrorLegacySceneMeta(meta: SceneMeta): SceneMeta {
+  const player = meta.player;
+  if (!player) return meta;
+  const { playback, controls, interaction, chrome } = player;
+
+  if (playback?.autoplay !== undefined) meta.autoplay = playback.autoplay;
+  if (playback?.loop !== undefined) meta.loop = playback.loop;
+  if (playback?.rate !== undefined) meta.playbackRate = playback.rate;
+  if (controls) meta.controls = Object.values(controls).some(Boolean);
+  if (interaction) {
+    meta.interactiveViewport = Boolean(interaction.zoom ?? true) || Boolean(interaction.pan ?? true);
+  }
+  if (chrome?.badge !== undefined) meta.copyright = chrome.badge;
+  if (chrome?.progress === "none") meta.progressColor = "none";
+  else if (chrome?.progressColor !== undefined) meta.progressColor = chrome.progressColor;
+
+  return meta;
+}
 
 /**
  * True for statements that open a new top-level construct. Used to recover
@@ -814,6 +843,38 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
     const unsupportedMessage = unsupportedSyntaxMessage(line);
     if (unsupportedMessage) throw new ParseError(unsupportedMessage, lineNo);
 
+    if (/^player\s*:\s*$/.test(line)) {
+      const { body, nextIdx } = readIndentedBody(blocks, i + 1, block.indent);
+      if (body.length === 0) throw new ParseError("player block requires at least one setting", lineNo);
+      const player = (meta.player ??= {});
+
+      const applySetting = (scope: PlayerScope, setting: Block): void => {
+        const match = setting.text.match(PLAYER_SETTING_RE);
+        const error = applyPlayerSetting(player, scope, match?.[1] ?? "", match?.[2] ?? "");
+        if (error) diagnostics.push({ severity: "warning", message: error, line: setting.line });
+      };
+
+      let settingIdx = 0;
+      while (settingIdx < body.length) {
+        const setting = body[settingIdx];
+        const groupMatch = setting.text.match(PLAYER_GROUP_RE);
+        if (groupMatch) {
+          const scope = groupMatch[1] as PlayerScope;
+          const { body: childBody, nextIdx: childNextIdx } = readIndentedBody(body, settingIdx + 1, setting.indent);
+          if (childBody.length === 0) {
+            throw new ParseError(`player ${scope} block requires at least one setting`, setting.line);
+          }
+          for (const child of childBody) applySetting(scope, child);
+          settingIdx = childNextIdx;
+          continue;
+        }
+        applySetting("player", setting);
+        settingIdx++;
+      }
+      i = nextIdx;
+      continue;
+    }
+
     if (line.startsWith("scene")) {
       const rest = line.slice(5).trim();
       if (line.endsWith("{")) {
@@ -840,28 +901,9 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
         else if (k === "duration") meta.duration = Number(v);
         else if (k === "theme") meta.theme = String(v);
         else if (k === "direction" || k === "layout") meta.direction = String(v).toUpperCase() as LayoutDirection;
-        else if (k === "progressColor" || k === "progressBarColor" || k === "progress_color" || k === "progress_bar_color" || k === "progress") {
-          meta.progressColor = String(v);
-        } else if (k === "progressBar" || k === "sceneBoundaryProgress") {
-          const bool = parseBooleanToken(v);
-          if (bool !== undefined) {
-            if (!bool) meta.progressColor = "none";
-          } else {
-            meta.progressColor = String(v);
-          }
-        } else if (k === "controls") {
-          meta.controls = parseBooleanToken(v) ?? true;
-        } else if (k === "interactive" || k === "interactiveViewport" || k === "interactive_viewport") {
-          meta.interactiveViewport = parseBooleanToken(v) ?? true;
-        } else if (k === "autoplay") {
-          meta.autoplay = parseBooleanToken(v) ?? true;
-        } else if (k === "loop") {
-          meta.loop = parseBooleanToken(v) ?? true;
-        } else if (k === "copyright") {
-          meta.copyright = parseBooleanToken(v) ?? true;
-        } else if (k === "playbackRate" || k === "playback_rate" || k === "speed") {
-          const r = Number(v);
-          if (!Number.isNaN(r) && r > 0) meta.playbackRate = r;
+        else if (PLAYER_FLAT_KEY_SET.has(k)) {
+          const error = applyPlayerSetting((meta.player ??= {}), "player", k, String(v));
+          if (error) diagnostics.push({ severity: "warning", message: error, line: lineNo });
         } else if (k === "type") {
           const t = String(v).toLowerCase();
           if (!DIAGRAM_TYPES.has(t)) {
@@ -875,47 +917,10 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
       continue;
     }
 
-    const directiveMatch = line.match(
-      /^(controls|interactive|interactiveViewport|interactive_viewport|autoplay|loop|copyright|playbackRate|playback_rate|speed|progressColor|progressBarColor|progress_color|progress_bar_color|progress|progressBar)\b(?:\s*[:=]?\s*(.+))?$/,
-    );
+    const directiveMatch = line.match(PLAYER_DIRECTIVE_RE);
     if (directiveMatch) {
-      const keyword = directiveMatch[1];
-      const rawVal = (directiveMatch[2] ?? "").trim();
-      const val =
-        (rawVal.startsWith('"') && rawVal.endsWith('"')) || (rawVal.startsWith("'") && rawVal.endsWith("'"))
-          ? rawVal.slice(1, -1)
-          : rawVal;
-
-      if (keyword === "controls") {
-        meta.controls = val ? (parseBooleanToken(val) ?? true) : true;
-      } else if (
-        keyword === "interactive" ||
-        keyword === "interactiveViewport" ||
-        keyword === "interactive_viewport"
-      ) {
-        meta.interactiveViewport = val ? (parseBooleanToken(val) ?? true) : true;
-      } else if (keyword === "autoplay") {
-        meta.autoplay = val ? (parseBooleanToken(val) ?? true) : true;
-      } else if (keyword === "loop") {
-        meta.loop = val ? (parseBooleanToken(val) ?? true) : true;
-      } else if (keyword === "copyright") {
-        meta.copyright = val ? (parseBooleanToken(val) ?? true) : true;
-      } else if (keyword === "playbackRate" || keyword === "playback_rate" || keyword === "speed") {
-        const r = Number(val);
-        if (!Number.isNaN(r) && r > 0) meta.playbackRate = r;
-      } else if (
-        keyword === "progressColor" ||
-        keyword === "progressBarColor" ||
-        keyword === "progress_color" ||
-        keyword === "progress_bar_color" ||
-        keyword === "progress"
-      ) {
-        if (val) meta.progressColor = val;
-      } else if (keyword === "progressBar") {
-        const bool = parseBooleanToken(val);
-        if (bool === false) meta.progressColor = "none";
-        else if (val) meta.progressColor = val;
-      }
+      const error = applyPlayerSetting((meta.player ??= {}), "player", directiveMatch[1], directiveMatch[2] ?? "");
+      if (error) diagnostics.push({ severity: "warning", message: error, line: lineNo });
       i++;
       continue;
     }
@@ -1085,7 +1090,7 @@ export function parse(source: string, opts: ParseOptions = {}): DiagramAST {
   }
 
   const ast: DiagramAST = {
-    meta: { ...meta, title: title || undefined },
+    meta: { ...mirrorLegacySceneMeta(meta), title: title || undefined },
     styles,
     nodes,
     edges,

--- a/packages/core/src/player.ts
+++ b/packages/core/src/player.ts
@@ -1,0 +1,345 @@
+/**
+ * Single source of truth for player configuration: schema, aliases, parsing,
+ * and default resolution. Hosts (DOM renderer, Astro, MDX, CLI) resolve
+ * behavior through `resolvePlayer` instead of re-deriving defaults.
+ */
+import type {
+  PlayerConfig,
+  PlayerProgress,
+  ResolvedPlayer,
+} from "./ast.js";
+
+export function parseBooleanToken(raw: unknown): boolean | undefined {
+  if (typeof raw === "boolean") return raw;
+  const s = String(raw).trim().toLowerCase();
+  if (["true", "on", "yes", "1"].includes(s)) return true;
+  if (["false", "off", "no", "0"].includes(s)) return false;
+  return undefined;
+}
+
+/** Groups own their own alias table, so `speed` can mean rate at the player
+ * root and the speed buttons inside `controls:`. */
+export type PlayerScope = "player" | "playback" | "controls" | "interaction" | "chrome";
+
+type SettingType = "boolean" | "rate" | "rates" | "progress" | "color" | "group";
+
+type Setting = {
+  group: "playback" | "controls" | "interaction" | "chrome";
+  key: string;
+  type: SettingType;
+};
+
+/** Affordances toggled together by the legacy `controls` / `interactive` keys. */
+export const CONTROL_KEYS = [
+  "play",
+  "restart",
+  "prevBeat",
+  "nextBeat",
+  "seek",
+  "speed",
+  "fit",
+  "resetView",
+  "svg",
+  "share",
+] as const;
+export const INTERACTION_KEYS = ["zoom", "pan", "doubleClickToReset"] as const;
+
+const PLAYBACK: Record<string, Setting> = {
+  autoplay: { group: "playback", key: "autoplay", type: "boolean" },
+  loop: { group: "playback", key: "loop", type: "boolean" },
+  rate: { group: "playback", key: "rate", type: "rate" },
+  speed: { group: "playback", key: "rate", type: "rate" },
+  playbackRate: { group: "playback", key: "rate", type: "rate" },
+  playback_rate: { group: "playback", key: "rate", type: "rate" },
+};
+
+const CONTROLS: Record<string, Setting> = {
+  controls: { group: "controls", key: "*", type: "group" },
+  play: { group: "controls", key: "play", type: "boolean" },
+  playButton: { group: "controls", key: "play", type: "boolean" },
+  play_button: { group: "controls", key: "play", type: "boolean" },
+  restart: { group: "controls", key: "restart", type: "boolean" },
+  restartButton: { group: "controls", key: "restart", type: "boolean" },
+  restart_button: { group: "controls", key: "restart", type: "boolean" },
+  prevBeat: { group: "controls", key: "prevBeat", type: "boolean" },
+  prev_beat: { group: "controls", key: "prevBeat", type: "boolean" },
+  nextBeat: { group: "controls", key: "nextBeat", type: "boolean" },
+  next_beat: { group: "controls", key: "nextBeat", type: "boolean" },
+  speeds: { group: "controls", key: "speeds", type: "rates" },
+  speedOptions: { group: "controls", key: "speeds", type: "rates" },
+  speed_options: { group: "controls", key: "speeds", type: "rates" },
+  seek: { group: "controls", key: "seek", type: "boolean" },
+  seekBar: { group: "controls", key: "seek", type: "boolean" },
+  seek_bar: { group: "controls", key: "seek", type: "boolean" },
+  speed: { group: "controls", key: "speed", type: "boolean" },
+  speedControls: { group: "controls", key: "speed", type: "boolean" },
+  speed_controls: { group: "controls", key: "speed", type: "boolean" },
+  fit: { group: "controls", key: "fit", type: "boolean" },
+  fitView: { group: "controls", key: "fit", type: "boolean" },
+  fit_view: { group: "controls", key: "fit", type: "boolean" },
+  fitViewButton: { group: "controls", key: "fit", type: "boolean" },
+  fit_view_button: { group: "controls", key: "fit", type: "boolean" },
+  resetView: { group: "controls", key: "resetView", type: "boolean" },
+  reset_view: { group: "controls", key: "resetView", type: "boolean" },
+  resetViewButton: { group: "controls", key: "resetView", type: "boolean" },
+  reset_view_button: { group: "controls", key: "resetView", type: "boolean" },
+  svg: { group: "controls", key: "svg", type: "boolean" },
+  exportSvg: { group: "controls", key: "svg", type: "boolean" },
+  export_svg: { group: "controls", key: "svg", type: "boolean" },
+  share: { group: "controls", key: "share", type: "boolean" },
+  shareLink: { group: "controls", key: "share", type: "boolean" },
+  share_link: { group: "controls", key: "share", type: "boolean" },
+};
+
+const INTERACTION: Record<string, Setting> = {
+  interactive: { group: "interaction", key: "*", type: "group" },
+  interactiveViewport: { group: "interaction", key: "*", type: "group" },
+  interactive_viewport: { group: "interaction", key: "*", type: "group" },
+  zoom: { group: "interaction", key: "zoom", type: "boolean" },
+  allowZoom: { group: "interaction", key: "zoom", type: "boolean" },
+  allow_zoom: { group: "interaction", key: "zoom", type: "boolean" },
+  pan: { group: "interaction", key: "pan", type: "boolean" },
+  allowPan: { group: "interaction", key: "pan", type: "boolean" },
+  allow_pan: { group: "interaction", key: "pan", type: "boolean" },
+  clickToPlay: { group: "interaction", key: "clickToPlay", type: "boolean" },
+  click_to_play: { group: "interaction", key: "clickToPlay", type: "boolean" },
+  keyboard: { group: "interaction", key: "keyboard", type: "boolean" },
+  shortcuts: { group: "interaction", key: "keyboard", type: "boolean" },
+  doubleClickToReset: { group: "interaction", key: "doubleClickToReset", type: "boolean" },
+  double_click_to_reset: { group: "interaction", key: "doubleClickToReset", type: "boolean" },
+};
+
+const CHROME: Record<string, Setting> = {
+  badge: { group: "chrome", key: "badge", type: "boolean" },
+  copyright: { group: "chrome", key: "badge", type: "boolean" },
+  progress: { group: "chrome", key: "progress", type: "progress" },
+  progressBar: { group: "chrome", key: "progress", type: "progress" },
+  progress_bar: { group: "chrome", key: "progress", type: "progress" },
+  sceneBoundaryProgress: { group: "chrome", key: "progress", type: "progress" },
+  progressColor: { group: "chrome", key: "progressColor", type: "color" },
+  progress_color: { group: "chrome", key: "progressColor", type: "color" },
+  progressBarColor: { group: "chrome", key: "progressColor", type: "color" },
+  progress_bar_color: { group: "chrome", key: "progressColor", type: "color" },
+};
+
+/** Flat aliases accepted at the `player:` root, on `scene`, and as top-level
+ * directives. Group blocks are the canonical form; these stay for compat. */
+const FLAT: Record<string, Setting> = {
+  ...PLAYBACK,
+  ...CHROME,
+  controls: CONTROLS.controls,
+  playButton: CONTROLS.playButton,
+  play_button: CONTROLS.play_button,
+  restartButton: CONTROLS.restartButton,
+  restart_button: CONTROLS.restart_button,
+  seek: CONTROLS.seek,
+  seekBar: CONTROLS.seekBar,
+  seek_bar: CONTROLS.seek_bar,
+  speedControls: CONTROLS.speedControls,
+  speed_controls: CONTROLS.speed_controls,
+  speeds: CONTROLS.speeds,
+  speedOptions: CONTROLS.speedOptions,
+  speed_options: CONTROLS.speed_options,
+  prevBeat: CONTROLS.prevBeat,
+  prev_beat: CONTROLS.prev_beat,
+  nextBeat: CONTROLS.nextBeat,
+  next_beat: CONTROLS.next_beat,
+  keyboard: INTERACTION.keyboard,
+  shortcuts: INTERACTION.shortcuts,
+  fitView: CONTROLS.fitView,
+  fit_view: CONTROLS.fit_view,
+  fitViewButton: CONTROLS.fitViewButton,
+  fit_view_button: CONTROLS.fit_view_button,
+  resetViewButton: CONTROLS.resetViewButton,
+  reset_view_button: CONTROLS.reset_view_button,
+  exportSvg: CONTROLS.exportSvg,
+  export_svg: CONTROLS.export_svg,
+  shareLink: CONTROLS.shareLink,
+  share_link: CONTROLS.share_link,
+  interactive: INTERACTION.interactive,
+  interactiveViewport: INTERACTION.interactiveViewport,
+  interactive_viewport: INTERACTION.interactive_viewport,
+  allowZoom: INTERACTION.allowZoom,
+  allow_zoom: INTERACTION.allow_zoom,
+  allowPan: INTERACTION.allowPan,
+  allow_pan: INTERACTION.allow_pan,
+  clickToPlay: INTERACTION.clickToPlay,
+  click_to_play: INTERACTION.click_to_play,
+  doubleClickToReset: INTERACTION.doubleClickToReset,
+  double_click_to_reset: INTERACTION.double_click_to_reset,
+};
+
+const SCOPES: Record<PlayerScope, Record<string, Setting>> = {
+  player: FLAT,
+  playback: PLAYBACK,
+  controls: CONTROLS,
+  interaction: INTERACTION,
+  // `color` is unambiguous inside the block, but too generic at the root.
+  chrome: { ...CHROME, color: CHROME.progressColor },
+};
+
+export const PLAYER_GROUPS = ["playback", "controls", "interaction", "chrome"] as const;
+
+/** Keys usable as `scene` props and top-level directives. */
+export const PLAYER_FLAT_KEYS: string[] = Object.keys(FLAT);
+
+export function playerSettingScope(scope: PlayerScope, key: string): Setting | undefined {
+  return SCOPES[scope][key];
+}
+
+/**
+ * Applies one `key value` pair into `config`. Returns an error message when the
+ * key is unknown or the value does not fit the setting type.
+ */
+export function applyPlayerSetting(
+  config: PlayerConfig,
+  scope: PlayerScope,
+  key: string,
+  rawValue: string,
+): string | undefined {
+  const setting = SCOPES[scope][key];
+  if (!setting) return `unknown player property '${key}'`;
+
+  const value = unquote(rawValue).trim();
+  const group = (config[setting.group] ??= {}) as Record<string, unknown>;
+
+  if (setting.type === "boolean" || setting.type === "group") {
+    const parsed = value ? parseBooleanToken(value) : true;
+    if (parsed === undefined) return `player property '${key}' expects true or false`;
+    if (setting.type === "boolean") group[setting.key] = parsed;
+    else for (const child of setting.group === "controls" ? CONTROL_KEYS : INTERACTION_KEYS) group[child] = parsed;
+    return undefined;
+  }
+
+  if (setting.type === "rate") {
+    const rate = Number(value);
+    if (!Number.isFinite(rate) || rate <= 0) return `player property '${key}' expects a positive number`;
+    group[setting.key] = rate;
+    return undefined;
+  }
+
+  if (setting.type === "rates") {
+    const rates = value
+      .split(/[\s,]+/)
+      .filter(Boolean)
+      .map(Number);
+    if (!rates.length || rates.some((rate) => !Number.isFinite(rate) || rate <= 0)) {
+      return `player property '${key}' expects a list of positive numbers`;
+    }
+    group[setting.key] = rates;
+    return undefined;
+  }
+
+  if (setting.type === "color") {
+    if (value) group[setting.key] = value;
+    return undefined;
+  }
+
+  // `progress` doubles as mode and color so legacy `progress=emerald` keeps working.
+  const mode = toProgressMode(value);
+  if (mode) group.progress = mode;
+  else if (value) group.progressColor = value;
+  return undefined;
+}
+
+function toProgressMode(value: string): PlayerProgress | undefined {
+  const lower = value.toLowerCase();
+  if (lower === "none" || lower === "bar" || lower === "boundary") return lower;
+  const bool = parseBooleanToken(lower);
+  if (bool === true) return "boundary";
+  if (bool === false) return "none";
+  return undefined;
+}
+
+function unquote(raw: string): string {
+  const value = raw.trim();
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/** Host-supplied overrides always win over script configuration. */
+export type PlayerOverrides = {
+  autoplay?: boolean;
+  loop?: boolean;
+  playbackRate?: number;
+  copyright?: boolean;
+  controls?: boolean;
+  interactiveViewport?: boolean;
+  progress?: PlayerProgress;
+  progressColor?: string;
+};
+
+export function resolvePlayer(config: PlayerConfig = {}, overrides: PlayerOverrides = {}): ResolvedPlayer {
+  const playback = config.playback ?? {};
+  const interaction = config.interaction ?? {};
+  const chrome = config.chrome ?? {};
+
+  // Declaring a group opts in; every affordance then defaults on.
+  const controlsOn =
+    overrides.controls !== false && (overrides.controls === true || config.controls !== undefined);
+  const controls = {
+    play: controlsOn && (config.controls?.play ?? true),
+    restart: controlsOn && (config.controls?.restart ?? true),
+    prevBeat: controlsOn && (config.controls?.prevBeat ?? true),
+    nextBeat: controlsOn && (config.controls?.nextBeat ?? true),
+    seek: controlsOn && (config.controls?.seek ?? true),
+    speed: controlsOn && (config.controls?.speed ?? true),
+    fit: controlsOn && (config.controls?.fit ?? true),
+    resetView: controlsOn && (config.controls?.resetView ?? true),
+    svg: controlsOn && (config.controls?.svg ?? true),
+    share: controlsOn && (config.controls?.share ?? true),
+  };
+
+  // Legacy host coupling: `controls` as a host option also unlocks the viewport.
+  const interactionOn =
+    overrides.interactiveViewport !== false &&
+    (overrides.interactiveViewport === true || config.interaction !== undefined || overrides.controls === true);
+  const gestures = {
+    zoom: interactionOn && (interaction.zoom ?? true),
+    pan: interactionOn && (interaction.pan ?? true),
+    doubleClickToReset: interactionOn && (interaction.doubleClickToReset ?? true),
+  };
+  const interactionEnabled = gestures.zoom || gestures.pan || gestures.doubleClickToReset;
+
+  const resetView = controls.resetView && interactionEnabled;
+  const controlsEnabled =
+    controls.play ||
+    controls.restart ||
+    controls.prevBeat ||
+    controls.nextBeat ||
+    controls.seek ||
+    controls.speed ||
+    controls.fit ||
+    controls.svg ||
+    controls.share ||
+    resetView;
+
+  const rate = overrides.playbackRate ?? playback.rate ?? 1;
+
+  return {
+    playback: {
+      autoplay: overrides.autoplay ?? playback.autoplay ?? true,
+      loop: overrides.loop ?? playback.loop ?? true,
+      rate: Number.isFinite(rate) && rate > 0 ? rate : 1,
+    },
+    controls: {
+      ...controls,
+      resetView,
+      enabled: controlsEnabled,
+      speeds: config.controls?.speeds?.length ? config.controls.speeds : [0.5, 1, 2],
+    },
+    interaction: {
+      ...gestures,
+      enabled: interactionEnabled,
+      clickToPlay: interaction.clickToPlay ?? true,
+      keyboard: interaction.keyboard ?? false,
+    },
+    chrome: {
+      badge: overrides.copyright ?? chrome.badge ?? true,
+      progress: overrides.progress ?? chrome.progress ?? "boundary",
+      progressColor: overrides.progressColor ?? chrome.progressColor,
+    },
+  };
+}

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -4,6 +4,7 @@ import {
   VISUAL_PRIMITIVE_KINDS,
   VISUAL_PRIMITIVE_TYPES,
 } from "./system-vocabulary.js";
+import { PLAYER_FLAT_KEYS } from "./player.js";
 
 export const NODE_KINDS = new Set<string>([
   ...TECHNICAL_NODE_TYPES,
@@ -66,23 +67,7 @@ export const SCENE_KEYS = new Set([
   "direction",
   "layout",
   "type",
-  "progressColor",
-  "progressBarColor",
-  "progress_color",
-  "progress_bar_color",
-  "progress",
-  "progressBar",
-  "sceneBoundaryProgress",
-  "controls",
-  "interactive",
-  "interactiveViewport",
-  "interactive_viewport",
-  "autoplay",
-  "loop",
-  "copyright",
-  "playbackRate",
-  "playback_rate",
-  "speed",
+  ...PLAYER_FLAT_KEYS,
 ]);
 
 export function nodeRole(kind: string): string {

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -564,6 +564,128 @@ beat main:
     expect(ast3.diagnostics).toEqual([]);
   });
 
+  it("parses grouped player configuration", () => {
+    const ast = parse(`
+player:
+  playback:
+    autoplay false
+    loop true
+    rate 1.5
+  controls:
+    play true
+    restart false
+    seek true
+    speed false
+    fit true
+    reset_view true
+  interaction:
+    zoom false
+    pan true
+    click_to_play false
+    double_click_to_reset true
+  chrome:
+    badge false
+    progress bar
+    color "#10b981"
+
+scene "Configured player"
+service API
+beat main:
+  show API
+`);
+
+    expect(ast.meta.player).toEqual({
+      playback: { autoplay: false, loop: true, rate: 1.5 },
+      controls: { play: true, restart: false, seek: true, speed: false, fit: true, resetView: true },
+      interaction: { zoom: false, pan: true, clickToPlay: false, doubleClickToReset: true },
+      chrome: { badge: false, progress: "bar", progressColor: "#10b981" },
+    });
+    expect(ast.diagnostics).toEqual([]);
+  });
+
+  it("normalizes legacy directives and flat player keys into grouped configuration", () => {
+    const ast = parse(`
+controls true
+interactive true
+speed 2
+copyright false
+
+player:
+  allow_zoom false
+  seek_bar true
+
+scene "Legacy" autoplay=false
+service API
+beat main:
+  show API
+`);
+
+    expect(ast.meta.player).toEqual({
+      playback: { rate: 2, autoplay: false },
+      controls: {
+        play: true,
+        restart: true,
+        prevBeat: true,
+        nextBeat: true,
+        seek: true,
+        speed: true,
+        fit: true,
+        resetView: true,
+        svg: true,
+        share: true,
+      },
+      interaction: { zoom: false, pan: true, doubleClickToReset: true },
+      chrome: { badge: false },
+    });
+    // Deprecated mirrors stay populated for existing consumers.
+    expect(ast.meta.controls).toBe(true);
+    expect(ast.meta.interactiveViewport).toBe(true);
+    expect(ast.meta.playbackRate).toBe(2);
+    expect(ast.meta.autoplay).toBe(false);
+    expect(ast.meta.copyright).toBe(false);
+    expect(ast.diagnostics).toEqual([]);
+  });
+
+  it("parses beat navigation, custom speed options, and keyboard opt-in", () => {
+    const ast = parse(`
+player:
+  controls:
+    prev_beat true
+    next_beat false
+    speeds "0.25, 1, 3"
+  interaction:
+    keyboard true
+
+scene "Presentation"
+service API
+beat main:
+  show API
+`);
+
+    expect(ast.meta.player?.controls).toEqual({ prevBeat: true, nextBeat: false, speeds: [0.25, 1, 3] });
+    expect(ast.meta.player?.interaction).toEqual({ keyboard: true });
+    expect(ast.diagnostics).toEqual([]);
+  });
+
+  it("warns on unknown or malformed player settings", () => {
+    const ast = parse(`
+player:
+  controls:
+    play maybe
+    teleport true
+
+scene "Bad player"
+service API
+beat main:
+  show API
+`);
+
+    expect(ast.diagnostics.map((d) => d.message)).toEqual([
+      "player property 'play' expects true or false",
+      "unknown player property 'teleport'",
+    ]);
+  });
+
   it("parses style declarations and custom style references on nodes", () => {
     const code = `
 style Highlight = fill="#0f172a" stroke="#38bdf8" text="#ffffff" accent="#f59e0b"

--- a/packages/markdy-language-server/src/index.ts
+++ b/packages/markdy-language-server/src/index.ts
@@ -3,6 +3,8 @@ import {
   NODE_KINDS,
   ParseError,
   parse,
+  PLAYER_FLAT_KEYS,
+  PLAYER_GROUPS,
   type Diagnostic,
 } from "@markdy/core";
 import {
@@ -23,15 +25,9 @@ const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
 const KEYWORDS = [
   "scene",
   "layout",
-  "controls",
-  "interactive",
-  "interactiveViewport",
-  "autoplay",
-  "loop",
-  "copyright",
-  "speed",
-  "playbackRate",
-  "progressColor",
+  "player",
+  ...PLAYER_GROUPS,
+  ...PLAYER_FLAT_KEYS,
   "var",
   "group",
   "beat",

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -61,7 +61,7 @@ beat main:
 
 ## Performance Notes
 
-- Default transform options set `autoplay=false`, `loop=false`, `progressBar=false`.
+- The transform adds no implicit props, so a scene's own `player:` config stays authoritative. Pass `remarkMarkdy({ defaults: { autoplay: false, loop: false, progressBar: false } })` to restore the previous static-page behavior for every block.
 - Runtime diagram component does not import renderer code until the block enters viewport.
 - Placeholder is SSR-safe and keeps stable layout ratio to avoid CLS.
 

--- a/packages/mdx/src/remark.ts
+++ b/packages/mdx/src/remark.ts
@@ -87,12 +87,8 @@ function toCodeAttribute(code: string): MdxAttribute {
 
 export function remarkMarkdy(opts: RemarkMarkdyOptions = {}) {
   const componentName = opts.componentName ?? "MarkdyDiagram";
-  const defaultProps: MarkdyFenceDefaults = {
-    autoplay: false,
-    loop: false,
-    progressBar: false,
-    ...opts.defaults,
-  };
+  // No implicit defaults: the scene's own `player:` config stays authoritative.
+  const defaultProps: MarkdyFenceDefaults = { ...opts.defaults };
 
   return (tree: Root): void => {
     visit(tree, "code", (node, index, parent) => {

--- a/packages/renderer-dom/README.md
+++ b/packages/renderer-dom/README.md
@@ -77,8 +77,9 @@ diagram.destroy();    // clean up DOM + cancel animations
 | `sceneBoundaryProgress` | `boolean \| string` | `true` | Show boundary progress bar, or pass a custom color/gradient string |
 | `progressColor` | `string` | `plan.meta.progressColor ?? "rainbow"` | Custom progress bar color (e.g. `"#3b82f6"`) or gradient (e.g. `"#ec4899, #8b5cf6"`) |
 | `playbackRate` | `number` | `plan.meta.playbackRate ?? 1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
-| `interactiveViewport` | `boolean` | `controls \|\| plan.meta.interactiveViewport` | Enable wheel zoom and drag pan on the rendered viewport |
-| `controls` | `boolean` | `plan.meta.controls ?? false` | Show left-aligned footer controls toolbar (play/pause, restart, speed, reset view); also enables viewport interaction |
+| `interactiveViewport` | `boolean` | `controls \|\| player.interaction` | Enable wheel zoom and drag pan on the rendered viewport |
+| `controls` | `boolean` | `player.controls` | Show the footer toolbar (play, prev/next beat, restart, seek, speed, fit, reset view, SVG, share); also enables viewport interaction |
+| `shareUrl` | `string` | Markdy playground | Base URL used by the Share control when building `#code=` links |
 | `onWarning` | `(warning: Diagnostic) => void` | `console.warn` | Called for each soft parse warning |
 | `onTimeUpdate` | `(seconds: number, durationSeconds: number) => void` | — | Called whenever playback or seek changes the current time |
 | `onPlayStateChange` | `(playing: boolean) => void` | — | Called when playback starts or pauses |

--- a/packages/renderer-dom/src/diagram.ts
+++ b/packages/renderer-dom/src/diagram.ts
@@ -1,7 +1,14 @@
 /**
  * Markdy diagram runtime — renders a RenderPlan via WAAPI.
  */
-import { parseAndCompile, type BeatRange, type Diagnostic } from "@markdy/core";
+import {
+  compressMarkdyToUrlHash,
+  parseAndCompile,
+  resolvePlayer,
+  type BeatRange,
+  type Diagnostic,
+  type PlayerProgress,
+} from "@markdy/core";
 import {
   buildCueAnimations,
   buildStructuralEdgeAnimations,
@@ -19,11 +26,11 @@ import { mountTreeBuses } from "./tree.js";
 import { applyThemeToScene, ensureSceneStyles } from "./theme.js";
 
 const NORMAL_PLAYBACK_RATE = 4 / 5;
-const DEFAULT_PLAYBACK_RATE = 1;
 const MIN_VIEWPORT_ZOOM = 0.5;
 const MAX_VIEWPORT_ZOOM = 3;
 const VIEWPORT_ZOOM_STEP = 0.0015;
 const DRAG_CLICK_THRESHOLD_PX = 4;
+const BEAT_NAV_EPSILON_S = 0.05;
 const MARKDY_PLAYGROUND_URL = "https://markdy.com/playground/";
 
 function encodeCodeForPlaygroundHash(code: string): string {
@@ -54,6 +61,8 @@ export interface DiagramOptions {
   playbackRate?: number;
   /** Enable wheel zoom and drag pan on the rendered viewport. Defaults to false. */
   interactiveViewport?: boolean;
+  /** Base URL for the Share control. Defaults to the Markdy playground. */
+  shareUrl?: string;
   /** Show built-in playback and viewport controls. Also enables viewport interaction. Defaults to false. */
   controls?: boolean;
   onWarning?: (warning: Diagnostic) => void;
@@ -73,6 +82,8 @@ export interface Diagram {
   isPlaying(): boolean;
   beats(): BeatRange[];
   seekToBeat(name: string): void;
+  nextBeat(): void;
+  prevBeat(): void;
   destroy(): void;
 }
 
@@ -126,6 +137,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     playbackRate: initialPlaybackRate,
     controls: explicitControls,
     interactiveViewport: explicitInteractiveViewport,
+    shareUrl,
     autoplay: explicitAutoplay,
     loop: explicitLoop,
     copyright: explicitCopyright,
@@ -140,34 +152,60 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     if (w.severity === "warning") onWarning(w);
   }
 
-  const controls = explicitControls ?? plan.meta.controls ?? false;
-  const interactiveViewport =
-    explicitInteractiveViewport ??
-    (explicitControls !== undefined ? explicitControls : (plan.meta.interactiveViewport ?? plan.meta.controls ?? false));
-  const autoplay = explicitAutoplay ?? plan.meta.autoplay ?? true;
-  const loop = explicitLoop ?? plan.meta.loop ?? true;
-  const copyright = explicitCopyright ?? plan.meta.copyright ?? true;
-
-  const rawPlaybackRate = initialPlaybackRate ?? plan.meta.playbackRate ?? DEFAULT_PLAYBACK_RATE;
-  let playbackRate = Number.isFinite(rawPlaybackRate) && rawPlaybackRate > 0 ? rawPlaybackRate : DEFAULT_PLAYBACK_RATE;
-
-  const showSceneBoundaryProgress =
+  const hostProgress: PlayerProgress | undefined =
     sceneBoundaryProgress === false || (sceneBoundaryProgress === undefined && progressBar === false)
-      ? false
-      : plan.meta.progressColor === "none"
-        ? false
-        : true;
-
-  const rawColor =
+      ? "none"
+      : undefined;
+  const hostProgressColor =
     progressColor ??
     progressBarColor ??
     (typeof sceneBoundaryProgress === "string" && sceneBoundaryProgress !== "true" && sceneBoundaryProgress !== "false"
       ? sceneBoundaryProgress
       : typeof progressBar === "string" && progressBar !== "true" && progressBar !== "false"
         ? progressBar
-        : undefined) ??
-    (plan.meta.progressColor && plan.meta.progressColor !== "none" ? plan.meta.progressColor : undefined);
+        : undefined);
 
+  const player = resolvePlayer(plan.meta.player, {
+    autoplay: explicitAutoplay,
+    loop: explicitLoop,
+    playbackRate: initialPlaybackRate,
+    copyright: explicitCopyright,
+    controls: explicitControls,
+    interactiveViewport: explicitInteractiveViewport,
+    progress: hostProgress,
+    progressColor: hostProgressColor,
+  });
+
+  const { autoplay, loop } = player.playback;
+  const {
+    enabled: interactiveViewport,
+    zoom: allowZoom,
+    pan: allowPan,
+    clickToPlay,
+    doubleClickToReset,
+    keyboard: keyboardShortcuts,
+  } = player.interaction;
+  const {
+    enabled: showControls,
+    play: playButton,
+    restart: restartButton,
+    prevBeat: prevBeatButton,
+    nextBeat: nextBeatButton,
+    seek: seekBar,
+    speed: speedControls,
+    speeds: speedOptions,
+    fit: fitViewButton,
+    resetView: resetViewButton,
+    svg: svgButton,
+    share: shareButton,
+  } = player.controls;
+  const copyright = player.chrome.badge;
+  const progressMode = player.chrome.progress;
+  const showProgress = progressMode !== "none";
+
+  let playbackRate = player.playback.rate;
+
+  const rawColor = player.chrome.progressColor;
   const customColor = rawColor && rawColor.trim() !== "rainbow" ? rawColor.trim() : null;
   const DEFAULT_RAINBOW =
     "hsl(0,90%,60%), hsl(45,90%,55%), hsl(90,80%,50%), hsl(180,80%,50%), hsl(270,80%,55%), hsl(330,90%,60%)";
@@ -190,11 +228,11 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   container.appendChild(viewport);
 
   let progressEl: HTMLElement | null = null;
-  if (showSceneBoundaryProgress) {
+  if (showProgress) {
     progressEl = document.createElement("div");
     Object.assign(progressEl.style, {
       position: "absolute",
-      inset: "0",
+      ...(progressMode === "bar" ? { left: "0", right: "0", bottom: "0", height: "3px" } : { inset: "0" }),
       zIndex: "9999",
       pointerEvents: "none",
       borderRadius: "inherit",
@@ -207,6 +245,12 @@ export function createDiagram(opts: DiagramOptions): Diagram {
 
   function updateProgressBar(pct: number): void {
     if (!progressEl) return;
+    if (progressMode === "bar") {
+      progressEl.style.background = customColor ?? "#2563eb";
+      progressEl.style.transformOrigin = "left center";
+      progressEl.style.transform = `scaleX(${pct})`;
+      return;
+    }
     const deg = pct * 360;
     const colorStops = customColor
       ? customColor.includes(",")
@@ -520,16 +564,46 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   let suppressNextClick = false;
   let controlsPlayButton: HTMLButtonElement | null = null;
   let controlsRateButtons: HTMLButtonElement[] = [];
+  let controlsSeekBar: HTMLInputElement | null = null;
+  let controlsFitButton: HTMLButtonElement | null = null;
+  let fitViewActive = false;
 
   function applyViewportTransform(): void {
     viewportTransform.style.transform = `translate(${viewportPanX}px, ${viewportPanY}px) scale(${viewportScale})`;
   }
 
   function resetViewportTransform(): void {
+    releaseFitView();
     viewportScale = 1;
     viewportPanX = 0;
     viewportPanY = 0;
     applyViewportTransform();
+  }
+
+  /** Inline `!important` outranks cue animations, pinning the camera. */
+  function releaseFitView(): void {
+    if (!fitViewActive) return;
+    fitViewActive = false;
+    cameraLayer.style.removeProperty("transform");
+  }
+
+  function toggleFitView(): void {
+    if (fitViewActive) {
+      resetViewportTransform();
+      syncControls();
+      return;
+    }
+
+    const bounds = computeContentBounds();
+    const scale = Math.min(plan.meta.width / bounds.width, plan.meta.height / bounds.height);
+    viewportScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+    viewportPanX = -bounds.minX * viewportScale + (plan.meta.width - bounds.width * viewportScale) / 2;
+    viewportPanY = -bounds.minY * viewportScale + (plan.meta.height - bounds.height * viewportScale) / 2;
+    applyViewportTransform();
+
+    fitViewActive = true;
+    cameraLayer.style.setProperty("transform", "none", "important");
+    syncControls();
   }
 
   function handleViewportWheel(event: WheelEvent): void {
@@ -550,6 +624,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   }
 
   function handleViewportPointerDown(event: PointerEvent): void {
+    if (!allowPan) return;
     if (event.button !== 0 || activePointerId !== null) return;
     activePointerId = event.pointerId;
     dragStartX = event.clientX;
@@ -607,6 +682,13 @@ export function createDiagram(opts: DiagramOptions): Diagram {
       button.style.background = active ? "#1e293b" : "rgba(248, 250, 252, 0.92)";
       button.style.color = active ? "#ffffff" : "#475569";
       button.style.borderColor = active ? "#0f172a" : "rgba(148, 163, 184, 0.55)";
+    }
+    if (controlsSeekBar) controlsSeekBar.value = String(sceneMs / 1000);
+    if (controlsFitButton) {
+      controlsFitButton.setAttribute("aria-pressed", fitViewActive ? "true" : "false");
+      controlsFitButton.style.background = fitViewActive ? "#1e293b" : "rgba(248, 250, 252, 0.92)";
+      controlsFitButton.style.color = fitViewActive ? "#ffffff" : "#475569";
+      controlsFitButton.style.borderColor = fitViewActive ? "#0f172a" : "rgba(148, 163, 184, 0.55)";
     }
   }
 
@@ -688,8 +770,23 @@ export function createDiagram(opts: DiagramOptions): Diagram {
       const beat = plan.beats.find((b) => b.name === name);
       if (beat) diagram.seek(beat.start);
     },
+    nextBeat() {
+      const next = plan.beats.find((beat) => beat.start > sceneMs / 1000 + BEAT_NAV_EPSILON_S);
+      if (next) diagram.seek(next.start);
+    },
+    prevBeat() {
+      const current = sceneMs / 1000;
+      let target = 0;
+      for (const beat of plan.beats) {
+        if (beat.start < current - BEAT_NAV_EPSILON_S) target = beat.start;
+      }
+      diagram.seek(target);
+    },
     destroy() {
       diagram.pause();
+      if (keyboardShortcuts && typeof window !== "undefined") {
+        window.removeEventListener("keydown", handleKeyDown);
+      }
       for (const anim of allAnims) anim.cancel();
       resizeObserver?.disconnect();
       if (progressEl?.parentNode === viewport) viewport.removeChild(progressEl);
@@ -729,6 +826,178 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     return button;
   }
 
+  function mountPlayControl(toolbar: HTMLElement): void {
+    if (!playButton) return;
+    controlsPlayButton = makeControlButton("Play", "Play diagram");
+    controlsPlayButton.className = "markdy-control-play";
+    controlsPlayButton.addEventListener("click", togglePlayback);
+    toolbar.appendChild(controlsPlayButton);
+  }
+
+  function mountBeatNavControls(toolbar: HTMLElement, position: "prev" | "next"): void {
+    const wanted = position === "prev" ? prevBeatButton : nextBeatButton;
+    if (!wanted || plan.beats.length < 2) return;
+    const label = position === "prev" ? "Prev" : "Next";
+    const button = makeControlButton(label, `${label === "Prev" ? "Previous" : "Next"} beat`);
+    button.className = `markdy-control-${position}-beat`;
+    button.addEventListener("click", () => (position === "prev" ? diagram.prevBeat() : diagram.nextBeat()));
+    toolbar.appendChild(button);
+  }
+
+  function mountRestartControl(toolbar: HTMLElement): void {
+    if (!restartButton) return;
+    const button = makeControlButton("Restart", "Restart diagram");
+    button.className = "markdy-control-restart";
+    button.addEventListener("click", () => {
+      diagram.seek(0);
+      diagram.play();
+    });
+    toolbar.appendChild(button);
+  }
+
+  function mountSeekControl(toolbar: HTMLElement): void {
+    if (!seekBar) return;
+    controlsSeekBar = document.createElement("input");
+    controlsSeekBar.className = "markdy-control-seek";
+    controlsSeekBar.type = "range";
+    controlsSeekBar.min = "0";
+    controlsSeekBar.max = String(durationSeconds);
+    controlsSeekBar.step = "0.01";
+    controlsSeekBar.value = String(sceneMs / 1000);
+    controlsSeekBar.setAttribute("aria-label", "Seek diagram timeline");
+    controlsSeekBar.addEventListener("input", () => diagram.seek(Number(controlsSeekBar?.value ?? 0)));
+    toolbar.appendChild(controlsSeekBar);
+  }
+
+  function mountSpeedControls(toolbar: HTMLElement): void {
+    if (!speedControls) return;
+    controlsRateButtons = speedOptions.map((rate) => {
+      const button = makeControlButton(`${rate}x`, `Set playback speed to ${rate}x`);
+      button.className = "markdy-control-rate";
+      button.dataset.rate = String(rate);
+      button.setAttribute("aria-pressed", "false");
+      button.addEventListener("click", () => diagram.setPlaybackRate(rate));
+      toolbar.appendChild(button);
+      return button;
+    });
+  }
+
+  function flashControlLabel(button: HTMLButtonElement, message: string): void {
+    const original = button.textContent ?? "";
+    button.textContent = message;
+    setTimeout(() => {
+      button.textContent = original;
+    }, 1400);
+  }
+
+  function downloadFile(filename: string, contents: string, type: string): void {
+    const blob = new Blob([contents], { type });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.style.display = "none";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  function mountSvgControl(toolbar: HTMLElement): void {
+    if (!svgButton) return;
+    const button = makeControlButton("SVG", "Export diagram as SVG");
+    button.className = "markdy-control-svg";
+    button.addEventListener("click", async () => {
+      const resumeAt = sceneMs;
+      const wasPlaying = isPlaying;
+      try {
+        // Export the settled frame so every revealed node is present.
+        diagram.pause();
+        diagram.seek(durationSeconds);
+        const { exportDiagramAsVectorSvg } = await import("./export/svg-exporter.js");
+        const svg = exportDiagramAsVectorSvg(container);
+        const name = (plan.title || "markdy-diagram").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+        downloadFile(`${name || "markdy-diagram"}.svg`, svg, "image/svg+xml");
+      } catch (error) {
+        onWarning({ severity: "warning", message: `SVG export failed: ${String(error)}`, line: 0 });
+        flashControlLabel(button, "Failed");
+      } finally {
+        diagram.seek(resumeAt / 1000);
+        if (wasPlaying) diagram.play();
+      }
+    });
+    toolbar.appendChild(button);
+  }
+
+  function mountShareControl(toolbar: HTMLElement): void {
+    if (!shareButton) return;
+    const button = makeControlButton("Share", "Copy a share link for this diagram");
+    button.className = "markdy-control-share";
+    button.addEventListener("click", async () => {
+      try {
+        const hash = await compressMarkdyToUrlHash(code);
+        const base = shareUrl ?? MARKDY_PLAYGROUND_URL;
+        await navigator.clipboard.writeText(`${base}#code=${hash}`);
+        flashControlLabel(button, "Copied");
+      } catch (error) {
+        onWarning({ severity: "warning", message: `Share link failed: ${String(error)}`, line: 0 });
+        flashControlLabel(button, "Failed");
+      }
+    });
+    toolbar.appendChild(button);
+  }
+
+  function mountFitControl(toolbar: HTMLElement): void {
+    if (!fitViewButton) return;
+    controlsFitButton = makeControlButton("Fit", "Fit all items in view and ignore camera zoom");
+    controlsFitButton.className = "markdy-control-fit";
+    controlsFitButton.setAttribute("aria-pressed", "false");
+    controlsFitButton.addEventListener("click", toggleFitView);
+    toolbar.appendChild(controlsFitButton);
+  }
+
+  function mountResetViewControl(toolbar: HTMLElement): void {
+    if (!resetViewButton) return;
+    const button = makeControlButton("Reset", "Reset diagram view");
+    button.className = "markdy-control-reset-view";
+    button.addEventListener("click", resetViewportTransform);
+    toolbar.appendChild(button);
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    const target = event.target as HTMLElement | null;
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      target?.isContentEditable
+    ) {
+      return;
+    }
+
+    switch (event.key) {
+      case "ArrowRight":
+      case "PageDown":
+        event.preventDefault();
+        diagram.nextBeat();
+        break;
+      case "ArrowLeft":
+      case "PageUp":
+        event.preventDefault();
+        diagram.prevBeat();
+        break;
+      case " ":
+        event.preventDefault();
+        togglePlayback();
+        break;
+      case "Home":
+        event.preventDefault();
+        diagram.seek(0);
+        break;
+      default:
+    }
+  }
+
   function mountControls(): void {
     const toolbar = document.createElement("div");
     toolbar.className = "markdy-controls";
@@ -755,35 +1024,16 @@ export function createDiagram(opts: DiagramOptions): Diagram {
       toolbar.addEventListener(eventName, (event) => event.stopPropagation());
     }
 
-    controlsPlayButton = makeControlButton("Play", "Play diagram");
-    controlsPlayButton.className = "markdy-control-play";
-    controlsPlayButton.addEventListener("click", togglePlayback);
-    toolbar.appendChild(controlsPlayButton);
-
-    const restartButton = makeControlButton("Restart", "Restart diagram");
-    restartButton.className = "markdy-control-restart";
-    restartButton.addEventListener("click", () => {
-      diagram.seek(0);
-      diagram.play();
-    });
-    toolbar.appendChild(restartButton);
-
-    controlsRateButtons = [0.5, 1, 2].map((rate) => {
-      const button = makeControlButton(`${rate}x`, `Set playback speed to ${rate}x`);
-      button.className = "markdy-control-rate";
-      button.dataset.rate = String(rate);
-      button.setAttribute("aria-pressed", "false");
-      button.addEventListener("click", () => diagram.setPlaybackRate(rate));
-      toolbar.appendChild(button);
-      return button;
-    });
-
-    if (interactiveViewport) {
-      const resetButton = makeControlButton("Reset", "Reset diagram view");
-      resetButton.className = "markdy-control-reset-view";
-      resetButton.addEventListener("click", resetViewportTransform);
-      toolbar.appendChild(resetButton);
-    }
+    mountPlayControl(toolbar);
+    mountBeatNavControls(toolbar, "prev");
+    mountBeatNavControls(toolbar, "next");
+    mountRestartControl(toolbar);
+    mountSeekControl(toolbar);
+    mountSpeedControls(toolbar);
+    mountFitControl(toolbar);
+    mountResetViewControl(toolbar);
+    mountSvgControl(toolbar);
+    mountShareControl(toolbar);
 
     ensureFooter().insertBefore(toolbar, badge ?? null);
     syncControls();
@@ -792,21 +1042,29 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   viewport.style.cursor = interactiveViewport ? "grab" : "pointer";
   if (interactiveViewport) {
     viewport.style.touchAction = "none";
-    viewport.addEventListener("wheel", handleViewportWheel, { passive: false });
-    viewport.addEventListener("pointerdown", handleViewportPointerDown);
-    viewport.addEventListener("pointermove", handleViewportPointerMove);
-    viewport.addEventListener("pointerup", handleViewportPointerEnd);
-    viewport.addEventListener("pointercancel", handleViewportPointerEnd);
-    viewport.addEventListener("dblclick", handleViewportDoubleClick);
-  }
-  if (controls) mountControls();
-  viewport.addEventListener("click", () => {
-    if (suppressNextClick) {
-      suppressNextClick = false;
-      return;
+    if (allowZoom) viewport.addEventListener("wheel", handleViewportWheel, { passive: false });
+    if (allowPan) {
+      viewport.addEventListener("pointerdown", handleViewportPointerDown);
+      viewport.addEventListener("pointermove", handleViewportPointerMove);
+      viewport.addEventListener("pointerup", handleViewportPointerEnd);
+      viewport.addEventListener("pointercancel", handleViewportPointerEnd);
     }
-    togglePlayback();
-  });
+    if (doubleClickToReset) viewport.addEventListener("dblclick", handleViewportDoubleClick);
+  }
+  if (showControls) mountControls();
+  if (clickToPlay) {
+    viewport.addEventListener("click", () => {
+      if (suppressNextClick) {
+        suppressNextClick = false;
+        return;
+      }
+      togglePlayback();
+    });
+  }
+
+  if (keyboardShortcuts && typeof window !== "undefined") {
+    window.addEventListener("keydown", handleKeyDown);
+  }
 
   if (autoplay) diagram.play();
   return diagram;

--- a/packages/renderer-dom/tests/diagram.smoke.test.ts
+++ b/packages/renderer-dom/tests/diagram.smoke.test.ts
@@ -358,6 +358,270 @@ beat b1:
     diagram2.destroy();
   });
 
+  it("applies granular player controls without coupling interaction behavior", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const diagram = createDiagram({
+      container,
+      code: `
+player:
+  playback:
+    autoplay false
+  chrome:
+    badge false
+    progress bar
+  controls:
+    play true
+    restart false
+    seek true
+    speed false
+    reset_view false
+  interaction:
+    zoom false
+    pan true
+    click_to_play false
+
+scene theme=paper
+service A
+beat b1:
+  show A
+`,
+    });
+
+    const viewport = container.firstElementChild as HTMLElement;
+    const footer = document.body.querySelector<HTMLElement>(".markdy-footer");
+    const seek = footer?.querySelector<HTMLInputElement>(".markdy-control-seek") ?? null;
+    expect(footer?.querySelector(".markdy-control-play")).not.toBeNull();
+    expect(footer?.querySelector(".markdy-control-restart")).toBeNull();
+    expect(footer?.querySelector(".markdy-control-rate")).toBeNull();
+    expect(footer?.querySelector(".markdy-control-reset-view")).toBeNull();
+    expect(seek).not.toBeNull();
+
+    viewport.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.isPlaying()).toBe(false);
+    viewport.dispatchEvent(pointerEvent("pointerdown", { clientX: 20, clientY: 20 }));
+    viewport.dispatchEvent(pointerEvent("pointermove", { clientX: 40, clientY: 25 }));
+    viewport.dispatchEvent(pointerEvent("pointerup", { clientX: 40, clientY: 25 }));
+    expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).toContain("translate(20px, 5px)");
+
+    seek!.value = "0.5";
+    seek!.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(diagram.currentTime()).toBe(0.5);
+    const progress = viewport.querySelector<HTMLElement>("div[style*='z-index: 9999']");
+    expect(progress?.style.height).toBe("3px");
+    expect(progress?.style.transform).toContain("scaleX");
+    diagram.destroy();
+  });
+
+  it("turns a player group off when every affordance in it is false", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const diagram = createDiagram({
+      container,
+      code: `
+player:
+  playback:
+    autoplay false
+  chrome:
+    badge false
+  controls:
+    play false
+    restart false
+    prev_beat false
+    next_beat false
+    seek false
+    speed false
+    fit false
+    reset_view false
+    svg false
+    share false
+  interaction:
+    zoom false
+    pan false
+    double_click_to_reset false
+
+scene theme=paper
+service A
+beat b1:
+  show A
+`,
+    });
+
+    const viewport = container.firstElementChild as HTMLElement;
+    expect(document.body.querySelector(".markdy-controls")).toBeNull();
+    expect(viewport.style.cursor).toBe("pointer");
+
+    viewport.dispatchEvent(pointerEvent("pointerdown", { clientX: 20, clientY: 20 }));
+    viewport.dispatchEvent(pointerEvent("pointermove", { clientX: 60, clientY: 40 }));
+    viewport.dispatchEvent(pointerEvent("pointerup", { clientX: 60, clientY: 40 }));
+    expect(container.querySelector<HTMLElement>(".markdy-viewport-transform")?.style.transform).not.toContain("translate(40px");
+
+    // click-to-play stays independent of viewport gestures
+    viewport.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.isPlaying()).toBe(true);
+    diagram.destroy();
+  });
+
+  it("fits every item in view and pins the camera against zoom cues", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const diagram = createDiagram({
+      container,
+      code: `
+player:
+  playback:
+    autoplay false
+  chrome:
+    badge false
+  controls:
+    play false
+    restart false
+    seek false
+    speed false
+    reset_view false
+
+scene theme=paper
+service A
+service B
+beat b1:
+  show A
+  frame A zoom=1.18
+`,
+    });
+
+    const cameraLayer = container.querySelector<HTMLElement>(".markdy-camera-layer")!;
+    const transformLayer = container.querySelector<HTMLElement>(".markdy-viewport-transform")!;
+    const fitButton = document.body.querySelector<HTMLButtonElement>(".markdy-control-fit")!;
+
+    expect(fitButton).not.toBeNull();
+    expect(fitButton.getAttribute("aria-pressed")).toBe("false");
+
+    fitButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(fitButton.getAttribute("aria-pressed")).toBe("true");
+    // Camera zoom cues are outranked while fitted.
+    expect(cameraLayer.style.getPropertyPriority("transform")).toBe("important");
+    expect(cameraLayer.style.transform).toBe("none");
+    expect(transformLayer.style.transform).toMatch(/translate\(.+\) scale\(.+\)/);
+
+    fitButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(fitButton.getAttribute("aria-pressed")).toBe("false");
+    expect(cameraLayer.style.transform).toBe("");
+    expect(transformLayer.style.transform).toBe("translate(0px, 0px) scale(1)");
+
+    diagram.destroy();
+  });
+
+  it("navigates beats from the toolbar, keyboard, and custom speed options", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const diagram = createDiagram({
+      container,
+      code: `
+player:
+  playback:
+    autoplay false
+  chrome:
+    badge false
+  controls:
+    seek false
+    fit false
+    speeds "0.25 1 3"
+  interaction:
+    keyboard true
+
+scene theme=paper
+service A
+service B
+beat one:
+  show A
+beat two:
+  show B
+`,
+    });
+
+    const footer = document.body.querySelector<HTMLElement>(".markdy-footer")!;
+    const nextButton = footer.querySelector<HTMLButtonElement>(".markdy-control-next-beat")!;
+    const prevButton = footer.querySelector<HTMLButtonElement>(".markdy-control-prev-beat")!;
+    const rates = [...footer.querySelectorAll<HTMLButtonElement>(".markdy-control-rate")].map((b) => b.dataset.rate);
+
+    expect(rates).toEqual(["0.25", "1", "3"]);
+
+    const secondBeat = diagram.beats()[1];
+    expect(secondBeat.start).toBeGreaterThan(0);
+
+    nextButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.currentTime()).toBeCloseTo(secondBeat.start);
+
+    prevButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(diagram.currentTime()).toBe(0);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(diagram.currentTime()).toBeCloseTo(secondBeat.start);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    expect(diagram.isPlaying()).toBe(true);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+    expect(diagram.currentTime()).toBe(0);
+
+    diagram.destroy();
+    // Listeners are removed with the diagram.
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(diagram.currentTime()).toBe(0);
+  });
+
+  it("leaves keyboard shortcuts off unless the scene opts in", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const diagram = createDiagram({ container, code: SCENE, autoplay: false, copyright: false });
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    expect(diagram.isPlaying()).toBe(false);
+
+    diagram.destroy();
+  });
+
+  it("copies a share link from the toolbar", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    const diagram = createDiagram({
+      container,
+      code: `
+player:
+  playback:
+    autoplay false
+  chrome:
+    badge false
+  controls:
+    play false
+    restart false
+    seek false
+    speed false
+    fit false
+    reset_view false
+
+scene theme=paper
+service A
+beat b1:
+  show A
+`,
+      shareUrl: "https://example.test/studio/",
+    });
+
+    const footer = document.body.querySelector<HTMLElement>(".markdy-footer")!;
+    expect(footer.querySelector(".markdy-control-svg")).not.toBeNull();
+    const shareControl = footer.querySelector<HTMLButtonElement>(".markdy-control-share")!;
+
+    shareControl.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0][0]).toMatch(/^https:\/\/example\.test\/studio\/#code=/);
+
+    diagram.destroy();
+  });
+
   it("mounts and destroys diagrams across all supported diagram archetypes without throwing", () => {
     const archetypes = [
       "architecture",

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -556,24 +556,10 @@ const homepageStructuredData = [
         <div class="studio-preview-pane">
           <div class="preview-transport-bar">
             <div class="transport-controls">
-              <button id="restart-btn" class="btn-transport" title="Restart">⏮</button>
-              <button id="rewind-btn" class="btn-transport" title="Back 1s">⏪ 1s</button>
-              <button id="play-btn" class="btn-transport-play" title="Play / Pause">
-                <svg id="play-icon" width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
-                <svg id="pause-icon" width="11" height="11" viewBox="0 0 24 24" fill="currentColor" style="display:none"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
-                <span id="play-label">Play</span>
-              </button>
               <button id="auto-shuffle-btn" class="btn-transport auto-shuffle-btn" title="Auto-Shuffle OFF: Click to enable auto-cycling examples on scene end" aria-pressed="false">
                 <span class="shuffle-icon">🔀</span>
                 <span class="shuffle-label">Shuffle</span>
               </button>
-            </div>
-
-            <div class="speed-group">
-              <button class="speed-btn" type="button" data-speed="0.5">0.5×</button>
-              <button class="speed-btn active" type="button" data-speed="1">1×</button>
-              <button class="speed-btn" type="button" data-speed="1.5">1.5×</button>
-              <button class="speed-btn" type="button" data-speed="2">2×</button>
             </div>
 
             <span id="status" class="status-indicator status-ok"></span>
@@ -581,12 +567,6 @@ const homepageStructuredData = [
 
           <div id="stage-wrap" class="stage-wrap">
             <div id="stage"></div>
-          </div>
-
-          <div class="timeline-bar">
-            <select id="scene-jump" class="scene-jump" aria-label="Jump to scene" hidden></select>
-            <input id="timeline-range" class="timeline-range" type="range" min="0" max="0" step="0.01" value="0" aria-label="Scrub timeline" />
-            <span id="timeline-time" class="timeline-time">0:00 / 0:00</span>
           </div>
         </div>
       </div>
@@ -952,16 +932,6 @@ markdy check-all ./docs/diagrams</code></pre>
   const stageWrap = document.getElementById("stage-wrap") as HTMLDivElement;
   const runBtn = document.getElementById("run-btn") as HTMLButtonElement;
   const statusEl = document.getElementById("status") as HTMLSpanElement;
-  const playBtn = document.getElementById("play-btn") as HTMLButtonElement;
-  const restartBtn = document.getElementById("restart-btn") as HTMLButtonElement;
-  const rewindBtn = document.getElementById("rewind-btn") as HTMLButtonElement;
-  const playIcon = document.getElementById("play-icon") as SVGElement;
-  const pauseIcon = document.getElementById("pause-icon") as SVGElement;
-  const playLabel = document.getElementById("play-label") as HTMLSpanElement;
-  const speedBtns = document.querySelectorAll<HTMLButtonElement>(".speed-btn");
-  const timelineRange = document.getElementById("timeline-range") as HTMLInputElement;
-  const timelineTime = document.getElementById("timeline-time") as HTMLSpanElement;
-  const sceneJump = document.getElementById("scene-jump") as HTMLSelectElement;
   const exampleSelect = document.getElementById("example-select") as HTMLSelectElement;
   const presetChips = document.querySelectorAll<HTMLButtonElement>(".preset-chip");
   const autoShuffleBtn = document.getElementById("auto-shuffle-btn") as HTMLButtonElement | null;
@@ -970,8 +940,6 @@ markdy check-all ./docs/diagrams</code></pre>
   let isAnimPlaying = false;
   let debounce: ReturnType<typeof setTimeout> | null = null;
   let editorView: any = null;
-  let isScrubbing = false;
-  let selectedPlaybackRate = 1;
   let isAutoShuffleEnabled = false;
   let autoShuffleTimer: ReturnType<typeof setTimeout> | null = null;
   let currentExampleIndex = 0;
@@ -1053,52 +1021,6 @@ markdy check-all ./docs/diagrams</code></pre>
     statusEl.className = `status-indicator ${ok ? "status-ok" : "status-error"}`;
   }
 
-  function formatTime(seconds: number): string {
-    if (!Number.isFinite(seconds) || seconds <= 0) return "0:00";
-    const total = Math.floor(seconds);
-    const mins = Math.floor(total / 60);
-    const secs = total % 60;
-    return `${mins}:${secs.toString().padStart(2, "0")}`;
-  }
-
-  function setTimeline(current: number, duration: number) {
-    if (!timelineRange || !timelineTime) return;
-    const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : 0;
-    const safeCurrent = safeDuration > 0 ? Math.min(Math.max(current, 0), safeDuration) : 0;
-    timelineRange.max = safeDuration.toFixed(2);
-    if (!isScrubbing) timelineRange.value = safeCurrent.toFixed(2);
-    timelineRange.disabled = safeDuration <= 0;
-    timelineTime.textContent = `${formatTime(safeCurrent)} / ${formatTime(safeDuration)}`;
-  }
-
-  function setPlayState(playing: boolean) {
-    isAnimPlaying = playing;
-    if (playIcon) playIcon.style.display = playing ? "none" : "";
-    if (pauseIcon) pauseIcon.style.display = playing ? "" : "none";
-    if (playLabel) playLabel.textContent = playing ? "Pause" : "Play";
-    if (playBtn) playBtn.setAttribute("aria-label", playing ? "Pause" : "Play");
-  }
-
-  function populateSceneJump(beats: { name: string; start: number }[]) {
-    if (!sceneJump) return;
-    sceneJump.innerHTML = "";
-    if (beats.length === 0) {
-      sceneJump.hidden = true;
-      return;
-    }
-    sceneJump.hidden = false;
-    const placeholder = document.createElement("option");
-    placeholder.value = "";
-    placeholder.textContent = "Jump to beat…";
-    sceneJump.appendChild(placeholder);
-    for (const beat of beats) {
-      const option = document.createElement("option");
-      option.value = beat.name;
-      option.textContent = beat.name;
-      sceneJump.appendChild(option);
-    }
-  }
-
   async function render(code: string, shouldAutoplay = true) {
     if (!stage) return;
     try {
@@ -1112,12 +1034,10 @@ markdy check-all ./docs/diagrams</code></pre>
         loop: false,
         copyright: false,
         sceneBoundaryProgress: false,
-        playbackRate: selectedPlaybackRate,
+        controls: true,
         interactiveViewport: true,
-        onTimeUpdate: setTimeline,
-        onPlayStateChange: setPlayState,
         onEnded: () => {
-          setPlayState(false);
+          isAnimPlaying = false;
           if (diagram) {
             diagram.pause();
             diagram.seek(diagram.duration());
@@ -1127,15 +1047,13 @@ markdy check-all ./docs/diagrams</code></pre>
           }
         },
       });
-      setPlayState(shouldAutoplay);
-      setTimeline(diagram.currentTime(), diagram.duration());
-      populateSceneJump(diagram.beats());
+      isAnimPlaying = shouldAutoplay;
       setStatus(true);
     } catch (e) {
       const msg = (e as Error).message ?? String(e);
       stage.innerHTML = `<p class="parse-error" style="color:var(--danger);padding:1rem;font-family:monospace;font-size:0.8rem;">${msg}</p>`;
       setStatus(false);
-      setPlayState(false);
+      isAnimPlaying = false;
     }
   }
 
@@ -1354,34 +1272,6 @@ markdy check-all ./docs/diagrams</code></pre>
     }
   });
 
-  // Playback transport buttons
-  playBtn?.addEventListener("click", () => {
-    clearAutoShuffleTimer();
-    if (!diagram) return;
-    if (isAnimPlaying) {
-      diagram.pause();
-    } else {
-      if (diagram.currentTime() >= diagram.duration() && diagram.duration() > 0) {
-        diagram.seek(0);
-      }
-      diagram.play();
-    }
-  });
-
-  restartBtn?.addEventListener("click", () => {
-    clearAutoShuffleTimer();
-    if (diagram) {
-      diagram.seek(0);
-      diagram.play();
-    }
-  });
-
-  rewindBtn?.addEventListener("click", () => {
-    clearAutoShuffleTimer();
-    if (!diagram) return;
-    diagram.seek(Math.max(0, diagram.currentTime() - 1));
-  });
-
   autoShuffleBtn?.addEventListener("click", () => {
     isAutoShuffleEnabled = !isAutoShuffleEnabled;
     autoShuffleBtn.classList.toggle("active", isAutoShuffleEnabled);
@@ -1391,30 +1281,6 @@ markdy check-all ./docs/diagrams</code></pre>
       : "Auto-Shuffle OFF: Click to enable auto-cycling examples on scene end";
     if (!isAutoShuffleEnabled) {
       clearAutoShuffleTimer();
-    }
-  });
-
-  speedBtns.forEach((btn) => {
-    btn.addEventListener("click", () => {
-      const speed = Number(btn.dataset.speed || "1");
-      selectedPlaybackRate = speed;
-      speedBtns.forEach((b) => b.classList.toggle("active", b === btn));
-      diagram?.setPlaybackRate(speed);
-    });
-  });
-
-  timelineRange?.addEventListener("input", () => {
-    isScrubbing = true;
-    diagram?.seek(Number(timelineRange.value));
-  });
-
-  timelineRange?.addEventListener("change", () => {
-    isScrubbing = false;
-  });
-
-  sceneJump?.addEventListener("change", () => {
-    if (sceneJump.value) {
-      diagram?.jumpTo(sceneJump.value);
     }
   });
 
@@ -1690,9 +1556,17 @@ markdy check-all ./docs/diagrams</code></pre>
     }
     if (e.code === "Space") {
       e.preventDefault();
-      playBtn?.click();
+      clearAutoShuffleTimer();
+      if (!diagram) return;
+      if (diagram.isPlaying()) diagram.pause();
+      else {
+        if (diagram.currentTime() >= diagram.duration() && diagram.duration() > 0) diagram.seek(0);
+        diagram.play();
+      }
     } else if (e.key === "r" || e.key === "R") {
-      restartBtn?.click();
+      clearAutoShuffleTimer();
+      diagram?.seek(0);
+      diagram?.play();
     }
   });
 
@@ -2812,46 +2686,6 @@ markdy check-all ./docs/diagrams</code></pre>
     color: var(--accent);
   }
 
-  .btn-transport-play {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    background: var(--accent-light);
-    border: 1px solid var(--accent);
-    color: var(--accent);
-    font-size: 0.74rem;
-    font-weight: 700;
-    padding: 0.3rem 0.65rem;
-    min-height: 28px;
-    border-radius: 6px;
-    cursor: pointer;
-  }
-
-  .speed-group {
-    display: flex;
-    gap: 0.25rem;
-  }
-
-  .speed-btn {
-    font-size: 0.7rem;
-    font-weight: 600;
-    padding: 0.3rem 0.5rem;
-    min-height: 28px;
-    min-width: 28px;
-    border: 1px solid var(--border);
-    background: var(--bg-tertiary);
-    color: var(--text-secondary);
-    border-radius: 6px;
-    cursor: pointer;
-    text-align: center;
-  }
-
-  .speed-btn.active {
-    background: var(--accent);
-    color: #ffffff;
-    border-color: var(--accent);
-  }
-
   .status-indicator {
     width: 7px;
     height: 7px;
@@ -2874,38 +2708,6 @@ markdy check-all ./docs/diagrams</code></pre>
     width: 100%;
     height: 100%;
     position: relative;
-  }
-
-  .timeline-bar {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.35rem 0.75rem;
-    background: var(--bg-secondary);
-    border-top: 1px solid var(--border);
-  }
-
-  .scene-jump {
-    font-size: 0.7rem;
-    background: var(--bg-tertiary);
-    border: 1px solid var(--border);
-    color: var(--text-primary);
-    padding: 0.15rem 0.35rem;
-    border-radius: 4px;
-  }
-
-  .timeline-range {
-    flex: 1;
-    accent-color: var(--accent);
-    cursor: pointer;
-  }
-
-  .timeline-time {
-    font-size: 0.68rem;
-    font-family: "JetBrains Mono", monospace;
-    color: var(--text-muted);
-    min-width: 72px;
-    text-align: right;
   }
 
   /* ─── Main Sections ────────────────────────────────────────────────── */

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -141,14 +141,6 @@ const playgroundStructuredData = [
           <span>⚡ Import / Transpile</span>
         </button>
 
-        <button id="export-svg-btn" class="tool-btn" type="button" title="Export current scene as scalable, styled Vector SVG">
-          <span>🎨 SVG</span>
-        </button>
-
-        <button id="share-btn" class="tool-btn" type="button" title="Copy compressed shareable URL to clipboard">
-          <span>🔗 Share</span>
-        </button>
-
         <a href="https://github.com/HoangYell/markdy-com" target="_blank" rel="noopener noreferrer" class="tool-btn tool-btn-icon" aria-label="GitHub Repository" title="GitHub Repository">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
@@ -389,14 +381,8 @@ const playgroundStructuredData = [
             <div class="canvas-view-controls" role="group" aria-label="Canvas View Controls">
               <button id="canvas-zoom-in-btn" class="canvas-tool-btn" type="button" title="Zoom In (+)">+</button>
               <button id="canvas-zoom-out-btn" class="canvas-tool-btn" type="button" title="Zoom Out (-)">−</button>
-              <button id="canvas-zoom-fit-btn" class="canvas-tool-btn" type="button" title="Reset View (100%)">⛶ Fit</button>
               <button id="canvas-grid-toggle-btn" class="canvas-tool-btn" type="button" title="Toggle Canvas Background Grid (Dots / Mesh / Plain)">▦ Grid</button>
             </div>
-          </div>
-
-          <div class="toolbar preview-actions" aria-label="Canvas actions">
-            <button id="restart-btn" class="tool-btn" type="button" title="Restart animation from beginning">↺ Restart</button>
-            <button id="play-btn" class="tool-btn tool-btn-primary" type="button">Pause</button>
           </div>
         </div>
 
@@ -475,8 +461,8 @@ const playgroundStructuredData = [
         </div>
         <p id="canvas-interaction-help" class="sr-only">Drag a node from the palette onto the canvas. Click any node to open the contextual editor HUD. Drag ports to connect flows.</p>
 
-        <!-- ── Unified Choreography & Storyboard Timeline Dock ── -->
-        <div class="choreography-dock" aria-label="Storyboard beats and animation timeline">
+        <!-- ── Storyboard Dock (transport lives in the built-in player toolbar) ── -->
+        <div class="choreography-dock" aria-label="Storyboard beats">
           <div class="dock-top-row">
             <div class="dock-storyboard-box">
               <span class="dock-label">🎬 Storyboard:</span>
@@ -485,23 +471,6 @@ const playgroundStructuredData = [
               </div>
               <button id="storyboard-add-beat-btn" class="dock-add-beat-btn" type="button" title="Append new animation beat">+ Beat</button>
             </div>
-
-            <div class="dock-speed-box">
-              <select id="beat-jump" class="beat-jump-select" aria-label="Jump to beat" hidden></select>
-              <div class="speed-group" role="group" aria-label="Playback speed">
-                <button class="speed-btn active" type="button" data-speed="1" aria-pressed="true">1x</button>
-                <button class="speed-btn" type="button" data-speed="1.5" aria-pressed="false">1.5x</button>
-                <button class="speed-btn" type="button" data-speed="2" aria-pressed="false">2x</button>
-                <button class="speed-btn" type="button" data-speed="0.5" aria-pressed="false">0.5x</button>
-              </div>
-            </div>
-          </div>
-
-          <div class="dock-timeline-row">
-            <button id="step-prev-btn" class="timeline-step-btn" type="button" title="Step backward">⏮</button>
-            <input id="timeline-range" class="timeline-slider" type="range" min="0" max="0" step="0.01" value="0" aria-label="Scrub animation timeline" />
-            <button id="step-next-btn" class="timeline-step-btn" type="button" title="Step forward">⏭</button>
-            <span id="timeline-label" class="timeline-timestamp">0:00 / 0:00</span>
           </div>
         </div>
       </section>
@@ -673,12 +642,11 @@ const playgroundStructuredData = [
 
   import { markdyLanguage, markdyAutocomplete, markdyHighlightLight, markdyHighlightDark } from "../editor/markdy-language";
   import { baseTheme, lightTheme, darkTheme } from "../editor/editor-theme";
-  import { createDiagram, exportDiagramAsVectorSvg, exportDiagramAsPng, exportDiagramAsGif } from "@markdy/renderer-dom";
+  import { createDiagram, exportDiagramAsPng, exportDiagramAsGif } from "@markdy/renderer-dom";
   import type { Diagram } from "@markdy/renderer-dom";
   import {
     parse,
     validateArchitecture,
-    compressMarkdyToUrlHash,
     decompressMarkdyFromUrlHash,
     type Diagnostic,
   } from "@markdy/core";
@@ -744,7 +712,6 @@ const playgroundStructuredData = [
   const loadSampleBtn = document.getElementById("load-sample-btn") as HTMLButtonElement;
   const pasteImportBtn = document.getElementById("paste-import-btn") as HTMLButtonElement;
   const doImportBtn = document.getElementById("do-import-btn") as HTMLButtonElement;
-  const exportSvgBtn = document.getElementById("export-svg-btn") as HTMLButtonElement;
   const exportPngBtn = document.getElementById("export-png-btn") as HTMLButtonElement | null;
   const exportGifBtn = document.getElementById("export-gif-btn") as HTMLButtonElement | null;
   const formatTabs = document.querySelectorAll<HTMLButtonElement>(".format-tab");
@@ -759,19 +726,10 @@ const playgroundStructuredData = [
   const pasteCodeBtn = document.getElementById("paste-code-btn") as HTMLButtonElement;
   const copyCodeBtn = document.getElementById("copy-code-btn") as HTMLButtonElement;
   const formatCodeBtn = document.getElementById("format-code-btn") as HTMLButtonElement;
-  const shareBtn = document.getElementById("share-btn") as HTMLButtonElement;
-  const restartBtn = document.getElementById("restart-btn") as HTMLButtonElement;
-  const playBtn = document.getElementById("play-btn") as HTMLButtonElement;
-  const stepPrevBtn = document.getElementById("step-prev-btn") as HTMLButtonElement;
-  const stepNextBtn = document.getElementById("step-next-btn") as HTMLButtonElement;
 
-  const timelineRange = document.getElementById("timeline-range") as HTMLInputElement;
-  const timelineLabel = document.getElementById("timeline-label") as HTMLSpanElement;
-  const beatJump = document.getElementById("beat-jump") as HTMLSelectElement;
   const exampleSourceLink = document.getElementById("example-source-link") as HTMLAnchorElement;
   const quickExampleSelect = document.getElementById("quick-example-select") as HTMLSelectElement;
   const exampleBtns = document.querySelectorAll<HTMLButtonElement>(".example-btn");
-  const speedBtns = document.querySelectorAll<HTMLButtonElement>(".speed-btn");
   const themeToggle = (document.getElementById("theme-toggle") || document.getElementById("theme-toggle-btn")) as HTMLButtonElement;
   const workspace = document.getElementById("workspace") as HTMLElement;
   const splitter = document.getElementById("splitter") as HTMLButtonElement;
@@ -785,7 +743,6 @@ const playgroundStructuredData = [
   // Canvas zoom & view controls
   const canvasZoomInBtn = document.getElementById("canvas-zoom-in-btn") as HTMLButtonElement;
   const canvasZoomOutBtn = document.getElementById("canvas-zoom-out-btn") as HTMLButtonElement;
-  const canvasZoomFitBtn = document.getElementById("canvas-zoom-fit-btn") as HTMLButtonElement;
   const canvasGridToggleBtn = document.getElementById("canvas-grid-toggle-btn") as HTMLButtonElement;
 
   // Assistant Drawer
@@ -809,8 +766,6 @@ const playgroundStructuredData = [
   let diagram: Diagram | null = null;
   let debounce: ReturnType<typeof setTimeout> | null = null;
   let selectedExample = 0;
-  let playbackRate = 1;
-  let isScrubbing = false;
 
   let parsedAst: any = null;
   let selectedNodeId: string | null = null;
@@ -843,12 +798,6 @@ const playgroundStructuredData = [
       sun.style.display = theme === "dark" ? "none" : "block";
       moon.style.display = theme === "dark" ? "block" : "none";
     }
-  }
-
-  function formatTime(seconds: number): string {
-    if (!Number.isFinite(seconds) || seconds <= 0) return "0:00";
-    const total = Math.floor(seconds);
-    return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, "0")}`;
   }
 
   function updateStatusIndicator(ok: boolean, nodeCount: number = 0, edgeCount: number = 0, errorMsg?: string) {
@@ -890,35 +839,6 @@ const playgroundStructuredData = [
       list.appendChild(li);
     }
     diagnostics.appendChild(list);
-  }
-
-  function setTimeline(current: number, duration: number) {
-    const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : 0;
-    const safeCurrent = safeDuration > 0 ? Math.min(Math.max(current, 0), safeDuration) : 0;
-    timelineRange.max = safeDuration.toFixed(2);
-    if (!isScrubbing) timelineRange.value = safeCurrent.toFixed(2);
-    timelineRange.disabled = safeDuration <= 0;
-    timelineLabel.textContent = `${formatTime(safeCurrent)} / ${formatTime(safeDuration)}`;
-  }
-
-  function populateBeatJump(beats: Array<{ name: string; label?: string }>) {
-    beatJump.innerHTML = "";
-    if (beats.length === 0) {
-      beatJump.hidden = true;
-      return;
-    }
-    beatJump.hidden = false;
-    const placeholder = document.createElement("option");
-    placeholder.value = "";
-    placeholder.textContent = "Jump to beat...";
-    beatJump.appendChild(placeholder);
-    for (const beat of beats) {
-      const option = document.createElement("option");
-      option.value = beat.name;
-      option.textContent = beat.label ? `${beat.name} - ${beat.label}` : beat.name;
-      beatJump.appendChild(option);
-    }
-    beatJump.value = "";
   }
 
   function getCode(): string {
@@ -1181,20 +1101,15 @@ const playgroundStructuredData = [
         loop: true,
         copyright: false,
         sceneBoundaryProgress: false,
-        playbackRate,
+        controls: true,
         interactiveViewport: true,
+        shareUrl: `${window.location.origin}${window.location.pathname}`,
         onWarning(warning: Diagnostic) {
           warnings.push(`line ${warning.line}: ${warning.message}`);
-        },
-        onTimeUpdate: setTimeline,
-        onPlayStateChange(playing) {
-          playBtn.textContent = playing ? "Pause" : "Play";
         },
       });
       announce("Preview updated successfully.");
       showDiagnostics(warnings);
-      setTimeline(diagram.currentTime(), diagram.duration());
-      populateBeatJump(diagram.beats());
       updateEntitiesAndSuggestions(code);
       attachCanvasInteraction();
     } catch (error) {
@@ -1203,9 +1118,6 @@ const playgroundStructuredData = [
       updateStatusIndicator(false, 0, 0, message);
       announce(`Preview could not update. ${message}`);
       showDiagnostics([message]);
-      setTimeline(0, 0);
-      populateBeatJump([]);
-      playBtn.textContent = "Play";
     }
   }
 
@@ -1647,16 +1559,6 @@ const playgroundStructuredData = [
     viewport.dispatchEvent(wheelEvent);
   });
 
-  canvasZoomFitBtn?.addEventListener("click", () => {
-    const viewport = stageCanvas?.querySelector<HTMLElement>(".markdy-viewport");
-    if (!viewport) return;
-    const dblEvent = new MouseEvent("dblclick", {
-      bubbles: true,
-      cancelable: true,
-    });
-    viewport.dispatchEvent(dblEvent);
-  });
-
   const GRID_CLASSES = ["stage-grid--dots", "stage-grid--mesh", "stage-grid--plain"];
   const GRID_LABELS = ["▦ Dots", "▦ Mesh", "▦ Plain"];
 
@@ -1704,28 +1606,6 @@ const playgroundStructuredData = [
     const existingCount = (parsedAst?.beats || []).length;
     const newBeatName = `step_${existingCount + 1}`;
     insertCodeAtCursor(`\nbeat ${newBeatName} "Step ${existingCount + 1}":\n  show $nodes stagger=50ms\n`);
-  });
-
-  stepPrevBtn?.addEventListener("click", () => {
-    if (!diagram) return;
-    const beats = diagram.beats();
-    if (beats.length === 0) {
-      diagram.seek(Math.max(0, diagram.currentTime() - 1));
-      return;
-    }
-    const curr = diagram.currentTime();
-    diagram.seek(Math.max(0, curr - 1.5));
-  });
-
-  stepNextBtn?.addEventListener("click", () => {
-    if (!diagram) return;
-    const beats = diagram.beats();
-    if (beats.length === 0) {
-      diagram.seek(Math.min(diagram.duration(), diagram.currentTime() + 1));
-      return;
-    }
-    const curr = diagram.currentTime();
-    diagram.seek(Math.min(diagram.duration(), curr + 1.5));
   });
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -1787,14 +1667,6 @@ const playgroundStructuredData = [
     setActiveExample(index);
     createEditor(example.code);
     render(example.code);
-  }
-
-  async function encodeShare(code: string): Promise<string> {
-    try {
-      return await compressMarkdyToUrlHash(code);
-    } catch {
-      return btoa(encodeURIComponent(code));
-    }
   }
 
   async function decodeShare(value: string): Promise<string | null> {
@@ -2177,16 +2049,6 @@ Requirements:
     setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 
-  exportSvgBtn?.addEventListener("click", async () => {
-    try {
-      const svg = await withFinalFrame((scene) => exportDiagramAsVectorSvg(scene, { includeThemeStyles: true }));
-      download(new Blob([svg], { type: "image/svg+xml;charset=utf-8" }), "markdy-diagram.svg");
-      if (exportSvgBtn) showButtonStatus(exportSvgBtn, "Saved SVG");
-    } catch (err) {
-      alert("SVG export error: " + (err as Error).message);
-    }
-  });
-
   exportPngBtn?.addEventListener("click", async () => {
     try {
       const blob = await withFinalFrame((scene) => exportDiagramAsPng(scene, { includeThemeStyles: true, pixelRatio: 2 }));
@@ -2229,49 +2091,6 @@ Requirements:
   pasteCodeBtn?.addEventListener("click", () => pasteCodeToEditor(pasteCodeBtn));
   copyCodeBtn?.addEventListener("click", () => {
     if (copyCodeBtn) writeClipboard(getCode(), copyCodeBtn, "Copied");
-  });
-  shareBtn?.addEventListener("click", async () => {
-    const hash = await encodeShare(getCode());
-    const url = `${window.location.origin}${window.location.pathname}#code=${hash}`;
-    if (shareBtn) writeClipboard(url, shareBtn, "Copied Link");
-  });
-
-  restartBtn?.addEventListener("click", () => {
-    if (!diagram) return;
-    diagram.seek(0);
-    diagram.play();
-  });
-
-  playBtn?.addEventListener("click", () => {
-    if (!diagram) return;
-    if (diagram.isPlaying()) diagram.pause();
-    else diagram.play();
-  });
-
-  speedBtns.forEach((btn) => {
-    btn.addEventListener("click", () => {
-      playbackRate = Number(btn.dataset.speed ?? "1");
-      speedBtns.forEach((item) => {
-        const active = item === btn;
-        item.classList.toggle("active", active);
-        item.setAttribute("aria-pressed", active ? "true" : "false");
-      });
-      diagram?.setPlaybackRate(playbackRate);
-    });
-  });
-
-  timelineRange?.addEventListener("mousedown", () => { isScrubbing = true; });
-  timelineRange?.addEventListener("touchstart", () => { isScrubbing = true; }, { passive: true });
-  window.addEventListener("mouseup", () => { isScrubbing = false; });
-  window.addEventListener("touchend", () => { isScrubbing = false; });
-  timelineRange?.addEventListener("input", () => {
-    if (!diagram || !timelineRange) return;
-    diagram.seek(Number(timelineRange.value));
-  });
-
-  beatJump?.addEventListener("change", () => {
-    if (!diagram || !beatJump?.value) return;
-    diagram.seekToBeat(beatJump.value);
   });
 
   themeToggle?.addEventListener("click", () => {
@@ -2416,7 +2235,8 @@ Requirements:
       formatCodeBtn?.click();
     } else if (event.key === " " && document.activeElement !== editorHost && !(document.activeElement instanceof HTMLInputElement) && !(document.activeElement instanceof HTMLTextAreaElement) && !editor?.hasFocus) {
       event.preventDefault();
-      playBtn?.click();
+      if (diagram?.isPlaying()) diagram.pause();
+      else diagram?.play();
     } else if (event.key === "Escape") {
       deselectCanvas();
       importModal?.close();
@@ -4154,121 +3974,6 @@ Requirements:
     font-style: italic;
   }
 
-  /* ── Speed controls ── */
-  .dock-speed-box {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    flex-shrink: 0;
-  }
-
-  .beat-jump-select {
-    height: 30px;
-    border: 1px solid var(--border);
-    border-radius: 7px;
-    background: var(--bg-secondary);
-    color: var(--text-primary);
-    padding: 0 1.8rem 0 0.65rem;
-    font-family: inherit;
-    font-size: 0.72rem;
-    font-weight: 700;
-    cursor: pointer;
-    transition: border-color 0.12s ease, box-shadow 0.12s ease;
-    box-shadow: var(--shadow-xs);
-  }
-
-  .beat-jump-select:hover {
-    border-color: var(--border-hover);
-  }
-
-  .beat-jump-select:focus {
-    outline: none;
-    border-color: var(--accent);
-    box-shadow: 0 0 0 2px var(--accent-light);
-  }
-
-  .speed-group {
-    display: inline-flex;
-    align-items: center;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    padding: 2px;
-    gap: 1px;
-    box-shadow: var(--shadow-xs);
-  }
-
-  .speed-btn {
-    border: none;
-    background: transparent;
-    color: var(--text-secondary);
-    font-family: inherit;
-    font-size: 0.67rem;
-    font-weight: 700;
-    padding: 0.15rem 0.42rem;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: background 0.1s ease, color 0.1s ease;
-    white-space: nowrap;
-  }
-
-  .speed-btn:hover {
-    background: var(--bg-tertiary);
-    color: var(--text-primary);
-  }
-
-  .speed-btn.active {
-    background: var(--accent);
-    color: #ffffff;
-    box-shadow: 0 1px 3px var(--accent-glow);
-  }
-
-  .dock-timeline-row {
-    display: flex;
-    align-items: center;
-    gap: 0.65rem;
-  }
-
-  .timeline-step-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 30px;
-    height: 30px;
-    border: 1px solid var(--border);
-    background: var(--bg-secondary);
-    color: var(--text-secondary);
-    font-size: 0.72rem;
-    font-weight: 700;
-    padding: 0;
-    border-radius: 7px;
-    cursor: pointer;
-    transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease, transform 0.12s ease;
-    box-shadow: var(--shadow-xs);
-  }
-
-  .timeline-step-btn:hover {
-    color: var(--text-primary);
-    border-color: var(--border-hover);
-    background: var(--bg-tertiary);
-    transform: translateY(-1px);
-    box-shadow: var(--shadow-sm);
-  }
-
-  .timeline-slider {
-    flex: 1;
-    accent-color: var(--accent);
-    height: 4px;
-  }
-
-  .timeline-timestamp {
-    font-family: "JetBrains Mono", monospace;
-    font-size: 0.72rem;
-    color: var(--text-muted);
-    min-width: 72px;
-    text-align: right;
-  }
-
   /* ── Resource Strip & Showcase Gallery ─────────────────────────────── */
   .resource-strip {
     display: grid;
@@ -4885,9 +4590,6 @@ Requirements:
       flex-direction: column;
       align-items: stretch;
       gap: 0.4rem;
-    }
-    .dock-speed-box {
-      justify-content: space-between;
     }
   }
 </style>


### PR DESCRIPTION
## Summary

Consolidates every non-scene behavior (playback, toolbar controls, pointer/key interaction, and decoration) into one declarative `player:` block, resolved by a single core module instead of scattered defaults across the parser, renderer, Astro, and MDX.

```markdy
player:
  playback:
    autoplay false
    rate 1.5
  controls:
    prev_beat true
    next_beat true
    seek true
    speeds "0.5 1 2"
    fit true
    svg true
    share true
  interaction:
    zoom true
    pan true
    keyboard true
  chrome:
    badge false
    progress boundary
```

### Design
- Declaring a group opts in and every affordance inside defaults to **on**, so authors list only what to switch off. A group disables itself when all affordances are `false`, so there is no separate `enabled` flag to keep in sync.
- Group-local aliases let `speed` mean playback rate at the root but the speed buttons inside `controls:` — impossible in the previous flat model.

### New controls
- **Fit** frames all content and pins the camera so `frame`/`focus` zoom cues stop moving the view.
- **Prev/Next beat** (time-aware, mounted only for multi-beat scenes), **seek bar**, **configurable speeds**, **SVG export**, and **Share**.
- Opt-in keyboard shortcuts (arrows step beats, Space toggles, Home restarts) — off by default since the listener is window-level.

### Consolidation
- Live Studio and homepage drop their duplicated transport UI (play/restart/rewind, speed buttons, timeline scrubber, step buttons, beat/scene jump, canvas Fit, topbar SVG/Share) plus handlers and CSS.
- `remarkMarkdy()` no longer injects `autoplay=false`, `loop=false`, `progressBar=false`, which previously outranked a scene's own config. **Behavior change** for MDX; restore with `remarkMarkdy({ defaults: { ... } })`.

### Compatibility
Legacy directives, flat `player:` keys, and inline `scene` props are normalized into the grouped model, and deprecated `SceneMeta` fields stay populated as mirrors of `meta.player`.

## Validation
- `pnpm run build` (20 site pages)
- `pnpm run lint`
- `pnpm test` — 179 tests passing
- `pnpm exec tsx scripts/verify-examples.ts` — 63 examples, 0 warnings