### PR TITLE
fix: make player configuration predictable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `markdy` project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Predictable player resolution** — Homepage previews no longer apply host playback or progress overrides; their intentionally compact control subset remains. Controls are explicit opt-ins, and single-choice speed selectors are omitted.
+- **Unified footer** — Player controls stay left-aligned while the linked `Powered by Markdy` badge occupies the right edge.
+
+### Fixed
+- **Safe player formatting** — CLI and Playground formatters preserve grouped `player:` behavior and place the optional block after scene content.
+- **Renderer lifecycle** — Code panels are escaped and removed with their diagram; duplicate seek styles and homepage render paths were consolidated.
+
 ## [1.0.18] — 2026-08-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -299,35 +299,33 @@ Selectors: `$nodes` targets every node, `$edges` targets structural and animated
 
 ### Player Configuration
 
-Everything outside the scene itself lives in one `player:` block, grouped by concern:
+Everything outside the scene itself can live in one optional `player:` block. Keep it at the bottom so the diagram remains the first thing readers see:
 
 ```markdy
+scene theme=paper
+layout LR
+
+browser Client
+service API
+
+beat request:
+  show $nodes
+  Client -> API "GET /orders"
+
 player:
   playback:
-    autoplay false
-    loop true
-    rate 1
+    loop false
   controls:
-    play true
-    restart false
-    prev_beat true
-    next_beat true
-    seek true
     speed true
-    speeds "0.5 1 2"
+    speeds "0.5 1"
     fit true
-    reset_view true
-    svg true
     share true
   interaction:
     zoom true
     pan true
-    click_to_play false
-    keyboard true
   chrome:
-    badge false
+    badge true
     progress boundary
-    color "#3b82f6"
 ```
 
 | Group | Owns |
@@ -337,7 +335,7 @@ player:
 | `interaction` | what pointer and key input do |
 | `chrome` | non-interactive decoration (badge, progress) |
 
-Declaring a group opts in and every affordance defaults on, so you only list what to turn off. A group turns itself off when all of its affordances are false. `fit` frames every item and pins the camera so `frame`/`focus` zoom cues stop moving the view; `prev_beat`/`next_beat` step through beats. `keyboard` is opt-in (<kbd>←</kbd>/<kbd>→</kbd> beats, <kbd>Space</kbd> play, <kbd>Home</kbd> restart) because it captures window key events. Legacy directives and flat keys are normalized into the same groups, and explicit renderer or component options override script settings.
+Controls are explicit opt-ins: only leaves set to `true` are mounted. `fit` frames every item and pins the camera so `frame`/`focus` zoom cues stop moving the view; `prev_beat`/`next_beat` step through beats. `rate` sets the initial multiplier, while `speeds` provides viewer choices; the speed selector needs at least two distinct positive values. The linked badge stays at the footer's right edge. `keyboard` is opt-in (<kbd>←</kbd>/<kbd>→</kbd> beats, <kbd>Space</kbd> play, <kbd>Home</kbd> restart) because it captures window key events. Legacy directives and flat keys normalize into the same groups; explicit host options gate or supply defaults for script settings.
 
 ### Themes & Layout Modes
 
