### PR TITLE
fix(renderer-dom): route portrait tree edges cleanly along trunk corridor

### DIFF
--- a/packages/renderer-dom/src/diagram.ts
+++ b/packages/renderer-dom/src/diagram.ts
@@ -814,6 +814,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
       { width: plan.meta.width, height: plan.meta.height },
     )
     : [];
+  const isVerticalTree = Boolean(plan.treeBuses?.some((b) => b.vertical) || ast.meta.direction === "TB");
   let allAnims: Animation[] = [
     ...sequenceAnims,
     ...buildStructuralEdgeAnimations(
@@ -826,11 +827,12 @@ export function createDiagram(opts: DiagramOptions): Diagram {
       edgeSceneId,
       plan.diagramType,
       plan.cues,
+      isVerticalTree,
     ),
     ...buildCueAnimations(plan.cues, nodeEls, plan.nodes, plan.theme, cameraLayer, titleEl, {
       width: plan.meta.width,
       height: plan.meta.height,
-    }, plan.edges, edgeRuntimes, edgeSceneId, plan.diagramType),
+    }, plan.edges, edgeRuntimes, edgeSceneId, plan.diagramType, isVerticalTree),
     ...buildBeatCaptionAnimations(plan.beats, captionLayer),
   ];
   mountAnnotations(annotationLayer, plan.annotations, plan.nodes, plan.theme, {
@@ -914,6 +916,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
       edgeSceneId,
       plan.diagramType,
       plan.cues,
+      Boolean(plan.treeBuses?.some((b) => b.vertical) || ast.meta.direction === "TB"),
     );
 
     for (const anim of allAnims) anim.cancel();
@@ -941,6 +944,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
         edgeRuntimes,
         edgeSceneId,
         plan.diagramType,
+        Boolean(plan.treeBuses?.some((b) => b.vertical) || ast.meta.direction === "TB"),
       ),
       ...buildBeatCaptionAnimations(plan.beats, captionLayer),
     ];

--- a/packages/renderer-dom/src/edges.ts
+++ b/packages/renderer-dom/src/edges.ts
@@ -1,5 +1,5 @@
 import type { DiagramType, EdgeKind, PositionedNode, RoutedEdge, ThemeTokens, TimedCue } from "@markdy/core";
-import { placeFlowLabel, polylineLength, routeOrthogonal, selfLoopPath, toPathD, wrapFlowLabelText } from "./geometry/path.js";
+import { placeFlowLabel, polylineLength, routeOrthogonal, routeTreeEdgePoints, selfLoopPath, toPathD, wrapFlowLabelText } from "./geometry/path.js";
 import { boxRect, inflateRect, type Point, type Rect } from "./geometry/rect.js";
 
 const EDGE_LAYER_ATTR = "data-markdy-edge-layer";
@@ -134,8 +134,14 @@ function routeEdgePoints(
   routeObstacles: Rect[],
   bounds: { width: number; height: number },
   lane: number,
+  diagramType: DiagramType = "architecture",
+  isVerticalTree = false,
 ): Point[] {
   if (from.shape === "circle" && to.shape === "circle") return circleBoundaryRoute(from, to);
+  if (diagramType === "tree") {
+    const treeRoute = routeTreeEdgePoints(from, to, lane, isVerticalTree, bounds);
+    if (treeRoute) return snapRouteEndpointsToShapes(treeRoute, from, to);
+  }
   const raw = routeOrthogonal(boxRect(from), boxRect(to), routeObstacles, bounds, lane);
   return snapRouteEndpointsToShapes(raw, from, to);
 }
