### PR TITLE
fix(harness): decouple visual harness port to 4325 to prevent Astro 4321 collision

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -12,6 +12,7 @@ module.exports = {
       max_memory_restart: '300M',
       env: {
         NODE_ENV: 'development',
+        HARNESS_PORT: '4325',
       },
     },
   ],

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  apps: [
+    {
+      name: 'markdy-harness',
+      script: 'packages/renderer-dom/harness/serve.mjs',
+      cwd: __dirname,
+      autorestart: true,
+      max_restarts: 5,
+      min_uptime: '10s',
+      restart_delay: 2000,
+      exp_backoff_restart_delay: 2000,
+      max_memory_restart: '300M',
+      env: {
+        NODE_ENV: 'development',
+      },
+    },
+  ],
+};

--- a/packages/renderer-dom/harness/serve.mjs
+++ b/packages/renderer-dom/harness/serve.mjs
@@ -21,7 +21,7 @@ const REPO_ROOT = resolve(HERE, "..", "..", "..");
 const CORE_DIST = resolve(REPO_ROOT, "packages/core/dist");
 const RENDERER_DIST = resolve(REPO_ROOT, "packages/renderer-dom/dist");
 const EXAMPLE_DIRS = ["examples/showcase", "examples"];
-const PORT = Number(process.env.HARNESS_PORT ?? 4321);
+const PORT = Number(process.env.HARNESS_PORT ?? 4325);
 
 function contentType(path) {
   if (path.endsWith(".js")) return "text/javascript; charset=utf-8";


### PR DESCRIPTION
## Summary
- Changes default `markdy-harness` port from `4321` to `4325` to prevent collision with Astro applications on `4321` (such as `hoangyell-com`).
- Adds `ecosystem.config.cjs` with standard restart backoff and memory limits.
- Passes all 225 test suite cases in `@markdy/core`, `@markdy/renderer-dom`, and `@markdy/cli`.