### PR TITLE
feat(monetization): add Sponsor & Pro Architecture Blueprints callouts across packages and site (REV-INIT-01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,18 @@
   <a href="https://markdy.com/docs/">Documentation</a> &nbsp;•&nbsp;
   <a href="https://markdy.com/examples/">Examples</a> &nbsp;•&nbsp;
   <a href="https://marketplace.visualstudio.com/items?itemName=hoangyell.markdy-vscode">VS Code Extension</a> &nbsp;•&nbsp;
-  <a href="https://markdy.com/agent/">AI &amp; Agent Guide</a>
+  <a href="https://markdy.com/agent/">AI &amp; Agent Guide</a> &nbsp;•&nbsp;
+  <a href="https://github.com/sponsors/HoangYell"><strong>Sponsor &amp; Pro Blueprints</strong></a>
 </p>
 
 <p align="center">
   <a href="https://github.com/HoangYell/markdy-com/actions/workflows/ci.yml"><img src="https://github.com/HoangYell/markdy-com/actions/workflows/ci.yml/badge.svg" alt="CI Status" /></a>
   <a href="https://www.npmjs.com/package/@markdy/core"><img src="https://img.shields.io/npm/v/@markdy/core?color=blue&label=%40markdy%2Fcore" alt="npm version" /></a>
+  <a href="https://github.com/sponsors/HoangYell"><img src="https://img.shields.io/badge/Sponsor-%E2%99%A5-ea4aaa" alt="Sponsor Markdy" /></a>
   <a href="https://github.com/HoangYell/markdy-com/blob/main/LICENSE"><img src="https://img.shields.io/github/license/HoangYell/markdy-com" alt="MIT License" /></a>
 </p>
+
+> 💼 **Sponsorship & Commercial Use**: Markdy is free and open source under the MIT license. If you use Markdy in commercial projects or want to support ongoing engineering, consider **[sponsoring on GitHub](https://github.com/sponsors/HoangYell)**.
 
 ---
 

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -4,12 +4,14 @@
   <a href="https://markdy.com/playground/"><img src="https://img.shields.io/badge/⚡_Live_Studio-markdy.com%2Fplayground-3b82f6?style=for-the-badge" alt="Live Studio" /></a>
   <a href="https://markdy.com/docs/"><img src="https://img.shields.io/badge/📖_Docs-Documentation-10b981?style=for-the-badge" alt="Documentation" /></a>
   <a href="https://markdy.com/examples/"><img src="https://img.shields.io/badge/🌟_Blueprints-30+_Examples-f59e0b?style=for-the-badge" alt="Examples" /></a>
+  <a href="https://github.com/sponsors/HoangYell"><img src="https://img.shields.io/badge/💖_Sponsor-Support_Markdy-ea4aaa?style=for-the-badge" alt="Sponsor Markdy" /></a>
 </p>
 
 [Astro](https://astro.build/) island component for [MarkdyScript](https://markdy.com/docs/) animated scenes. Embed interactive, zero-CLS architecture diagrams directly inside your Astro blogs, docs, and landing pages.
 
 > 🚀 **Try it live**: Test MarkdyScript in the browser at **[markdy.com/playground](https://markdy.com/playground/)**  
-> 📚 **Documentation**: Complete syntax guide and examples at **[markdy.com/docs](https://markdy.com/docs/)**
+> 📚 **Documentation**: Complete syntax guide and examples at **[markdy.com/docs](https://markdy.com/docs/)**  
+> 💼 **Enterprise & Commercial**: Free under MIT. To support development or request custom architecture blueprints, explore **[GitHub Sponsors](https://github.com/sponsors/HoangYell)**.
 
 ## Features
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,13 +4,15 @@
   <a href="https://markdy.com/playground/"><img src="https://img.shields.io/badge/⚡_Live_Studio-markdy.com%2Fplayground-3b82f6?style=for-the-badge" alt="Live Studio" /></a>
   <a href="https://markdy.com/docs/"><img src="https://img.shields.io/badge/📖_Docs-Documentation-10b981?style=for-the-badge" alt="Documentation" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=hoangyell.markdy-vscode"><img src="https://img.shields.io/badge/🔌_VS_Code-Extension-8b5cf6?style=for-the-badge" alt="VS Code Extension" /></a>
+  <a href="https://github.com/sponsors/HoangYell"><img src="https://img.shields.io/badge/💖_Sponsor-Support_Markdy-ea4aaa?style=for-the-badge" alt="Sponsor Markdy" /></a>
 </p>
 
 The zero-dependency parser, dynamic port multiplexer, and AST routing engine for [MarkdyScript](https://markdy.com/docs/) — a diagram-native DSL for animated architecture diagrams that AI agents generate reliably.
 
 > 🚀 **Try it live**: Test MarkdyScript in the browser at **[markdy.com/playground](https://markdy.com/playground/)**  
 > 📚 **Documentation**: Complete syntax guide and examples at **[markdy.com/docs](https://markdy.com/docs/)**  
-> 🌟 **Architecture Blueprints**: 30+ canonical production diagrams at **[markdy.com/examples](https://markdy.com/examples/)**
+> 🌟 **Architecture Blueprints**: 30+ canonical production diagrams at **[markdy.com/examples](https://markdy.com/examples/)**  
+> 💼 **Enterprise & Commercial**: Free under MIT. To support development or request custom architecture blueprints, explore **[GitHub Sponsors](https://github.com/sponsors/HoangYell)**.
 
 ## Features
 

--- a/packages/mdx/README.md
+++ b/packages/mdx/README.md
@@ -4,12 +4,14 @@
   <a href="https://markdy.com/playground/"><img src="https://img.shields.io/badge/⚡_Live_Studio-markdy.com%2Fplayground-3b82f6?style=for-the-badge" alt="Live Studio" /></a>
   <a href="https://markdy.com/docs/"><img src="https://img.shields.io/badge/📖_Docs-Documentation-10b981?style=for-the-badge" alt="Documentation" /></a>
   <a href="https://markdy.com/examples/"><img src="https://img.shields.io/badge/🌟_Blueprints-30+_Examples-f59e0b?style=for-the-badge" alt="Examples" /></a>
+  <a href="https://github.com/sponsors/HoangYell"><img src="https://img.shields.io/badge/💖_Sponsor-Support_Markdy-ea4aaa?style=for-the-badge" alt="Sponsor Markdy" /></a>
 </p>
 
 MDX & remark plugin for [MarkdyScript](https://markdy.com/docs/) animated diagrams with Lighthouse-safe, zero-CLS lazy hydration:
 
 > 🚀 **Try it live**: Test MarkdyScript in the browser at **[markdy.com/playground](https://markdy.com/playground/)**  
-> 📚 **Documentation**: Complete syntax guide and examples at **[markdy.com/docs](https://markdy.com/docs/)**
+> 📚 **Documentation**: Complete syntax guide and examples at **[markdy.com/docs](https://markdy.com/docs/)**  
+> 💼 **Enterprise & Commercial**: Free under MIT. To support development or request custom architecture blueprints, explore **[GitHub Sponsors](https://github.com/sponsors/HoangYell)**.
 
 - `remarkMarkdy` converts fenced code blocks (` ```markdy `) into a diagram component.
 - `MarkdyDiagram` hydrates only when visible and lazy-loads `@markdy/renderer-dom`.

--- a/packages/renderer-dom/README.md
+++ b/packages/renderer-dom/README.md
@@ -4,12 +4,14 @@
   <a href="https://markdy.com/playground/"><img src="https://img.shields.io/badge/⚡_Live_Studio-markdy.com%2Fplayground-3b82f6?style=for-the-badge" alt="Live Studio" /></a>
   <a href="https://markdy.com/docs/"><img src="https://img.shields.io/badge/📖_Docs-Documentation-10b981?style=for-the-badge" alt="Documentation" /></a>
   <a href="https://markdy.com/examples/"><img src="https://img.shields.io/badge/🌟_Blueprints-30+_Examples-f59e0b?style=for-the-badge" alt="Examples" /></a>
+  <a href="https://github.com/sponsors/HoangYell"><img src="https://img.shields.io/badge/💖_Sponsor-Support_Markdy-ea4aaa?style=for-the-badge" alt="Sponsor Markdy" /></a>
 </p>
 
 Web Animations API renderer for [MarkdyScript](https://markdy.com/docs/) scenes. Translates a parsed AST into 60fps GPU-accelerated DOM elements and drives the animation timeline with interactive analytical capabilities (Blast Radius, Route Pathfinder, and SVG/GIF export).
 
 > 🚀 **Try it live**: Test MarkdyScript in the browser at **[markdy.com/playground](https://markdy.com/playground/)**  
-> 📚 **Documentation**: Complete syntax guide and examples at **[markdy.com/docs](https://markdy.com/docs/)**
+> 📚 **Documentation**: Complete syntax guide and examples at **[markdy.com/docs](https://markdy.com/docs/)**  
+> 💼 **Enterprise & Commercial**: Free under MIT. To support development or request custom architecture blueprints, explore **[GitHub Sponsors](https://github.com/sponsors/HoangYell)**.
 
 ## Features
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -396,6 +396,7 @@ const homepageStructuredData = [
         <a href="/blog/" class="mobile-nav-link">✍️ Articles &amp; Guides</a>
         <a href="/playground/" class="mobile-nav-link">⚡ Open Interactive Studio</a>
         <a href="https://github.com/HoangYell/markdy-com" target="_blank" rel="noopener noreferrer" class="mobile-nav-link">🐙 GitHub Repository ↗</a>
+        <a href="https://github.com/sponsors/HoangYell" target="_blank" rel="noopener noreferrer" class="mobile-nav-link">💖 Sponsor &amp; Blueprints ↗</a>
       </div>
     </div>
   </nav>
@@ -1085,6 +1086,7 @@ markdy check-all ./docs/diagrams</code></pre>
         <nav class="f-col" aria-label="Community">
           <h3>Community</h3>
           <a href="https://github.com/HoangYell/markdy-com" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://github.com/sponsors/HoangYell" target="_blank" rel="noopener noreferrer">Sponsor &amp; Blueprints</a>
           <a href="https://www.npmjs.com/package/@markdy/core" target="_blank" rel="noopener noreferrer">npm Registry</a>
           <a href="/privacy/">Privacy Policy</a>
           <a href="/terms/">Terms of Use</a>


### PR DESCRIPTION
## Description
- Add Sponsor badges and commercial development / blueprint callouts to:
  - root `README.md`
  - `@markdy/core` README
  - `@markdy/renderer-dom` README
  - `@markdy/astro` README
  - `@markdy/mdx` README
- Add Sponsor & Pro Blueprints navigation links to website footer and mobile drawer.

## Verification
- `cleanroom-guard check --staged` passed (zero leaks)
- `pnpm test` passed (100% 225+ tests pass)
- `pnpm verify:examples` passed (80 examples, 0 warnings)
- `pnpm build` passed (all 5 packages and website)