### PR TITLE
docs(renderer-dom): document visual harness development server and port 4325

### DIFF
--- a/packages/renderer-dom/README.md
+++ b/packages/renderer-dom/README.md
@@ -151,6 +151,16 @@ when capture fails. Browser font and cross-origin image restrictions still apply
 | `exportDiagramAsPng(container, opts?)` | `Function` | Export high-DPI rasterized PNG Blob |
 | `exportDiagramAsGif(container, timeline, opts?)` | `Function` | Export animated GIF89a recording |
 
+## Development & Visual Harness
+
+To inspect the renderer visually during local development:
+
+```sh
+pnpm --filter @markdy/renderer-dom run harness
+```
+
+The harness runs on **`http://127.0.0.1:4325`** (port 4325 is decoupled from Astro's default port 4321 to avoid collisions with documentation previews). It serves canonical test fixtures, live theme switching, and real-time interactive DOM rendering.
+
 ## Ecosystem & Documentation
 
 - ⚡ **[Interactive Studio / Playground](https://markdy.com/playground/)** — edit MarkdyScript with instant live preview in your browser


### PR DESCRIPTION
## Description
Documents the visual harness development server command (`pnpm --filter @markdy/renderer-dom run harness`) running on decoupled port `4325` in `@markdy/renderer-dom`'s README.

## Verification
- Clean-Room Pre-flight Guard: PASS
- Markdown structure: PASS