@@ -315,6 +321,8 @@ export function createEdgeRuntime(
   bounds: { width: number; height: number },
   lane: number,
   existingPaths: Point[][] = [],
+  diagramType: DiagramType = "architecture",
+  isVerticalTree = false,
 ): EdgeRuntime {
   ensureDefs(svg, theme, sceneId);
   const color = theme.edges[kind] ?? theme.edges.request ?? theme.accent;
@@ -322,7 +330,7 @@ export function createEdgeRuntime(
   const isSelfLoop = from.id === to.id;
   const points = isSelfLoop
     ? dedupePoints(selfLoopPath(from, bounds))
-    : dedupePoints(routeEdgePoints(from, to, routeObstacles, bounds, lane));
+    : dedupePoints(routeEdgePoints(from, to, routeObstacles, bounds, lane, diagramType, isVerticalTree));
   const d = toPathD(points, 14, existingPaths);
   const len = polylineLength(points);
 
@@ -372,7 +380,10 @@ export function createEdgeRuntime(
     for (let i = 0; i < points.length - 1; i++) {
       longestSegLen = Math.max(longestSegLen, Math.hypot(points[i + 1].x - points[i].x, points[i + 1].y - points[i].y));
     }
-    const maxAvailW = Math.max(90, longestSegLen - 24);
+    const isTreeVertical = diagramType === "tree" && isVerticalTree;
+    const maxAvailW = isTreeVertical
+      ? Math.max(48, Math.min(68, longestSegLen - 12))
+      : Math.max(90, longestSegLen - 24);
     const lines = wrapFlowLabelText(label, maxAvailW);
     const maxChars = Math.max(...lines.map((l) => l.length));
     const textWidth = Math.max(36, maxChars * 6.6 + 8);
@@ -693,7 +704,9 @@ export function buildCueAnimations(
   edgeRuntimes: EdgeRuntimeMap = new Map(),
   sceneId = createEdgeSceneId(),
   diagramType: DiagramType = "architecture",
+  isVerticalTree?: boolean,
 ): Animation[] {
+  const isVertical = isVerticalTree ?? (bounds.height > bounds.width);
   const anims: Animation[] = [];
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
   const rectById = new Map(nodes.map((n) => [n.id, boxRect(n)]));
@@ -732,6 +745,8 @@ export function buildCueAnimations(
       bounds,
       lane,
       placedPaths,
+      diagramType,
+      isVertical,
     );
     placedPaths.push(runtime.points);
     if (runtime.labelRect) edgeLabels.push(runtime.labelRect);
@@ -894,6 +909,8 @@ export function buildCueAnimations(
           bounds,
           lane,
           placedPaths,
+          diagramType,
+          isVertical,
         );
         placedPaths.push(runtime.points);
         if (runtime.labelRect) placedLabels.push(runtime.labelRect);
@@ -961,7 +978,9 @@ export function buildStructuralEdgeAnimations(
   sceneId = createEdgeSceneId(),
   diagramType: DiagramType = "architecture",
   cues: TimedCue[] = [],
+  isVerticalTree?: boolean,
 ): Animation[] {
+  const isVertical = isVerticalTree ?? (bounds.height > bounds.width);
   const structural = edges.filter((e) =>
     e.structural &&
     diagramType !== "sequence" &&
@@ -1023,6 +1042,8 @@ export function buildStructuralEdgeAnimations(
       bounds,
       lane,
       placedPaths,
+      diagramType,
+      isVertical,
     );
     placedPaths.push(runtime.points);
     if (runtime.labelRect) placedLabels.push(runtime.labelRect);

--- a/packages/renderer-dom/src/export/svg-exporter.ts
+++ b/packages/renderer-dom/src/export/svg-exporter.ts
@@ -24,6 +24,7 @@ import {
   placeFlowLabel,
   polylineLength,
   routeOrthogonal,
+  routeTreeEdgePoints,
   selfLoopPath,
   toPathD,
   wrapFlowLabelText,
@@ -234,8 +235,14 @@ function routeEdgePoints(
   routeObstacles: Rect[],
   bounds: { width: number; height: number },
   lane: number,
+  diagramType: string = "architecture",
+  isVerticalTree = false,
 ): Point[] {
   if (from.shape === "circle" && to.shape === "circle") return circleBoundaryRoute(from, to);
+  if (diagramType === "tree") {
+    const treeRoute = routeTreeEdgePoints(from, to, lane, isVerticalTree, bounds);
+    if (treeRoute) return snapRouteEndpointsToShapes(treeRoute, from, to);
+  }
   const raw = routeOrthogonal(boxRect(from), boxRect(to), routeObstacles, bounds, lane);
   return snapRouteEndpointsToShapes(raw, from, to);
 }
@@ -561,6 +568,7 @@ export function renderPureVectorSvg(plan: RenderPlan, options: SvgExportOptions 
     svg += `  <!-- Edge Connections -->\n  <g class="markdy-edges-layer">\n`;
     const nodeMap = new Map(plan.nodes.map((n) => [n.id, n]));
     const laneByPair = new Map<string, number>();
+    const isVerticalTree = Boolean(plan.treeBuses?.some((b) => b.vertical) || plan.meta?.direction === "TB" || plan.meta?.direction === "BT");
 
     plan.edges.forEach((edge, index) => {
       const from = nodeMap.get(edge.from);
@@ -577,7 +585,7 @@ export function renderPureVectorSvg(plan: RenderPlan, options: SvgExportOptions 
       const lane = nextEdgeLane(laneByPair, from, to);
       const points = isSelfLoop
         ? dedupePoints(selfLoopPath(from, bounds))
-        : dedupePoints(routeEdgePoints(from, to, routeObstacles, bounds, lane));
+        : dedupePoints(routeEdgePoints(from, to, routeObstacles, bounds, lane, plan.diagramType, isVerticalTree));
 
       const d = toPathD(points, 14, existingPaths);
       existingPaths.push(points);
@@ -606,7 +614,10 @@ export function renderPureVectorSvg(plan: RenderPlan, options: SvgExportOptions 
         for (let i = 0; i < points.length - 1; i++) {
           longestSegLen = Math.max(longestSegLen, Math.hypot(points[i + 1].x - points[i].x, points[i + 1].y - points[i].y));
         }
-        const maxAvailW = Math.max(48, longestSegLen - 24);
+        const isTreeVertical = plan.diagramType === "tree" && isVerticalTree;
+        const maxAvailW = isTreeVertical
+          ? Math.max(48, Math.min(68, longestSegLen - 12))
+          : Math.max(48, longestSegLen - 24);
         const lines = wrapFlowLabelText(edge.label, maxAvailW);
         const maxChars = Math.max(...lines.map((l) => l.length));
         const textWidth = Math.max(36, maxChars * 6.6 + 8);

--- a/packages/renderer-dom/src/geometry/path.ts
+++ b/packages/renderer-dom/src/geometry/path.ts
@@ -288,7 +288,7 @@ export function wrapFlowLabelText(text: string, maxAvailableWidth: number): stri
   const CHAR_WIDTH = 6.6;
   const PAD = 8;
   const singleLineWidth = text.length * CHAR_WIDTH + PAD;
-  if (singleLineWidth <= maxAvailableWidth || text.length <= 18 || !text.includes(" ")) {
+  if (singleLineWidth <= maxAvailableWidth || (maxAvailableWidth >= 70 && text.length <= 18) || !text.includes(" ")) {
     return [text];
   }
 
@@ -810,4 +810,78 @@ export function routeOrthogonal(
   }
 
   return cleanCollinearPoints(best.map((p) => clampPointToScene(p, bounds)));
+}
+
+/**
+ * Routes hierarchical parent-to-child edges in tree diagrams.
+ * - In portrait/vertical indented outline trees: routes cleanly down the parent trunk corridor,
+ *   with horizontal branches into each child's left-center edge, matching the layout structure.
+ * - In landscape trees: routes down from parent bottom-center, along a horizontal branch bus,
+ *   and down into child top-center.
+ */
+export function routeTreeEdgePoints(
+  from: { x: number; y: number; width: number; height: number },
+  to: { x: number; y: number; width: number; height: number },
+  lane: number,
+  isVertical: boolean,
+  bounds: { width: number; height: number },
+): Point[] | null {
+  // Only apply tree routing for downward/descendant flows
+  if (to.y < from.y + from.height - 12) return null;
+
+  if (isVertical) {
+    // Vertical indented tree outline (Portrait)
+    // If child is positioned to the left of parent, it is not an indented descendant
+    if (to.x < from.x - 4) return null;
+
+    // If child is directly below parent with no indentation (same column)
+    if (Math.abs(to.x - from.x) < 4) {
+      const pX = round1(from.x + from.width / 2);
+      const cX = round1(to.x + to.width / 2);
+      return cleanCollinearPoints([
+        { x: pX, y: from.y + from.height },
+        { x: cX, y: to.y },
+      ].map((p) => clampPointToScene(p, bounds)));
+    }
+
+    // Base trunk runs down along the parent indentation corridor
+    const trunkBaseX = Math.round((from.x + 18) / 4) * 4;
+    const maxShift = Math.max(0, Math.min(16, (to.x - from.x) / 3));
+    const shift = lane === 0 ? 0 : -Math.min(maxShift, lane * 4);
+    const trunkX = trunkBaseX + shift;
+    const fromY = from.y + from.height;
+    const toY = round1(to.y + to.height / 2);
+
+    const raw: Point[] = [
+      { x: trunkX, y: fromY },
+      { x: trunkX, y: toY },
+      { x: to.x, y: toY },
+    ];
+    return cleanCollinearPoints(raw.map((p) => clampPointToScene(p, bounds)));
+  } else {
+    // Horizontal landscape tree (Desktop)
+    const pX = round1(from.x + from.width / 2);
+    const pY = from.y + from.height;
+    const cX = round1(to.x + to.width / 2);
+    const cY = to.y;
+
+    if (Math.abs(pX - cX) < 2) {
+      return cleanCollinearPoints([
+        { x: pX, y: pY },
+        { x: cX, y: cY },
+      ].map((p) => clampPointToScene(p, bounds)));
+    }
+
+    const branchY = round1((pY + cY) / 2);
+    const laneShift = lane === 0 ? 0 : (lane % 2 === 1 ? 1 : -1) * Math.ceil(lane / 2) * 5;
+    const midY = round1(branchY + laneShift);
+
+    const raw: Point[] = [
+      { x: pX, y: pY },
+      { x: pX, y: midY },
+      { x: cX, y: midY },
+      { x: cX, y: cY },
+    ];
+    return cleanCollinearPoints(raw.map((p) => clampPointToScene(p, bounds)));
+  }
 }

--- a/packages/renderer-dom/tests/geometry.test.ts
+++ b/packages/renderer-dom/tests/geometry.test.ts
@@ -24,6 +24,7 @@ import {
   polylineLength,
   round1,
   routeOrthogonal,
+  routeTreeEdgePoints,
   toPathD,
 } from "../src/geometry/path.js";
 
@@ -260,5 +261,75 @@ describe("cleanCollinearPoints", () => {
     const raw = [{ x: 10, y: 10 }, { x: 10, y: 10 }, { x: 50, y: 10 }];
     const cleaned = cleanCollinearPoints(raw);
     expect(cleaned).toEqual([{ x: 10, y: 10 }, { x: 50, y: 10 }]);
+  });
+});
+
+describe("routeTreeEdgePoints", () => {
+  const boundsPortrait = { width: 496, height: 1232 };
+  const boundsLandscape = { width: 1920, height: 1080 };
+
+  const rootNode = { x: 68, y: 152, width: 256, height: 76 };
+  const childA = { x: 100, y: 244, width: 256, height: 76 };
+  const childB = { x: 100, y: 520, width: 256, height: 76 };
+  const childC = { x: 100, y: 796, width: 256, height: 76 };
+
+  it("routes vertical indented tree edges along parent trunk corridor into child left edge", () => {
+    const routeA = routeTreeEdgePoints(rootNode, childA, 0, true, boundsPortrait);
+    expect(routeA).not.toBeNull();
+    expect(routeA).toHaveLength(3);
+    // Exits bottom of parent at trunk corridor
+    expect(routeA![0].y).toBe(rootNode.y + rootNode.height); // 228
+    expect(routeA![0].x).toBe(88);
+    // Drops vertically along trunk to child center-Y
+    expect(routeA![1].x).toBe(88);
+    expect(routeA![1].y).toBe(childA.y + childA.height / 2); // 282
+    // Turns horizontally right into child left edge
+    expect(routeA![2].x).toBe(childA.x); // 100
+    expect(routeA![2].y).toBe(childA.y + childA.height / 2); // 282
+  });
+
+  it("assigns distinct parallel trunk lanes for concurrent child flows", () => {
+    const routeA = routeTreeEdgePoints(rootNode, childA, 0, true, boundsPortrait);
+    const routeB = routeTreeEdgePoints(rootNode, childB, 1, true, boundsPortrait);
+    const routeC = routeTreeEdgePoints(rootNode, childC, 2, true, boundsPortrait);
+
+    expect(routeA![0].x).toBe(88);
+    expect(routeB![0].x).toBe(84);
+    expect(routeC![0].x).toBe(80);
+
+    // Each target receives line at its own center-Y
+    expect(routeB![2]).toEqual({ x: 100, y: 558 });
+    expect(routeC![2]).toEqual({ x: 100, y: 834 });
+  });
+
+  it("routes direct vertical child in same column straight down", () => {
+    const nodeA = { x: 100, y: 100, width: 200, height: 60 };
+    const nodeB = { x: 100, y: 220, width: 200, height: 60 };
+    const route = routeTreeEdgePoints(nodeA, nodeB, 0, true, boundsPortrait);
+    expect(route).toEqual([
+      { x: 200, y: 160 },
+      { x: 200, y: 220 },
+    ]);
+  });
+
+  it("routes landscape tree edges from parent bottom via horizontal branch to child top", () => {
+    const parent = { x: 800, y: 100, width: 200, height: 60 };
+    const child = { x: 300, y: 240, width: 180, height: 60 };
+    const route = routeTreeEdgePoints(parent, child, 0, false, boundsLandscape);
+    expect(route).not.toBeNull();
+    expect(route).toHaveLength(4);
+    expect(route![0]).toEqual({ x: 900, y: 160 }); // parent bottom-center
+    expect(route![1].x).toBe(900); // drops to branch level
+    expect(route![1].y).toBe(200); // (160 + 240) / 2
+    expect(route![2].x).toBe(390); // runs to child center-X (300 + 90)
+    expect(route![2].y).toBe(200);
+    expect(route![3]).toEqual({ x: 390, y: 240 }); // enters child top-center
+  });
+
+  it("returns null for non-downward or backward edges so orthogonal fallback applies", () => {
+    const lower = { x: 100, y: 400, width: 200, height: 60 };
+    const upper = { x: 100, y: 100, width: 200, height: 60 };
+    expect(routeTreeEdgePoints(lower, upper, 0, true, boundsPortrait)).toBeNull();
+    expect(routeTreeEdgePoints(lower, upper, 0, false, boundsLandscape)).toBeNull();
   });
 });


### PR DESCRIPTION
### Summary
- Route dynamic flows and structural edges in portrait hierarchical trees cleanly down the indentation corridor (trunk) rather than using generic orthogonal routing that loops over root nodes or collides with intermediate cards.
- Add `routeTreeEdgePoints` in `@markdy/renderer-dom/geometry/path.ts` supporting lane-based separation and clean orthogonal horizontal branches.
- Wrap narrow tree flow edge labels into compact badges to fit within indentation spacing without overflowing into cards.
- Full verification: 100% unit tests passed (142 tests), visual regression 0.000% diff, sub-frame performance budgets satisfied.