@@ -402,6 +400,9 @@ interface DiagramOptions {
   progressBar?: boolean;    // Deprecated: use sceneBoundaryProgress
   sceneBoundaryProgress?: boolean; // Rainbow border progress bar (default: true)
   playbackRate?: number;    // Timeline speed multiplier (default: 1)
+  interactiveViewport?: boolean; // true: default gestures; false: suppress script gestures
+  controls?: boolean;       // true: legacy defaults; false: suppress script controls
+  shareUrl?: string;        // Base URL for Share links
   onWarning?: (w: Diagnostic) => void;                 // Soft parse warnings
   onTimeUpdate?: (seconds: number, duration: number) => void;
   onPlayStateChange?: (playing: boolean) => void;
@@ -432,10 +433,12 @@ interface Diagram {
 | `assets` | `Record<string, string>` | `{}` | Asset URL overrides |
 | `autoplay` | `boolean` | `true` | Auto-play when fully visible in viewport |
 | `loop` | `boolean` | `true` | Loop the animation when it ends |
-| `copyright` | `boolean` | `true` | Show a "Powered by Markdy" badge below the animation |
+| `copyright` | `boolean` | script or `true` | Show the linked badge at the footer's right edge |
 | `progressBar` | `boolean` | `true` | Show a rainbow progress bar around the viewport border |
 | `sceneBoundaryProgress` | `boolean` | `progressBar` | Preferred flag for the rainbow scene-boundary progress bar |
-| `playbackRate` | `number` | `1` | Timeline speed multiplier |
+| `playbackRate` | `number` | script or `1` | Initial timeline speed multiplier |
+| `interactiveViewport` | `boolean` | script | `true` supplies default gestures; `false` suppresses script gestures |
+| `controls` | `boolean` | script | `true` supplies legacy defaults; `false` suppresses script controls |
 | `class` | `string` | — | CSS class for outer wrapper |
 
 ---

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -15,6 +15,16 @@ MarkdyScript is diagram-native. Declare semantic nodes, groups, beats, flow oper
 ### Scene & Directives
 
 ```markdy
+scene theme=paper
+layout LR
+
+browser Client
+service API
+
+beat request:
+  show $nodes
+  Client -> API "GET /orders"
+
 player:
   playback:
     autoplay true
@@ -46,12 +56,9 @@ player:
     badge false
     progress boundary
     color "#3b82f6"
-
-scene theme=paper
-layout LR
 ```
 
-Canonical scenes put `layout LR|RL|TB|BT` on its own line. For AI-generated compatibility, the parser also accepts `layout LR` or `layout=LR` on the `scene` line.
+Canonical scenes put `layout LR|RL|TB|BT` on its own line and optional `player:` configuration at the bottom. The parser accepts `player:` elsewhere, plus `layout LR` or `layout=LR` on the `scene` line, for compatibility.
 
 `player:` owns everything outside the diagram scene itself, split into four groups:
 
@@ -62,17 +69,21 @@ Canonical scenes put `layout LR|RL|TB|BT` on its own line. For AI-generated comp
 | `interaction:` | what pointer and key input do | `zoom`, `pan`, `click_to_play`, `double_click_to_reset`, `keyboard` |
 | `chrome:` | non-interactive decoration | `badge`, `progress` (`none\|bar\|boundary`), `color` |
 
-Declaring a group opts in, and every affordance in it defaults on — so list only what you want to turn off. A group switches itself off when all of its affordances are false, which means there is no separate enable flag to keep in sync. `reset_view` additionally requires interaction, and `click_to_play` is independent of viewport gestures.
+Toolbar controls are opt-in: only affordances explicitly set to `true` are mounted. When none are enabled, the toolbar is omitted; the footer remains only when the badge is enabled. `reset_view` additionally requires interaction, and `click_to_play` is independent of viewport gestures.
+
+The subtle "Powered by Markdy" link remains visible at the right edge of the footer by default. It links to the Markdy playground with the current source encoded in the URL; set `chrome.badge false` or the renderer's `copyright` option to `false` to hide it.
 
 `fit` mounts a toggle that frames every item in the scene and pins the camera, so `frame`/`focus` zoom cues stop moving the view while it is active. Toggling it off, pressing `reset_view`, or double-clicking restores normal camera motion. `fullscreen` toggles browser fullscreen presentation for the diagram container.
 
-`prev_beat` and `next_beat` step through beats and only appear when the scene has more than one. `speeds` sets the multipliers offered by the speed buttons (`speeds "0.25 1 3"`).
+`prev_beat` and `next_beat` step through beats and only appear when the scene has more than one. `rate` sets the initial playback multiplier; `speeds` sets the choices offered to viewers (`speeds "0.25 1 3"`). The speed selector is omitted unless `speed true` provides at least two distinct positive choices.
 
 `keyboard` is the one affordance that stays **off** unless you ask for it, because it listens on the window and captures space and arrow keys: <kbd>←</kbd>/<kbd>→</kbd> step beats, <kbd>Space</kbd> toggles playback, and <kbd>Home</kbd> restarts.
 
 `svg` downloads the settled final frame as vector SVG. `share` copies a compressed share link; hosts can point it at their own editor with the renderer's `shareUrl` option, and it defaults to the Markdy playground. `code` opens a dialog displaying the raw MarkdyScript source code with syntax tinting and copy button.
 
-Settings accept camel case or snake case, and `key value`, `key: value`, or `key = value`. Explicit renderer, Astro, or MDX props override script configuration. Legacy top-level directives, flat `player:` keys, and inline scene properties such as `controls true`, `interactive true`, `speed 1.5`, and `scene autoplay=false` are normalized into the same groups.
+Settings accept camel case or snake case, and `key value`, `key: value`, or `key = value`. Omitted renderer, Astro, or MDX props preserve script configuration; host `false` gates controls or interaction, while host `true` supplies legacy defaults for unset leaves. Legacy top-level directives, flat `player:` keys, and inline scene properties such as `controls true`, `interactive true`, `speed 1.5`, and `scene autoplay=false` are normalized into the same groups.
+
+`markdy fmt` preserves this behavior while canonicalizing aliases and indentation into a grouped block at the bottom.
 
 ### Nodes
 

--- a/examples/20-player-configuration.markdy
+++ b/examples/20-player-configuration.markdy
@@ -1,0 +1,38 @@
+scene "Script-Owned Player" theme=paper
+layout LR
+
+browser Viewer
+service ApiGateway "API Gateway"
+database Orders "Orders DB"
+
+beat reveal "Reveal the system":
+  show $nodes stagger=80ms
+
+beat request "Trace one request":
+  frame ApiGateway Orders zoom=1.15 dur=600ms
+  Viewer -> ApiGateway "POST /orders" -> Orders "persist"
+  Viewer <- ApiGateway "201 Created"
+
+beat overview "Return to overview":
+  frame $nodes dur=600ms
+
+player:
+  playback:
+    loop false
+  controls:
+    speed true
+    speeds "0.5 1"
+    fit true
+    fullscreen true
+    share true
+    code true
+  interaction:
+    zoom true
+    pan true
+    click_to_play true
+    double_click_to_reset true
+    keyboard false
+  chrome:
+    badge true
+    progress boundary
+    color "#3b82f6"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 # MarkdyScript examples
 
-Every file in this tree parses cleanly on the current 0.8 diagram grammar. Changes that break an example also break the `verify:examples` gate in CI.
+Every file in this tree parses cleanly on the current grammar. Changes that break an example also break the `verify:examples` gate in CI.
+Examples lead with scene content and keep optional `player:` configuration at the bottom.
 
 ## Layout
 
@@ -24,6 +25,7 @@ Every file in this tree parses cleanly on the current 0.8 diagram grammar. Chang
   - [`17-venn-overlap.markdy`](17-venn-overlap.markdy) — 2&ndash;3 circle set overlap and sweet-spot intersection.
   - [`18-layer-stack.markdy`](18-layer-stack.markdy) — OSI & abstraction layer stacked horizontal bands.
   - [`19-nested-containment.markdy`](19-nested-containment.markdy) — concentric defense-in-depth security perimeters.
+  - [`20-player-configuration.markdy`](20-player-configuration.markdy) — script-owned playback, focused controls, interaction, and footer chrome.
 - `showcase/` — 30 curated showcase demo scenes shown on the homepage playground and docs page.
 - `astro-starter/` — a minimal Astro project embedding the `<Markdy />` component.
 

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -79,18 +79,18 @@ export const code = `
 | `height` | `number` | `400` | Placeholder height in pixels |
 | `bg` | `string` | `"white"` | Placeholder background colour |
 | `assets` | `Record<string, string>` | `{}` | Asset URL overrides |
-| `autoplay` | `boolean` | `plan.meta.autoplay ?? true` | Start playing on hydration |
-| `loop` | `boolean` | `plan.meta.loop ?? true` | Loop the animation when it ends |
-| `copyright` | `boolean` | `plan.meta.copyright ?? true` | Show a "Powered by Markdy" badge below the animation |
+| `autoplay` | `boolean` | script or `true` | Override whether playback starts on hydration |
+| `loop` | `boolean` | script or `true` | Override whether playback loops |
+| `copyright` | `boolean` | script or `true` | Show the linked badge at the footer's right edge |
 | `progressBar` | `boolean \| string` | `true` | Deprecated compatibility flag for the scene-boundary progress bar |
-| `sceneBoundaryProgress` | `boolean \| string` | `true` | Show boundary progress bar, or pass a custom color/gradient string |
-| `progressColor` | `string` | `plan.meta.progressColor ?? "rainbow"` | Custom progress bar color (e.g. `"#3b82f6"`) or gradient (e.g. `"#ec4899, #8b5cf6"`) |
-| `playbackRate` | `number` | `plan.meta.playbackRate ?? 1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
-| `interactiveViewport` | `boolean` | `controls \|\| player.interaction` | Enable wheel zoom and drag pan after hydration |
-| `controls` | `boolean` | `player.controls` | Show the footer toolbar (play, prev/next beat, restart, seek, speed, fit, reset view, SVG, share); also enables viewport interaction |
+| `sceneBoundaryProgress` | `boolean \| string` | script | Override boundary progress or its color |
+| `progressColor` | `string` | script or rainbow | Override the progress color or gradient |
+| `playbackRate` | `number` | script or `1` | Override the initial timeline multiplier |
+| `interactiveViewport` | `boolean` | script | `true` supplies default gestures; `false` suppresses script gestures |
+| `controls` | `boolean` | script | `true` supplies legacy toolbar defaults; `false` suppresses script controls |
 | `class` | `string` | — | CSS class for the outer wrapper |
 
-> **Self-Contained MarkdyScript:** You can declare `controls true`, `interactive true`, `progressColor "#3b82f6"`, `loop false`, etc. directly inside the `.markdy` code so you only need `<Markdy code={code} />`. Explicit props passed to `<Markdy />` will override in-script directives.
+> **Self-Contained MarkdyScript:** Prefer grouped `player:` settings inside the `.markdy` code so `<Markdy code={code} />` preserves scene behavior. Pass props only when the host intentionally gates or supplies defaults.
 >
 > **Tip:** Match `width`, `height`, and `bg` props to your `scene` declaration values to avoid a visual flash on hydration.
 

--- a/packages/astro/src/Markdy.astro
+++ b/packages/astro/src/Markdy.astro
@@ -34,11 +34,11 @@ export interface Props {
    * Useful for CDN assets or data URIs in demos.
    */
   assets?: Record<string, string>;
-  /** Start playing as soon as the scene is hydrated. Defaults to true. */
+  /** Override whether playback starts when the scene is hydrated. */
   autoplay?: boolean;
-  /** Loop the animation when it ends. Defaults to true. */
+  /** Override whether playback loops when it ends. */
   loop?: boolean;
-  /** Show a small "Powered by Markdy" badge below the animation. Defaults to true. */
+  /** Show the linked "Powered by Markdy" badge at the footer's right edge. */
   copyright?: boolean;
   /** Show a rainbow progress bar around the viewport border, or specify a custom color/gradient. Defaults to true. */
   progressBar?: boolean | string;
@@ -50,9 +50,9 @@ export interface Props {
   progressBarColor?: string;
   /** Playback speed multiplier. Defaults to 1, where 1 is Markdy's normal pace. */
   playbackRate?: number;
-  /** Enable wheel zoom and drag pan after hydration. Defaults to false. */
+  /** Host interaction override: true supplies default gestures; false suppresses script gestures. */
   interactiveViewport?: boolean;
-  /** Show built-in playback and viewport controls. Also enables viewport interaction. Defaults to false. */
+  /** Host controls override: true supplies legacy defaults; false suppresses script controls. */
   controls?: boolean;
   class?: string;
   /**

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -54,7 +54,7 @@ markdy check-all . --arch-rules          # batch lint entire workspace
 ## Notes
 
 - The CLI resolves `import "file.markdy" as ns` from disk before parsing.
-- `fmt` prints a canonicalized scene and may expand higher-level sugar into its parsed form.
+- `fmt` canonicalizes aliases and indentation, places optional `player:` configuration last, and preserves its behavior; it may expand higher-level scene sugar into parsed form.
 - `render --out` writes a self-contained HTML preview to the exact path you pass in.
 - If the path is relative, it is resolved from the current working directory.
 - If you see `zsh: command not found: markdy`, the package is installed locally but that directory is not on your PATH.

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -1,4 +1,4 @@
-import type { BeatDecl, Cue, DiagramAST, GroupDecl, NodeDecl, StyleDecl } from "@markdy/core";
+import type { BeatDecl, Cue, DiagramAST, GroupDecl, NodeDecl, PlayerConfig, StyleDecl } from "@markdy/core";
 
 export function formatScene(ast: DiagramAST): string {
   const lines: string[] = [];
@@ -45,7 +45,66 @@ export function formatScene(ast: DiagramAST): string {
     lines.push("");
   }
 
+  const player = formatPlayer(ast.meta.player);
+  if (player.length > 0) {
+    if (lines.at(-1) !== "") lines.push("");
+    lines.push(...player);
+  }
+
   return `${lines.join("\n").trim()}\n`;
+}
+
+function formatPlayer(player: PlayerConfig | undefined): string[] {
+  if (!player) return [];
+
+  const groups: Array<[string, Array<[string, boolean | number | string | undefined]>]> = [
+    ["playback", [
+      ["autoplay", player.playback?.autoplay],
+      ["loop", player.playback?.loop],
+      ["rate", player.playback?.rate],
+    ]],
+    ["controls", [
+      ["play", player.controls?.play],
+      ["restart", player.controls?.restart],
+      ["prev_beat", player.controls?.prevBeat],
+      ["next_beat", player.controls?.nextBeat],
+      ["seek", player.controls?.seek],
+      ["speed", player.controls?.speed],
+      ["speeds", player.controls?.speeds?.join(" ")],
+      ["fit", player.controls?.fit],
+      ["reset_view", player.controls?.resetView],
+      ["fullscreen", player.controls?.fullscreen],
+      ["svg", player.controls?.svg],
+      ["share", player.controls?.share],
+      ["code", player.controls?.code],
+      ["theme", player.controls?.theme],
+    ]],
+    ["interaction", [
+      ["zoom", player.interaction?.zoom],
+      ["pan", player.interaction?.pan],
+      ["click_to_play", player.interaction?.clickToPlay],
+      ["double_click_to_reset", player.interaction?.doubleClickToReset],
+      ["keyboard", player.interaction?.keyboard],
+    ]],
+    ["chrome", [
+      ["badge", player.chrome?.badge],
+      ["progress", player.chrome?.progress],
+      ["color", player.chrome?.progressColor],
+    ]],
+  ];
+
+  const lines = ["player:"];
+  for (const [group, settings] of groups) {
+    const configured = settings.filter(([, value]) => value !== undefined);
+    if (configured.length === 0) continue;
+    lines.push(`  ${group}:`);
+    for (const [key, value] of configured) {
+      const formatted = typeof value === "string" && key !== "progress" ? JSON.stringify(value) : String(value);
+      lines.push(`    ${key} ${formatted}`);
+    }
+  }
+
+  return lines.length > 1 ? lines : [];
 }
 
 function formatStyle(style: StyleDecl): string {

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -73,6 +73,25 @@ describe("markdy cli", () => {
     expect(second.exitCode).toBe(0);
   });
 
+  it("formats grouped player configuration without changing behavior", async () => {
+    const dir = await tempDir();
+    const file = join(dir, "player.markdy");
+    const source = `player:\n  playback:\n    autoplay false\n    loop true\n    rate 1.5\n  controls:\n    speed true\n    speeds "0.25 1 2"\n    reset_view true\n    code true\n  interaction:\n    zoom true\n    keyboard false\n  chrome:\n    badge true\n    progress boundary\n    color "#3b82f6"\n\nscene theme=paper\nservice API\nbeat main:\n  show API\n`;
+    await writeFile(file, source, "utf8");
+
+    const result = await runCli(["fmt", file, "--write"], new BufferIo(), { openBrowser: async () => {} });
+    expect(result.exitCode).toBe(0);
+    const formatted = await readFile(file, "utf8");
+    expect(formatted).toContain("player:\n  playback:\n    autoplay false\n    loop true\n    rate 1.5");
+    expect(formatted).toContain('speed true\n    speeds "0.25 1 2"');
+    expect(formatted).toContain("reset_view true\n    code true");
+    expect(formatted).toContain('progress boundary\n    color "#3b82f6"');
+    expect(formatted.indexOf("scene theme=paper")).toBeLessThan(formatted.indexOf("player:"));
+
+    const second = await runCli(["fmt", file, "--check"], new BufferIo(), { openBrowser: async () => {} });
+    expect(second.exitCode).toBe(0);
+  });
+
   it("formats frame cues and preserves node props", async () => {
     const dir = await tempDir();
     const file = join(dir, "story.markdy");

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -68,7 +68,8 @@ try {
 | `ParseError` | class | Error with `.line` number for diagnostics |
 | `DiagramAST` | type | Parsed scene: meta, nodes, edges, groups, patterns, beats |
 | `RenderPlan` | type | Positioned nodes, routed edges, group zones, sequence messages, timed cues, beat ranges |
-| `SceneMeta` | type | Scene configuration (width, height, fps, theme, direction, controls, interactive, progressColor, playbackRate, loop, autoplay, copyright) |
+| `SceneMeta` | type | Scene configuration; `meta.player` is authoritative, with deprecated flat mirrors retained for compatibility |
+| `PlayerConfig` / `resolvePlayer` | type / function | Grouped playback, controls, interaction, and chrome configuration with host resolution |
 | `NodeDecl` | type | Node declaration (kind, id, label, style) |
 | `EdgeDecl` | type | Edge declaration (kind, from, to, label) |
 | `BeatDecl` | type | Named beat with cues |

--- a/packages/core/src/player.ts
+++ b/packages/core/src/player.ts
@@ -291,7 +291,7 @@ function unquote(raw: string): string {
   return value;
 }
 
-/** Host-supplied overrides always win over script configuration. */
+/** Host behavior overrides. `false` gates a feature off; `true` supplies legacy defaults when script values are absent. */
 export type PlayerOverrides = {
   autoplay?: boolean;
   loop?: boolean;
@@ -305,28 +305,28 @@ export type PlayerOverrides = {
 
 export function resolvePlayer(config: PlayerConfig = {}, overrides: PlayerOverrides = {}): ResolvedPlayer {
   const playback = config.playback ?? {};
+  const configuredControls = config.controls ?? {};
   const interaction = config.interaction ?? {};
   const chrome = config.chrome ?? {};
 
-  // Declaring a group opts in; every affordance then defaults on.
-  const controlsOn =
-    overrides.controls !== false && (overrides.controls === true || config.controls !== undefined);
-  const controls = {
-    play: controlsOn && (config.controls?.play ?? true),
-    restart: controlsOn && (config.controls?.restart ?? true),
-    prevBeat: controlsOn && (config.controls?.prevBeat ?? false),
-    nextBeat: controlsOn && (config.controls?.nextBeat ?? false),
-    seek: controlsOn && (config.controls?.seek ?? true),
-    speed: controlsOn && (config.controls?.speed ?? true),
-    fit: controlsOn && (config.controls?.fit ?? true),
-    resetView: controlsOn && (config.controls?.resetView ?? true),
-    fullscreen: controlsOn && (config.controls?.fullscreen ?? true),
-    svg: controlsOn && (config.controls?.svg ?? true),
-    share: controlsOn && (config.controls?.share ?? true),
-    // `code` is opt-in: off by default, on only when explicitly declared true.
-    code: controlsOn && (config.controls?.code ?? false),
-    // `theme` is opt-in: off by default, on only when explicitly declared true.
-    theme: controlsOn && (config.controls?.theme ?? false),
+  const controlsAllowed = overrides.controls !== false;
+  const hostControlDefault = overrides.controls === true;
+  const resolveControl = (value: boolean | undefined, fallback = hostControlDefault): boolean =>
+    controlsAllowed && (value ?? fallback);
+  const requestedControls = {
+    play: resolveControl(configuredControls.play),
+    restart: resolveControl(configuredControls.restart),
+    prevBeat: resolveControl(configuredControls.prevBeat, false),
+    nextBeat: resolveControl(configuredControls.nextBeat, false),
+    seek: resolveControl(configuredControls.seek),
+    speed: resolveControl(configuredControls.speed),
+    fit: resolveControl(configuredControls.fit),
+    resetView: resolveControl(configuredControls.resetView),
+    fullscreen: resolveControl(configuredControls.fullscreen),
+    svg: resolveControl(configuredControls.svg),
+    share: resolveControl(configuredControls.share),
+    code: resolveControl(configuredControls.code, false),
+    theme: resolveControl(configuredControls.theme, false),
   };
 
   // Legacy host coupling: `controls` as a host option also unlocks the viewport.
@@ -339,23 +339,17 @@ export function resolvePlayer(config: PlayerConfig = {}, overrides: PlayerOverri
     doubleClickToReset: interactionOn && (interaction.doubleClickToReset ?? true),
   };
   const interactionEnabled = gestures.zoom || gestures.pan || gestures.doubleClickToReset;
+  const configuredSpeeds = configuredControls.speeds?.length ? configuredControls.speeds : [0.25, 1];
+  const speeds = configuredSpeeds.filter(
+    (rate, index) => Number.isFinite(rate) && rate > 0 && configuredSpeeds.indexOf(rate) === index,
+  );
 
-  const resetView = controls.resetView && interactionEnabled;
-  const controlsEnabled =
-    controls.play ||
-    controls.restart ||
-    controls.prevBeat ||
-    controls.nextBeat ||
-    controls.seek ||
-    controls.speed ||
-    controls.fit ||
-    controls.resetView ||
-    controls.fullscreen ||
-    controls.svg ||
-    controls.share ||
-    controls.code ||
-    controls.theme ||
-    resetView;
+  const controls = {
+    ...requestedControls,
+    speed: requestedControls.speed && speeds.length > 1,
+    resetView: requestedControls.resetView && interactionEnabled,
+  };
+  const controlsEnabled = Object.values(controls).some(Boolean);
 
   const rate = overrides.playbackRate ?? playback.rate ?? 1;
 
@@ -367,9 +361,8 @@ export function resolvePlayer(config: PlayerConfig = {}, overrides: PlayerOverri
     },
     controls: {
       ...controls,
-      resetView,
       enabled: controlsEnabled,
-      speeds: config.controls?.speeds?.length ? config.controls.speeds : [0.25, 1],
+      speeds,
     },
     interaction: {
       ...gestures,

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -699,13 +699,32 @@ beat main:
 `);
     expect(astAlias.meta.player?.controls).toEqual({ code: true });
 
-    // When controls group is declared, code must remain false unless explicitly set.
-    const resolved = resolvePlayer({ controls: { play: true, restart: true, prevBeat: true, nextBeat: true, seek: true, speed: true, fit: true, resetView: true, fullscreen: true, svg: true, share: true } });
-    expect(resolved.controls.code).toBe(false);
+    // A controls group enables only the buttons it explicitly declares.
+    const resolved = resolvePlayer({ controls: { play: true } });
+    expect(resolved.controls).toMatchObject({
+      enabled: true,
+      play: true,
+      restart: false,
+      seek: false,
+      speed: false,
+      fit: false,
+      resetView: false,
+      fullscreen: false,
+      svg: false,
+      share: false,
+      code: false,
+      theme: false,
+    });
 
     // When explicitly set, it should be true.
     const resolvedWithCode = resolvePlayer({ controls: { code: true } });
     expect(resolvedWithCode.controls.code).toBe(true);
+
+    const resolvedWithUnavailableReset = resolvePlayer({ controls: { resetView: true } });
+    expect(resolvedWithUnavailableReset.controls).toMatchObject({ enabled: false, resetView: false });
+
+    const resolvedWithOneSpeed = resolvePlayer({ controls: { speed: true, speeds: [0.25] } });
+    expect(resolvedWithOneSpeed.controls).toMatchObject({ enabled: false, speed: false, speeds: [0.25] });
   });
 
   it("warns on unknown or malformed player settings", () => {

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -76,6 +76,6 @@ Fenced block metadata is passed as props to `MarkdyDiagram`. Snake-case aliases 
 | `progress_color="#3b82f6"` | `progressColor="#3b82f6"` | Custom progress bar color or gradient |
 | `playback_rate=0.5` | `playbackRate={0.5}` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
 | `interactive_viewport=true` | `interactiveViewport={true}` | Enable wheel zoom and drag pan on the rendered viewport |
-| `controls=true` | `controls={true}` | Show a compact toolbar with play/pause, restart, speed, and view reset controls; also enables viewport interaction |
+| `controls=true` | `controls={true}` | Supply legacy toolbar defaults; `false` suppresses controls declared by the script |
 
-> **Self-Contained MarkdyScript:** You can also declare `controls true`, `interactive true`, `progressColor "#3b82f6"`, `loop false`, etc. directly inside the Markdy code block without needing fence metadata attributes. Fence attributes act as explicit overrides.
+> **Self-Contained MarkdyScript:** Prefer grouped `player:` settings inside the code block. Fence metadata is a host override; omit it when the script should remain authoritative.

--- a/packages/renderer-dom/README.md
+++ b/packages/renderer-dom/README.md
@@ -13,7 +13,7 @@ Web Animations API renderer for [MarkdyScript](../../docs/SYNTAX.md) scenes. Tra
 - **Seek-safe** — manual `currentTime` control enables reliable `seek()` in any direction
 - **Playback-rate controls** — set normalized timeline speed to slow down or speed up diagrams without rebuilding animations
 - **Interactive viewport** — opt into wheel zoom and drag pan while click-to-pause stays available
-- **Embed controls** — opt into a compact playback toolbar with restart, speed, and view reset controls
+- **Embed controls** — opt into only the playback, timeline, viewport, export, and sharing controls a scene needs
 - **Semantic themes** — `paper`, `editorial`, `nebula`, `midnight`, `blueprint`, and `graphite`, with per-role node and edge colors
 - **Single dependency** — only `@markdy/core`
 
@@ -70,21 +70,21 @@ diagram.destroy();    // clean up DOM + cancel animations
 |---|---|---|---|
 | `container` | `HTMLElement` | *(required)* | DOM element to mount the scene into |
 | `code` | `string` | *(required)* | MarkdyScript source code |
-| `autoplay` | `boolean` | `plan.meta.autoplay ?? true` | Start playing immediately |
-| `loop` | `boolean` | `plan.meta.loop ?? true` | Loop the animation when it reaches the end |
-| `copyright` | `boolean` | `plan.meta.copyright ?? true` | Show a small "Powered by Markdy" badge below the animation |
+| `autoplay` | `boolean` | `player.playback.autoplay ?? true` | Override whether playback starts immediately |
+| `loop` | `boolean` | `player.playback.loop ?? true` | Override whether playback loops at the end |
+| `copyright` | `boolean` | `player.chrome.badge ?? true` | Show the linked badge at the footer's right edge |
 | `progressBar` | `boolean \| string` | `true` | Deprecated compatibility flag for the scene-boundary progress bar |
-| `sceneBoundaryProgress` | `boolean \| string` | `true` | Show boundary progress bar, or pass a custom color/gradient string |
-| `progressColor` | `string` | `plan.meta.progressColor ?? "rainbow"` | Custom progress bar color (e.g. `"#3b82f6"`) or gradient (e.g. `"#ec4899, #8b5cf6"`) |
-| `playbackRate` | `number` | `plan.meta.playbackRate ?? 1` | Normalized timeline speed multiplier; `1` is Markdy's normal pace |
-| `interactiveViewport` | `boolean` | `controls \|\| player.interaction` | Enable wheel zoom and drag pan on the rendered viewport |
-| `controls` | `boolean` | `player.controls` | Show the footer toolbar (play, prev/next beat, restart, seek, speed, fit, reset view, SVG, share); also enables viewport interaction |
+| `sceneBoundaryProgress` | `boolean \| string` | `player.chrome.progress` | Override boundary progress, or pass a custom color/gradient |
+| `progressColor` | `string` | `player.chrome.color` or rainbow | Override the progress color or gradient |
+| `playbackRate` | `number` | `player.playback.rate ?? 1` | Override the initial timeline multiplier |
+| `interactiveViewport` | `boolean` | `player.interaction` | `true` supplies default gestures; `false` suppresses script gestures |
+| `controls` | `boolean` | `player.controls` | `true` supplies legacy toolbar defaults; `false` suppresses script controls |
 | `shareUrl` | `string` | Markdy playground | Base URL used by the Share control when building `#code=` links |
 | `onWarning` | `(warning: Diagnostic) => void` | `console.warn` | Called for each soft parse warning |
 | `onTimeUpdate` | `(seconds: number, durationSeconds: number) => void` | — | Called whenever playback or seek changes the current time |
 | `onPlayStateChange` | `(playing: boolean) => void` | — | Called when playback starts or pauses |
 
-> **Note:** Directives declared inside the MarkdyScript code (e.g. `controls true`, `interactive true`, `progressColor "#3b82f6"`) apply automatically if the corresponding JavaScript option is omitted (`undefined`). Options passed to `createDiagram()` override the in-script declarations.
+> **Note:** Prefer grouped `player:` configuration in MarkdyScript. Omitted host options preserve it; host `false` suppresses controls or interaction, while host `true` supplies legacy defaults for leaves the script does not set. A speed selector renders only with at least two distinct positive `speeds` values.
 
 ### `Diagram`
 

--- a/packages/renderer-dom/src/diagram.ts
+++ b/packages/renderer-dom/src/diagram.ts
@@ -23,7 +23,7 @@ import { mountGroupBoundaries } from "./groups.js";
 import { createNodeEl, createTitleEl, ensureNodeStyles } from "./nodes.js";
 import { mountSequenceLayer } from "./sequence.js";
 import { mountTreeBuses } from "./tree.js";
-import { applyThemeToScene, ensureSceneStyles } from "./theme.js";
+import { applyThemeToScene, applyThemeVariables, ensureSceneStyles } from "./theme.js";
 
 const NORMAL_PLAYBACK_RATE = 4 / 5;
 const MIN_VIEWPORT_ZOOM = 0.5;
@@ -59,11 +59,11 @@ export interface DiagramOptions {
   progressBarColor?: string;
   /** Playback speed multiplier. Defaults to 1, where 1 is Markdy's normal pace. */
   playbackRate?: number;
-  /** Enable wheel zoom and drag pan on the rendered viewport. Defaults to false. */
+  /** Host interaction override. `true` enables default gestures; `false` suppresses script interaction. */
   interactiveViewport?: boolean;
   /** Base URL for the Share control. Defaults to the Markdy playground. */
   shareUrl?: string;
-  /** Show built-in playback and viewport controls. Also enables viewport interaction. Defaults to false. */
+  /** Host controls override. `true` enables the legacy default set; `false` suppresses script controls. */
   controls?: boolean;
   onWarning?: (warning: Diagnostic) => void;
   onTimeUpdate?: (seconds: number, durationSeconds: number) => void;
@@ -273,11 +273,12 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     if (footer) return footer;
     footer = document.createElement("div");
     footer.className = "markdy-footer";
+    applyThemeVariables(footer, plan.theme);
     Object.assign(footer.style, {
       display: "flex",
       alignItems: "center",
       justifyContent: "space-between",
-      flexWrap: "wrap",
+      flexWrap: "nowrap",
       gap: "6px",
       width: "100%",
       boxSizing: "border-box",
@@ -286,6 +287,24 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     if (container.parentNode) container.parentNode.insertBefore(footer, container.nextSibling);
     else container.appendChild(footer);
     return footer;
+  }
+
+  let badge: HTMLAnchorElement | null = null;
+  if (copyright) {
+    badge = document.createElement("a");
+    badge.className = "markdy-badge";
+    badge.href = `${MARKDY_PLAYGROUND_URL}#code=${encodeCodeForPlaygroundHash(code)}`;
+    badge.target = "_blank";
+    badge.rel = "noopener noreferrer";
+    badge.title = "Open and edit in Markdy Playground";
+    badge.textContent = "Powered by Markdy";
+    ensureFooter().appendChild(badge);
+    const badgeLink = badge;
+    void compressMarkdyToUrlHash(code)
+      .then((hash) => {
+        badgeLink.href = `${MARKDY_PLAYGROUND_URL}#code=${hash}`;
+      })
+      .catch(() => undefined);
   }
 
   ensureSceneStyles(document);
@@ -305,18 +324,6 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   });
   applyThemeToScene(scene, plan.theme);
   viewport.appendChild(scene);
-
-  let badge: HTMLAnchorElement | null = null;
-  if (copyright) {
-    badge = document.createElement("a");
-    badge.className = "markdy-badge";
-    badge.href = "https://markdy.com";
-    badge.target = "_blank";
-    badge.rel = "noopener noreferrer";
-    badge.title = "Powered by Markdy - Diagram as Code";
-    badge.textContent = "Powered by Markdy";
-    viewport.appendChild(badge);
-  }
 
   const viewportTransform = document.createElement("div");
   viewportTransform.className = "markdy-viewport-transform";
@@ -560,6 +567,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   let controlsSeekBar: HTMLInputElement | null = null;
   let controlsTimeEl: HTMLSpanElement | null = null;
   let controlsFitButton: HTMLButtonElement | null = null;
+  let closeCodePanel: (() => void) | null = null;
   let fitViewActive = false;
 
   const ICONS = {
@@ -803,8 +811,9 @@ export function createDiagram(opts: DiagramOptions): Diagram {
       for (const anim of allAnims) anim.cancel();
       resizeObserver?.disconnect();
       removeFullscreenListeners?.();
+      closeCodePanel?.();
+      closeCodePanel = null;
       if (progressEl?.parentNode === viewport) viewport.removeChild(progressEl);
-      if (badge?.parentNode) badge.parentNode.removeChild(badge);
       if (footer?.parentNode) footer.parentNode.removeChild(footer);
       if (viewport.parentNode === container) container.removeChild(viewport);
     },
@@ -984,30 +993,44 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     toolbar.appendChild(button);
   }
 
-  /** Lightweight client-side syntax tinting — wraps recognisable tokens in
-   *  coloured spans without importing a full highlighter. */
+  /** Lightweight client-side syntax tinting without importing a full highlighter. */
   function tintCode(raw: string): string {
     return raw
       .split("\n")
       .map((line) => {
-        // Comments — must be tested first so the rest don't taint comment text.
-        if (/^\s*\/\//.test(line)) {
-          return `<span class="t-comment">${escHtml(line)}</span>`;
-        }
-        // Edge operators at word boundaries.
-        line = line.replace(/(->|<-|~>|--|<~)/g, '<span class="t-edge">$1</span>');
-        // Quoted strings.
-        line = line.replace(/"([^"]*)"/g, '"<span class="t-string">$1</span>"');
-        // Leading DSL keywords (scene, beat, group, show, frame, glow…).
-        line = line.replace(
+        if (/^\s*\/\//.test(line)) return `<span class="t-comment">${escHtml(line)}</span>`;
+
+        const keyword = line.match(
           /^(\s*)(scene|beat|group|player|show|frame|glow|focus|layout|edge|annotation|start|end|decision|service|browser|gateway|database|cache|queue|worker|function|pod|user|client|hub|station|metric|mobile)\b/,
-          '$1<span class="t-keyword">$2</span>',
         );
-        // Bare numbers / units (e.g. zoom=1.2, stagger=80ms).
-        line = line.replace(/\b(\d[\d.]*(?:ms|px|s)?)\b/g, '<span class="t-number">$1</span>');
-        return line;
+        const prefix = keyword
+          ? `${escHtml(keyword[1])}<span class="t-keyword">${keyword[2]}</span>`
+          : "";
+        return prefix + tintInlineCode(line.slice(keyword?.[0].length ?? 0));
       })
       .join("\n");
+  }
+
+  function tintInlineCode(raw: string): string {
+    const tokenPattern = /"[^"]*"|->|<-|~>|--|<~|\b\d[\d.]*(?:ms|px|s)?\b/g;
+    let output = "";
+    let cursor = 0;
+
+    for (const match of raw.matchAll(tokenPattern)) {
+      const token = match[0];
+      const index = match.index ?? 0;
+      output += escHtml(raw.slice(cursor, index));
+      if (token.startsWith('"')) {
+        output += `"<span class="t-string">${escHtml(token.slice(1, -1))}</span>"`;
+      } else if (/^\d/.test(token)) {
+        output += `<span class="t-number">${token}</span>`;
+      } else {
+        output += `<span class="t-edge">${escHtml(token)}</span>`;
+      }
+      cursor = index + token.length;
+    }
+
+    return output + escHtml(raw.slice(cursor));
   }
 
   function escHtml(str: string): string {
@@ -1021,6 +1044,8 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     button.setAttribute("aria-haspopup", "dialog");
 
     button.addEventListener("click", () => {
+      closeCodePanel?.();
+
       const overlay = document.createElement("div");
       overlay.className = "markdy-code-panel-overlay";
       overlay.setAttribute("role", "dialog");
@@ -1090,10 +1115,19 @@ export function createDiagram(opts: DiagramOptions): Diagram {
       // Focus the close button for keyboard accessibility.
       closeBtn.focus();
 
+      let closing = false;
+      function removePanel(): void {
+        document.removeEventListener("keydown", handleEscape);
+        overlay.remove();
+        if (closeCodePanel === removePanel) closeCodePanel = null;
+      }
+
       function closePanel(): void {
+        if (closing) return;
+        closing = true;
         overlay.dataset.closing = "1";
-        // Wait for the closing animation before removing the element.
-        overlay.addEventListener("animationend", () => overlay.remove(), { once: true });
+        document.removeEventListener("keydown", handleEscape);
+        overlay.addEventListener("animationend", removePanel, { once: true });
       }
 
       closeBtn.addEventListener("click", closePanel);
@@ -1103,12 +1137,10 @@ export function createDiagram(opts: DiagramOptions): Diagram {
       });
       // Escape key closes the panel.
       function handleEscape(e: KeyboardEvent): void {
-        if (e.key === "Escape") { closePanel(); document.removeEventListener("keydown", handleEscape); }
+        if (e.key === "Escape") closePanel();
       }
       document.addEventListener("keydown", handleEscape);
-      overlay.addEventListener("animationend", () => {
-        if (overlay.dataset.closing === "1") document.removeEventListener("keydown", handleEscape);
-      }, { once: true });
+      closeCodePanel = removePanel;
     });
 
     toolbar.appendChild(button);
@@ -1376,7 +1408,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
 
     if (toolsGroup.children.length > 0) toolbar.appendChild(toolsGroup);
 
-    ensureFooter().appendChild(toolbar);
+    ensureFooter().insertBefore(toolbar, badge);
     syncControls();
   }
 

--- a/packages/renderer-dom/src/theme.ts
+++ b/packages/renderer-dom/src/theme.ts
@@ -150,6 +150,7 @@ export function ensureSceneStyles(doc: Document): void {
   justify-content: space-between;
   gap: 8px;
   padding: 6px 12px;
+  color: var(--md-text, #f8fafc);
   background: var(--md-footer-bg, rgba(15, 23, 42, 0.85));
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
@@ -160,7 +161,9 @@ export function ensureSceneStyles(doc: Document): void {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  width: 100%;
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
   gap: 8px;
   max-width: 100%;
   overflow-x: auto;
@@ -194,7 +197,6 @@ export function ensureSceneStyles(doc: Document): void {
   align-items: center;
   gap: 4px;
   flex-shrink: 0;
-  margin-left: auto;
 }
 .markdy-control-divider {
   width: 1px;
@@ -265,37 +267,24 @@ export function ensureSceneStyles(doc: Document): void {
   transform: translateY(-1px) scale(1.02);
 }
 .markdy-badge {
-  position: absolute;
-  top: 10px;
-  right: 12px;
-  z-index: 25;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  text-align: right;
+  font-family: system-ui, sans-serif;
   font-size: 10px;
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  color: var(--md-text-muted, #94a3b8);
+  font-weight: 400;
+  color: var(--md-control-text, #94a3b8);
   text-decoration: none;
-  padding: 2.5px 7px;
-  border-radius: 5px;
-  background: var(--md-surface, rgba(15, 23, 42, 0.45));
-  border: 1px solid var(--md-border, rgba(148, 163, 184, 0.15));
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  opacity: 0.65;
-  transition: all 0.2s ease;
-  pointer-events: auto;
-  user-select: none;
+  padding: 0;
+  opacity: 0.7;
+  margin-left: auto;
+  flex-shrink: 0;
+  transition: opacity 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
 }
 .markdy-badge:hover {
   opacity: 1;
-  color: var(--accent, #10b981);
-  border-color: var(--accent, #10b981);
-  background: var(--md-surface-raised, rgba(15, 23, 42, 0.75));
-  transform: translateY(-1px);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  color: var(--md-text, #f8fafc);
 }
 .markdy-speed-group {
   display: inline-flex;
@@ -327,57 +316,6 @@ export function ensureSceneStyles(doc: Document): void {
   background: var(--accent, #10b981) !important;
   color: #ffffff !important;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
-}
-.markdy-control-seek {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 100%;
-  height: 5px;
-  border-radius: 999px;
-  background: linear-gradient(
-    to right,
-    var(--accent, #10b981) 0%,
-    var(--accent, #10b981) var(--seek-pct, 0%),
-    rgba(148, 163, 184, 0.22) var(--seek-pct, 0%),
-    rgba(148, 163, 184, 0.22) 100%
-  );
-  outline: none;
-  cursor: pointer;
-  margin: 0;
-  transition: height 0.15s ease;
-}
-.markdy-control-seek:hover {
-  height: 7px;
-}
-.markdy-control-seek::-webkit-slider-thumb {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: #ffffff;
-  border: 2px solid var(--accent, #10b981);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-.markdy-control-seek:hover::-webkit-slider-thumb {
-  transform: scale(1.25);
-  box-shadow: 0 0 8px var(--accent-glow, rgba(16, 185, 129, 0.6));
-}
-.markdy-control-seek::-moz-range-thumb {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: #ffffff;
-  border: 2px solid var(--accent, #10b981);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-.markdy-control-seek:hover::-moz-range-thumb {
-  transform: scale(1.25);
-  box-shadow: 0 0 8px var(--accent-glow, rgba(16, 185, 129, 0.6));
 }
 .markdy-control-time {
   font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
@@ -564,44 +502,61 @@ export function ensureSceneStyles(doc: Document): void {
 .markdy-control-seek::-webkit-slider-runnable-track {
   width: 100%;
   height: 4.5px;
-  background: rgba(148, 163, 184, 0.35);
+  background: linear-gradient(
+    to right,
+    var(--accent, #10b981) 0%,
+    var(--accent, #10b981) var(--seek-pct, 0%),
+    rgba(148, 163, 184, 0.35) var(--seek-pct, 0%),
+    rgba(148, 163, 184, 0.35) 100%
+  );
   border-radius: 9999px;
-  transition: background 0.15s ease;
-}
-.markdy-control-seek:hover::-webkit-slider-runnable-track {
-  background: rgba(148, 163, 184, 0.55);
 }
 .markdy-control-seek::-webkit-slider-thumb {
+  appearance: none;
   -webkit-appearance: none;
   height: 13px;
   width: 13px;
   border-radius: 50%;
-  background: #2563eb;
+  background: var(--accent, #10b981);
   border: 2px solid #ffffff;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   margin-top: -4.25px;
   cursor: grab;
-  transition: transform 0.1s ease, background 0.15s ease;
+  transition: transform 0.1s ease, box-shadow 0.15s ease;
+}
+.markdy-control-seek:hover::-webkit-slider-thumb {
+  transform: scale(1.2);
+  box-shadow: 0 0 8px var(--accent-glow, rgba(16, 185, 129, 0.6));
 }
 .markdy-control-seek:active::-webkit-slider-thumb {
   cursor: grabbing;
   transform: scale(1.2);
-  background: #1d4ed8;
 }
 .markdy-control-seek::-moz-range-track {
   width: 100%;
   height: 4.5px;
-  background: rgba(148, 163, 184, 0.35);
+  background: linear-gradient(
+    to right,
+    var(--accent, #10b981) 0%,
+    var(--accent, #10b981) var(--seek-pct, 0%),
+    rgba(148, 163, 184, 0.35) var(--seek-pct, 0%),
+    rgba(148, 163, 184, 0.35) 100%
+  );
   border-radius: 9999px;
 }
 .markdy-control-seek::-moz-range-thumb {
   height: 13px;
   width: 13px;
   border-radius: 50%;
-  background: #2563eb;
+  background: var(--accent, #10b981);
   border: 2px solid #ffffff;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
   cursor: grab;
+  transition: transform 0.1s ease, box-shadow 0.15s ease;
+}
+.markdy-control-seek:hover::-moz-range-thumb {
+  transform: scale(1.2);
+  box-shadow: 0 0 8px var(--accent-glow, rgba(16, 185, 129, 0.6));
 }
 
 [data-markdy-theme="midnight"] .markdy-controls button,
@@ -622,9 +577,9 @@ export function ensureSceneStyles(doc: Document): void {
 [data-markdy-theme="nebula"] .markdy-controls button:hover:not([aria-pressed="true"]),
 :root[data-theme="dark"] .markdy-controls button:hover:not([aria-pressed="true"]),
 .theme-dark .markdy-controls button:hover:not([aria-pressed="true"]) {
-  background: rgba(51, 65, 85, 0.95);
-  color: #f8fafc;
-  border-color: #94a3b8;
+  background: var(--md-control-hover-bg, rgba(51, 65, 85, 0.95));
+  color: var(--md-control-hover-text, #f8fafc);
+  border-color: var(--md-control-hover-border, #94a3b8);
 }
 [data-markdy-theme="midnight"] .markdy-controls button[aria-pressed="true"],
 [data-markdy-theme="blueprint"] .markdy-controls button[aria-pressed="true"],
@@ -633,10 +588,10 @@ export function ensureSceneStyles(doc: Document): void {
 [data-markdy-theme="nebula"] .markdy-controls button[aria-pressed="true"],
 :root[data-theme="dark"] .markdy-controls button[aria-pressed="true"],
 .theme-dark .markdy-controls button[aria-pressed="true"] {
-  background: #3b82f6 !important;
+  background: var(--accent, #3b82f6) !important;
   color: #ffffff !important;
-  border-color: #3b82f6 !important;
-  box-shadow: 0 0 10px rgba(59, 130, 246, 0.5) !important;
+  border-color: var(--accent, #3b82f6) !important;
+  box-shadow: 0 0 10px var(--accent-glow, rgba(59, 130, 246, 0.5)) !important;
 }
 .markdy-footer a {
   transition: opacity 0.15s ease, color 0.15s ease;
@@ -731,39 +686,55 @@ export function ensureSceneStyles(doc: Document): void {
   doc.head.appendChild(style);
 }
 
-export function applyThemeToScene(scene: HTMLElement, theme: ThemeTokens): void {
-  scene.style.background = theme.canvas;
-  scene.style.color = theme.text;
-  scene.style.setProperty("--md-canvas", theme.canvas);
-  scene.style.setProperty("--md-surface", theme.surface);
-  scene.style.setProperty("--md-surface-raised", theme.surfaceRaised);
-  scene.style.setProperty("--md-border", theme.border);
-  scene.style.setProperty("--md-text", theme.text);
-  scene.style.setProperty("--md-text-muted", theme.textMuted);
-  scene.style.setProperty("--md-paper", theme.paper ?? theme.canvas);
-  scene.style.setProperty("--md-ink", theme.ink ?? theme.text);
-  scene.style.setProperty("--md-muted", theme.muted ?? theme.textMuted);
-  scene.style.setProperty("--md-rule", theme.rule ?? theme.border);
-  scene.style.setProperty("--md-grid-minor", theme.gridMinor);
-  scene.style.setProperty("--md-grid-major", theme.gridMajor);
-  scene.style.setProperty("--md-vignette", theme.vignette);
-  scene.style.setProperty("--md-accent", theme.accent);
-  if (theme.link) scene.style.setProperty("--md-link", theme.link);
-  if (theme.soft) scene.style.setProperty("--md-soft", theme.soft);
-  if (theme.accentTint) scene.style.setProperty("--md-accent-tint", theme.accentTint);
-  scene.style.setProperty("--md-node-surface", theme.nodeSurface ?? theme.surface);
-  scene.style.setProperty("--md-node-surface-raised", theme.nodeSurfaceRaised ?? theme.surfaceRaised);
-  scene.style.setProperty("--md-hairline", theme.hairline ?? `color-mix(in srgb, ${theme.border} 50%, transparent)`);
-  scene.style.setProperty("--md-shadow", theme.shadow ?? "rgba(2, 6, 23, 0.55)");
-  if (theme.fonts?.title) scene.style.setProperty("--md-font-title", theme.fonts.title);
-  if (theme.fonts?.nodeName) scene.style.setProperty("--md-font-node", theme.fonts.nodeName);
-  if (theme.fonts?.mono) scene.style.setProperty("--md-font-mono", theme.fonts.mono);
-  if (theme.radiusMd) scene.style.setProperty("--md-radius-md", `${theme.radiusMd}px`);
+export function applyThemeVariables(element: HTMLElement, theme: ThemeTokens): void {
+  element.style.setProperty("--md-canvas", theme.canvas);
+  element.style.setProperty("--md-surface", theme.surface);
+  element.style.setProperty("--md-surface-raised", theme.surfaceRaised);
+  element.style.setProperty("--md-border", theme.border);
+  element.style.setProperty("--md-text", theme.text);
+  element.style.setProperty("--md-text-muted", theme.textMuted);
+  element.style.setProperty("--md-paper", theme.paper ?? theme.canvas);
+  element.style.setProperty("--md-ink", theme.ink ?? theme.text);
+  element.style.setProperty("--md-muted", theme.muted ?? theme.textMuted);
+  element.style.setProperty("--md-rule", theme.rule ?? theme.border);
+  element.style.setProperty("--md-grid-minor", theme.gridMinor);
+  element.style.setProperty("--md-grid-major", theme.gridMajor);
+  element.style.setProperty("--md-vignette", theme.vignette);
+  element.style.setProperty("--md-accent", theme.accent);
+  element.style.setProperty("--accent", theme.accent);
+  element.style.setProperty("--accent-glow", `color-mix(in srgb, ${theme.accent} 40%, transparent)`);
+  element.style.setProperty("--accent-light", theme.accentTint ?? `color-mix(in srgb, ${theme.accent} 15%, transparent)`);
+  if (theme.link) element.style.setProperty("--md-link", theme.link);
+  if (theme.soft) element.style.setProperty("--md-soft", theme.soft);
+  if (theme.accentTint) element.style.setProperty("--md-accent-tint", theme.accentTint);
+  element.style.setProperty("--md-node-surface", theme.nodeSurface ?? theme.surface);
+  element.style.setProperty("--md-node-surface-raised", theme.nodeSurfaceRaised ?? theme.surfaceRaised);
+  element.style.setProperty("--md-hairline", theme.hairline ?? `color-mix(in srgb, ${theme.border} 50%, transparent)`);
+  element.style.setProperty("--md-shadow", theme.shadow ?? "rgba(2, 6, 23, 0.55)");
+  element.style.setProperty("--md-footer-bg", `color-mix(in srgb, ${theme.surface} 92%, transparent)`);
+  element.style.setProperty("--md-footer-border", theme.border);
+  element.style.setProperty("--md-control-bg", theme.surfaceRaised);
+  element.style.setProperty("--md-control-border", theme.border);
+  element.style.setProperty("--md-control-text", theme.textMuted);
+  element.style.setProperty("--md-control-hover-bg", theme.canvas);
+  element.style.setProperty("--md-control-hover-text", theme.text);
+  element.style.setProperty("--md-control-hover-border", theme.accent);
+  element.style.setProperty("--md-divider", theme.border);
+  if (theme.fonts?.title) element.style.setProperty("--md-font-title", theme.fonts.title);
+  if (theme.fonts?.nodeName) element.style.setProperty("--md-font-node", theme.fonts.nodeName);
+  if (theme.fonts?.mono) element.style.setProperty("--md-font-mono", theme.fonts.mono);
+  if (theme.radiusMd) element.style.setProperty("--md-radius-md", `${theme.radiusMd}px`);
   if (theme.spacing) {
     for (const [key, value] of Object.entries(theme.spacing)) {
-      scene.style.setProperty(`--md-space-${key}`, `${value}px`);
+      element.style.setProperty(`--md-space-${key}`, `${value}px`);
     }
   }
-  scene.dataset.markdyTheme = theme.name;
-  if (theme.flatCards) scene.dataset.flat = "1";
+  element.dataset.markdyTheme = theme.name;
+  if (theme.flatCards) element.dataset.flat = "1";
+}
+
+export function applyThemeToScene(scene: HTMLElement, theme: ThemeTokens): void {
+  applyThemeVariables(scene, theme);
+  scene.style.background = theme.canvas;
+  scene.style.color = theme.text;
 }

--- a/packages/renderer-dom/tests/__snapshots__/visual-gate.test.ts.snap
+++ b/packages/renderer-dom/tests/__snapshots__/visual-gate.test.ts.snap
@@ -676,6 +676,26 @@ exports[`renderer visual gate > matches the locked visual signature for every sc
       "role": "security",
     },
   ],
+  "examples/20-player-configuration.markdy": [
+    {
+      "icon": "browser",
+      "id": "Viewer",
+      "kind": "browser",
+      "role": "client",
+    },
+    {
+      "icon": "server",
+      "id": "ApiGateway",
+      "kind": "service",
+      "role": "compute",
+    },
+    {
+      "icon": "database",
+      "id": "Orders",
+      "kind": "database",
+      "role": "data",
+    },
+  ],
   "examples/showcase/cicd-delivery-pipeline.markdy": [
     {
       "icon": "user",

--- a/packages/renderer-dom/tests/diagram.smoke.test.ts
+++ b/packages/renderer-dom/tests/diagram.smoke.test.ts
@@ -244,7 +244,35 @@ describe("createDiagram integration", () => {
     diagram.destroy();
   });
 
-  it("mounts controls in footer and copyright badge in viewport top right", () => {
+  it("matches footer colors to light and dark scene themes", () => {
+    const lightContainer = document.createElement("div");
+    const darkContainer = document.createElement("div");
+    document.body.append(lightContainer, darkContainer);
+
+    const lightDiagram = createDiagram({ container: lightContainer, code: SCENE, controls: true, copyright: false });
+    const darkDiagram = createDiagram({
+      container: darkContainer,
+      code: SCENE.replace("theme=paper", "theme=midnight"),
+      controls: true,
+      copyright: false,
+    });
+
+    const footers = document.body.querySelectorAll<HTMLElement>(".markdy-footer");
+    const lightFooter = footers[0];
+    const darkFooter = footers[1];
+
+    expect(lightFooter.dataset.markdyTheme).toBe("paper");
+    expect(lightFooter.style.getPropertyValue("--md-footer-bg")).toContain("#ffffff");
+    expect(lightFooter.style.getPropertyValue("--md-control-text")).toBe("#475569");
+    expect(darkFooter.dataset.markdyTheme).toBe("midnight");
+    expect(darkFooter.style.getPropertyValue("--md-footer-bg")).toContain("#0e1a2c");
+    expect(darkFooter.style.getPropertyValue("--md-control-text")).toBe("#93a4bb");
+
+    lightDiagram.destroy();
+    darkDiagram.destroy();
+  });
+
+  it("mounts controls and the Powered by Markdy link in the footer", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
 
@@ -257,19 +285,37 @@ describe("createDiagram integration", () => {
     });
     const footer = document.body.querySelector<HTMLElement>(".markdy-footer");
     const toolbar = footer?.querySelector<HTMLElement>(".markdy-controls") ?? null;
-    const badge = container.querySelector<HTMLAnchorElement>(".markdy-viewport a.markdy-badge") ?? null;
+    const badge = footer?.querySelector<HTMLAnchorElement>("a.markdy-badge") ?? null;
 
     expect(footer).not.toBeNull();
     expect(toolbar).not.toBeNull();
     expect(badge).not.toBeNull();
     expect(badge?.textContent).toBe("Powered by Markdy");
-    expect(badge?.href).toBe("https://markdy.com/");
+    await vi.waitFor(() => expect(badge?.href).toMatch(/^https:\/\/markdy\.com\/playground\/#code=~m.+/));
     expect(badge?.target).toBe("_blank");
+    expect(footer?.style.flexWrap).toBe("nowrap");
     expect(footer?.firstElementChild).toBe(toolbar);
+    expect(footer?.lastElementChild).toBe(badge);
 
     const fullButton = toolbar?.querySelector<HTMLButtonElement>(".markdy-control-fullscreen");
     expect(fullButton).not.toBeNull();
     expect(fullButton?.getAttribute("aria-pressed")).toBe("false");
+
+    diagram.destroy();
+  });
+
+  it("keeps only the linked Markdy badge in the footer by default", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const diagram = createDiagram({ container, code: SCENE, autoplay: false });
+    const footer = document.body.querySelector<HTMLElement>(".markdy-footer");
+    const badge = footer?.querySelector<HTMLAnchorElement>(".markdy-badge");
+
+    expect(footer).not.toBeNull();
+    expect(footer?.querySelector(".markdy-controls")).toBeNull();
+    expect(badge?.textContent).toBe("Powered by Markdy");
+    await vi.waitFor(() => expect(badge?.href).toMatch(/^https:\/\/markdy\.com\/playground\/#code=~m.+/));
 
     diagram.destroy();
   });
@@ -485,6 +531,7 @@ player:
     restart false
     seek false
     speed false
+    fit true
     reset_view false
 
 scene theme=paper
@@ -534,6 +581,7 @@ player:
     next_beat true
     seek false
     fit false
+    speed true
     speeds "0.25 1 3"
   interaction:
     keyboard true
@@ -590,6 +638,32 @@ beat two:
     diagram.destroy();
   });
 
+  it("omits speed controls when the script offers only one speed", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const diagram = createDiagram({
+      container,
+      code: `
+player:
+  controls:
+    speed true
+    speeds "0.25"
+  chrome:
+    badge false
+
+scene theme=paper
+service A
+beat one:
+  show A
+`,
+    });
+
+    expect(document.body.querySelector(".markdy-footer")).toBeNull();
+    expect(document.body.querySelector(".markdy-control-rate")).toBeNull();
+
+    diagram.destroy();
+  });
+
   it("copies a share link from the toolbar", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -611,6 +685,8 @@ player:
     speed false
     fit false
     reset_view false
+    svg true
+    share true
 
 scene theme=paper
 service A
@@ -725,7 +801,7 @@ scene theme=paper
 layout LR
 
 browser Web
-service API
+service API "<img data-test=unsafe>"
 `;
 
     const diagram = createDiagram({
@@ -749,14 +825,15 @@ service API
 
     const pre = overlay?.querySelector<HTMLElement>(".markdy-code-panel__pre");
     expect(pre).not.toBeNull();
-    // The raw source text should be present somewhere in the pre content.
     expect(pre?.textContent).toContain("scene");
+    expect(pre?.textContent).toContain("<img data-test=unsafe>");
+    expect(pre?.querySelector("img")).toBeNull();
 
-    // The close button should dismiss the panel.
     const closeBtn = overlay?.querySelector<HTMLButtonElement>(".markdy-code-panel__close");
     expect(closeBtn).not.toBeNull();
 
     diagram.destroy();
+    expect(document.body.querySelector(".markdy-code-panel-overlay")).toBeNull();
     container.remove();
   });
 

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -14,7 +14,7 @@ const SECTIONS = [
       {
         slug: "markdy-playground",
         title: "Markdy Playground: Learn, Test, and Share Animated Diagrams",
-        dek: "Use the dedicated browser workspace to edit MarkdyScript, preview motion, inspect diagnostics, and share scenes.",
+        dek: "Edit MarkdyScript, configure player controls, inspect motion and diagnostics, and share runnable scenes.",
         tag: "Playground",
       },
     ],

--- a/website/src/pages/blog/markdy-playground.astro
+++ b/website/src/pages/blog/markdy-playground.astro
@@ -16,7 +16,7 @@ const structuredData = [
     "@id": `${canonicalURL}#article`,
     headline: "Markdy Playground: Learn, Test, and Share Animated Architecture Diagrams",
     description:
-      "Use the Markdy playground to edit MarkdyScript, preview animated architecture diagrams, jump between beats, inspect diagnostics, and share runnable scenes.",
+      "Use the Markdy playground to edit MarkdyScript, configure script-owned player controls, inspect animated architecture diagrams, and share runnable scenes.",
     inLanguage: "en",
     url: canonicalURL,
     mainEntityOfPage: canonicalURL,
@@ -46,11 +46,11 @@ const structuredData = [
 
 <ArticleLayout
   title="Markdy Playground — Learn, Test, and Share Animated Diagrams"
-  description="Use the Markdy playground to edit MarkdyScript, preview animated architecture diagrams, jump between beats, inspect diagnostics, and share runnable scenes."
+  description="Use the Markdy playground to edit MarkdyScript, configure script-owned player controls, inspect animated architecture diagrams, and share runnable scenes."
   keywords="Markdy playground, animated diagram playground, architecture diagram playground, diagram as code playground, Mermaid alternative playground, MarkdyScript editor"
   canonicalURL={canonicalURL}
   headline="Markdy Playground: Learn, Test, and Share Animated Architecture Diagrams"
-  dek="The dedicated Markdy playground is the fastest way to try animated diagrams as code: edit MarkdyScript, preview the motion, inspect diagnostics, and share runnable scenes without installing anything."
+  dek="Edit MarkdyScript, define the viewer contract, preview motion, inspect diagnostics, and share runnable scenes without installing anything."
   structuredData={structuredData}
 >
   <p>
@@ -95,7 +95,7 @@ const structuredData = [
   <h2>A small scene to try</h2>
   <p>
     Paste this into the <a href="/playground/">playground</a>. It demonstrates nodes, a group, a labeled beat,
-    a camera <code>frame</code>, a request flow, a response flow, and a clean reset back to the full diagram.
+    a camera <code>frame</code>, request/response flow, and a compact viewer contract.
   </p>
   <pre><code>scene theme=paper
 layout LR
@@ -115,7 +115,32 @@ beat request "Trace the request":
   Client &lt;- API "201 Created"
 
 beat reset "Return to overview":
-  frame $nodes dur=600ms</code></pre>
+  frame $nodes dur=600ms
+
+player:
+  playback:
+    loop false
+  controls:
+    speed true
+    speeds "0.5 1"
+    fit true
+    fullscreen true
+    share true
+  interaction:
+    zoom true
+    pan true
+    double_click_to_reset true
+  chrome:
+    badge true
+    progress boundary</code></pre>
+
+  <h2>Let the script own its player</h2>
+  <p>
+    The grouped <code>player:</code> block travels with the diagram through the playground, CLI, Astro, MDX,
+    and the DOM renderer. Controls are explicit opt-ins. <code>rate</code> sets the initial playback multiplier;
+    <code>speeds</code> supplies viewer choices, so the selector appears only when at least two distinct positive
+    values are available. Controls stay on the footer's left; the linked <code>Powered by Markdy</code> badge stays right.
+  </p>
 
   <h2>Best practices while experimenting</h2>
   <ol>
@@ -133,6 +158,7 @@ beat reset "Return to overview":
   </p>
   <pre><code>pnpm add -D @markdy/cli
 pnpm markdy lint architecture.markdy
+pnpm markdy fmt architecture.markdy --check
 pnpm markdy render architecture.markdy --out architecture.html</code></pre>
   <p>
     For deeper syntax details, open the <a href="/docs/">docs</a> or the

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,7 +4,46 @@ import { join } from "node:path";
 import { loadExamples } from "../data/examples";
 
 const ROOT = join(process.cwd(), "..");
-const EXAMPLES = await loadExamples(ROOT);
+const HOMEPAGE_HIDDEN_CONTROLS = new Set(["play", "restart", "prev_beat", "next_beat", "seek"]);
+
+function prepareHomepageCode(code: string): string {
+  let playerGroup: "controls" | "playback" | null = null;
+  let groupIndent: number | null = null;
+
+  return code
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trim();
+      const indent = line.length - line.trimStart().length;
+
+      if (groupIndent !== null && trimmed && indent <= groupIndent) {
+        playerGroup = null;
+        groupIndent = null;
+      }
+
+      const group = trimmed.match(/^(controls|playback)\s*:\s*$/)?.[1] as typeof playerGroup;
+      if (group) {
+        playerGroup = group;
+        groupIndent = indent;
+        return true;
+      }
+      if (!playerGroup || !trimmed) return true;
+
+      if (playerGroup === "playback") {
+        return !/^autoplay\s+true$/.test(trimmed) && !/^rate\s+1(?:\.0+)?$/.test(trimmed);
+      }
+
+      const [key, value, ...extra] = trimmed.split(/\s+/);
+      const isBooleanSetting = extra.length === 0 && (value === "true" || value === "false");
+      return !isBooleanSetting || !HOMEPAGE_HIDDEN_CONTROLS.has(key);
+    })
+    .join("\n");
+}
+
+const EXAMPLES = (await loadExamples(ROOT)).map((example) => ({
+  ...example,
+  code: prepareHomepageCode(example.code),
+}));
 
 const FLOWER_ASSET: Record<string, string> = {
   flower: "data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'36'%20height%3D'36'%3E%3Ccircle%20cx%3D'18'%20cy%3D'18'%20r%3D'16'%20fill%3D'%23ff69b4'%2F%3E%3Ccircle%20cx%3D'18'%20cy%3D'18'%20r%3D'6'%20fill%3D'%23ffff00'%2F%3E%3C%2Fsvg%3E",
@@ -138,7 +177,7 @@ const LAYOUT_CATEGORIES = [
   },
 ];
 
-const DEFAULT_PLAYER_YAML = `\n\nplayer:\n  playback:\n    autoplay true\n    loop true\n    rate 1.0\n  controls:\n    play true\n    restart true\n    prev_beat false\n    next_beat false\n    seek true\n    speed true\n    speeds "0.25 1"\n    fit true\n    reset_view true\n    fullscreen true\n    svg true\n    share true\n    code true\n    theme false\n  interaction:\n    zoom true\n    pan true\n    click_to_play true\n    double_click_to_reset true\n    keyboard false\n  chrome:\n    badge true\n    progress boundary\n    color "#3b82f6"`;
+const DEFAULT_PLAYER_YAML = `\n\nplayer:\n  playback:\n    loop true\n  interaction:\n    zoom true\n    pan true\n    click_to_play true\n    double_click_to_reset true\n    keyboard false\n  chrome:\n    badge true\n    progress boundary\n    color "#3b82f6"`;
 
 const LAYOUT_SNIPPETS: Record<string, string> = {
   architecture: `scene theme=paper\nlayout LR\n\nuser Client\ngateway ApiGateway\nservice Auth\nservice Payments\ndatabase Postgres\n\nbeat flow:\n  show $nodes stagger=60ms\n  Client -> ApiGateway "POST /checkout"\n  ApiGateway -> Auth "verify"\n  ApiGateway -> Payments "charge"\n  Payments -> Postgres "persist"` + DEFAULT_PLAYER_YAML,
@@ -544,13 +583,6 @@ const homepageStructuredData = [
             </select>
           </div>
         </div>
-
-        <div class="studio-right">
-          <div class="studio-compiler-pill">
-            <span id="status" class="status-indicator status-ok" title="Compiler status: OK"></span>
-            <span class="status-text">Synced</span>
-          </div>
-        </div>
       </div>
 
       <div class="studio-split-body">
@@ -579,7 +611,6 @@ const homepageStructuredData = [
                 <span class="theme-btn-icon">🎨</span>
                 <span id="theme-btn-name">Theme</span>
               </button>
-              <span class="preview-badge">Zero Keyframes</span>
             </div>
           </div>
           <div id="stage-wrap" class="stage-wrap">
@@ -947,14 +978,13 @@ markdy check-all ./docs/diagrams</code></pre>
   const editorContainer = document.getElementById("code-editor") as HTMLDivElement;
   const stage = document.getElementById("stage") as HTMLDivElement;
   const stageWrap = document.getElementById("stage-wrap") as HTMLDivElement;
-  const statusEl = document.getElementById("status") as HTMLSpanElement;
   const exampleSelect = document.getElementById("example-select") as HTMLSelectElement;
   const presetChips = document.querySelectorAll<HTMLButtonElement>(".preset-chip");
 
   let diagram: Diagram | null = null;
-  let isAnimPlaying = false;
   let debounce: ReturnType<typeof setTimeout> | null = null;
   let editorView: any = null;
+  let isSettingEditorCode = false;
   let currentExampleIndex = 0;
   let userEditedCode = false;
   let isAutoShuffleEnabled = false;
@@ -1022,7 +1052,7 @@ markdy check-all ./docs/diagrams</code></pre>
       if (examples[nextIdx]) {
         if (exampleSelect) exampleSelect.value = String(nextIdx);
         presetChips.forEach((c) => c.classList.toggle("active", c.dataset.index === String(nextIdx)));
-        setEditorCode(examples[nextIdx].code, true);
+        setEditorCode(examples[nextIdx].code);
       }
     }, 1500);
   }
@@ -1031,26 +1061,16 @@ markdy check-all ./docs/diagrams</code></pre>
     return document.documentElement.getAttribute("data-theme") === "dark";
   }
 
-  function setStatus(ok: boolean) {
-    if (!statusEl) return;
-    statusEl.className = `status-indicator ${ok ? "status-ok" : "status-error"}`;
-  }
-
-  async function render(code: string, shouldAutoplay = true) {
+  async function render(code: string) {
     if (!stage) return;
     try {
       const { createDiagram } = await getEditorModules();
       if (diagram) { diagram.destroy(); diagram = null; }
-      stage.innerHTML = "";
+      stage.replaceChildren();
       diagram = createDiagram({
         container: stage,
         code,
-        controls: true,
-        autoplay: shouldAutoplay,
-        loop: true,
-        sceneBoundaryProgress: true,
         onEnded: () => {
-          isAnimPlaying = false;
           if (diagram) {
             diagram.pause();
             diagram.seek(diagram.duration());
@@ -1060,13 +1080,18 @@ markdy check-all ./docs/diagrams</code></pre>
           }
         },
       });
-      isAnimPlaying = shouldAutoplay;
-      setStatus(true);
     } catch (e) {
       const msg = (e as Error).message ?? String(e);
-      stage.innerHTML = `<p class="parse-error" style="color:var(--danger);padding:1rem;font-family:monospace;font-size:0.8rem;">${msg}</p>`;
-      setStatus(false);
-      isAnimPlaying = false;
+      const error = document.createElement("p");
+      error.className = "parse-error";
+      Object.assign(error.style, {
+        color: "var(--danger)",
+        padding: "1rem",
+        fontFamily: "monospace",
+        fontSize: "0.8rem",
+      });
+      error.textContent = msg;
+      stage.replaceChildren(error);
     }
   }
 
@@ -1133,12 +1158,16 @@ markdy check-all ./docs/diagrams</code></pre>
       EditorView.contentAttributes.of({ "aria-label": "Code Editor" }),
       EditorView.updateListener.of((update: any) => {
         if (update.docChanged) {
+          if (isSettingEditorCode) return;
           if (update.transactions.some((tr: any) => tr.isUserEvent("input") || tr.isUserEvent("delete"))) {
             userEditedCode = true;
             clearAutoShuffleTimer();
           }
           if (debounce) clearTimeout(debounce);
-          debounce = setTimeout(() => render(getEditorCode(), true), 500);
+          debounce = setTimeout(() => {
+            debounce = null;
+            void render(getEditorCode());
+          }, 500);
         }
       }),
     ];
@@ -1152,12 +1181,21 @@ markdy check-all ./docs/diagrams</code></pre>
     });
   }
 
-  function setEditorCode(code: string, shouldAutoplay = true) {
+  function setEditorCode(code: string) {
     if (!editorView) return;
-    editorView.dispatch({
-      changes: { from: 0, to: editorView.state.doc.length, insert: code },
-    });
-    render(code, shouldAutoplay);
+    if (debounce) {
+      clearTimeout(debounce);
+      debounce = null;
+    }
+    isSettingEditorCode = true;
+    try {
+      editorView.dispatch({
+        changes: { from: 0, to: editorView.state.doc.length, insert: code },
+      });
+    } finally {
+      isSettingEditorCode = false;
+    }
+    void render(code);
   }
 
   // Preset chips handler
@@ -1168,7 +1206,7 @@ markdy check-all ./docs/diagrams</code></pre>
       const index = Number(chip.dataset.index || "0");
       currentExampleIndex = index;
       if (examples[index]) {
-        setEditorCode(examples[index].code, true);
+        setEditorCode(examples[index].code);
         if (exampleSelect) exampleSelect.value = String(index);
         presetChips.forEach((c) => c.classList.toggle("active", c === chip));
       }
@@ -1182,7 +1220,7 @@ markdy check-all ./docs/diagrams</code></pre>
     const idx = Number(exampleSelect.value);
     currentExampleIndex = idx;
     if (examples[idx]) {
-      setEditorCode(examples[idx].code, true);
+      setEditorCode(examples[idx].code);
       presetChips.forEach((c) => c.classList.toggle("active", c.dataset.index === String(idx)));
     }
   });
@@ -1219,7 +1257,7 @@ markdy check-all ./docs/diagrams</code></pre>
     const current = getEditorCode();
     const { newCode, themeName } = toggleRandomThemeInCode(current);
     if (themeBtnName) themeBtnName.textContent = themeName;
-    setEditorCode(newCode, true);
+    setEditorCode(newCode);
   });
 
   stage?.addEventListener("markdy-theme-switch", ((e: CustomEvent) => {
@@ -1236,7 +1274,7 @@ markdy check-all ./docs/diagrams</code></pre>
       newCode = `scene theme=${themeName}\n\n` + current;
     }
     if (themeBtnName) themeBtnName.textContent = themeName;
-    setEditorCode(newCode, true);
+    setEditorCode(newCode);
   }) as EventListener);
 
   // Snippet trigger buttons
@@ -1587,12 +1625,12 @@ markdy check-all ./docs/diagrams</code></pre>
   if ("requestIdleCallback" in window) {
     (window as any).requestIdleCallback(() => {
       createEditor(initialCode);
-      render(initialCode, true);
+      render(initialCode);
     }, { timeout: 1200 });
   } else {
     setTimeout(() => {
       createEditor(initialCode);
-      render(initialCode, true);
+      render(initialCode);
     }, 40);
   }
 </script>
@@ -2566,35 +2604,6 @@ markdy check-all ./docs/diagrams</code></pre>
     box-shadow: 0 0 0 2px var(--accent-light);
   }
 
-  .studio-right {
-    display: flex;
-    align-items: center;
-    gap: 0.6rem;
-  }
-
-  .studio-compiler-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    padding: 0.28rem 0.7rem;
-    border-radius: 999px;
-    background: var(--bg-elevated);
-    border: 1px solid var(--border);
-    font-size: 0.72rem;
-    font-weight: 600;
-    color: var(--text-secondary);
-  }
-
-  .status-indicator {
-    width: 7px;
-    height: 7px;
-    border-radius: 999px;
-    display: inline-block;
-  }
-
-  .status-ok { background: #10b981; box-shadow: 0 0 8px rgba(16, 185, 129, 0.6); }
-  .status-error { background: #ef4444; box-shadow: 0 0 8px rgba(239, 68, 68, 0.6); }
-
   .studio-split-body {
     display: grid;
     grid-template-columns: 460px 1fr;
@@ -2682,16 +2691,6 @@ markdy check-all ./docs/diagrams</code></pre>
     border-color: var(--accent);
     color: var(--accent);
     transform: translateY(-1px);
-  }
-
-  .preview-badge {
-    font-size: 0.65rem;
-    padding: 0.15rem 0.45rem;
-    border-radius: 999px;
-    background: var(--accent-light);
-    color: var(--accent);
-    font-weight: 700;
-    border: 1px solid var(--accent);
   }
 
   .studio-editor-pane {

--- a/website/src/pages/playground.astro
+++ b/website/src/pages/playground.astro
@@ -879,6 +879,7 @@ const playgroundStructuredData = [
   function formatMarkdyScript(rawCode: string): string {
     const lines = rawCode.split("\n");
     const formatted: string[] = [];
+    const playerBlock: string[] = [];
     let inBeatOrPattern = false;
     let inPlayer = false;
     let inPlayerScope = false;
@@ -887,8 +888,9 @@ const playgroundStructuredData = [
       const trimmed = line.trim();
       if (!trimmed) {
         // Keep at most 1 empty line
-        if (formatted.length > 0 && formatted[formatted.length - 1] !== "") {
-          formatted.push("");
+        const target = inPlayer ? playerBlock : formatted;
+        if (target.length > 0 && target[target.length - 1] !== "") {
+          target.push("");
         }
         continue;
       }
@@ -898,7 +900,7 @@ const playgroundStructuredData = [
         inBeatOrPattern = false;
         inPlayer = true;
         inPlayerScope = false;
-        formatted.push("player:");
+        playerBlock.push("player:");
         continue;
       }
 
@@ -906,7 +908,7 @@ const playgroundStructuredData = [
         // Sub-scopes: playback:, controls:, interaction:, chrome:
         if (/^(playback|controls|interaction|chrome)\s*:\s*$/.test(trimmed)) {
           inPlayerScope = true;
-          formatted.push(`  ${trimmed}`);
+          playerBlock.push(`  ${trimmed}`);
           continue;
         }
 
@@ -917,9 +919,9 @@ const playgroundStructuredData = [
         } else {
           // Setting within player
           if (inPlayerScope) {
-            formatted.push(`    ${trimmed}`);
+            playerBlock.push(`    ${trimmed}`);
           } else {
-            formatted.push(`  ${trimmed}`);
+            playerBlock.push(`  ${trimmed}`);
           }
           continue;
         }
@@ -938,7 +940,9 @@ const playgroundStructuredData = [
       }
     }
 
-    return formatted.join("\n") + "\n";
+    while (formatted.at(-1) === "") formatted.pop();
+    while (playerBlock.at(-1) === "") playerBlock.pop();
+    return [...formatted, ...(playerBlock.length > 0 ? ["", ...playerBlock] : [])].join("\n") + "\n";
   }
 
   function updateEntitiesAndSuggestions(code: string) {


### PR DESCRIPTION
## Summary
- make script-owned player settings authoritative and keep homepage previews compact
- unify footer controls and badge placement while tightening renderer lifecycle behavior
- preserve grouped player configuration in formatters and place the optional block last
- update documentation and add a focused player configuration example

## Validation
- pnpm run build
- pnpm run lint
- pnpm run typecheck
- pnpm run ci
- live Playground formatter check