### PR TITLE
feat(player): default fit to true/selected and viewport interaction to false when undeclared

### DIFF
--- a/packages/astro/src/Markdy.astro
+++ b/packages/astro/src/Markdy.astro
@@ -54,6 +54,8 @@ export interface Props {
   interactiveViewport?: boolean;
   /** Host controls override: true supplies legacy defaults; false suppresses script controls. */
   controls?: boolean;
+  /** Initial fit-all-in-view state. Defaults to true when undeclared. */
+  fit?: boolean;
   class?: string;
   /**
    * Short human-readable title for the animation.
@@ -83,6 +85,7 @@ const {
   progressBarColor,
   playbackRate,
   controls,
+  fit,
   interactiveViewport,
   class: className,
   title = "Markdy animation",
@@ -119,6 +122,7 @@ const codeB64 =
   data-markdy-playback-rate={playbackRate !== undefined ? String(playbackRate) : undefined}
   data-markdy-interactive-viewport={interactiveViewport !== undefined ? String(interactiveViewport) : undefined}
   data-markdy-controls={controls !== undefined ? String(controls) : undefined}
+  data-markdy-fit={fit !== undefined ? String(fit) : undefined}
   role="img"
   aria-label={title}
   aria-busy="true"
@@ -327,6 +331,10 @@ const codeB64 =
       el.dataset.markdyControls !== undefined
         ? el.dataset.markdyControls === "true"
         : undefined;
+    const fit =
+      el.dataset.markdyFit !== undefined
+        ? el.dataset.markdyFit === "true"
+        : undefined;
     const interactiveViewport =
       el.dataset.markdyInteractiveViewport !== undefined
         ? el.dataset.markdyInteractiveViewport === "true"
@@ -352,6 +360,7 @@ const codeB64 =
       playbackRate,
       interactiveViewport,
       controls,
+      defaultFit: fit,
     });
 
     el.dataset.markdyInit = "done";

--- a/packages/core/src/player.ts
+++ b/packages/core/src/player.ts
@@ -173,6 +173,7 @@ const FLAT: Record<string, Setting> = {
   next_beat: CONTROLS.next_beat,
   keyboard: INTERACTION.keyboard,
   shortcuts: INTERACTION.shortcuts,
+  fit: CONTROLS.fit,
   fitView: CONTROLS.fitView,
   fit_view: CONTROLS.fit_view,
   fitViewButton: CONTROLS.fitViewButton,
@@ -347,6 +348,7 @@ export function resolvePlayer(config: PlayerConfig = {}, overrides: PlayerOverri
 
   const controlsAllowed = overrides.controls !== false;
   const hostControlDefault = overrides.controls === true;
+  const hasControlsConfig = config.controls !== undefined || overrideControls !== undefined;
   const resolveControl = (value: boolean | undefined, fallback = hostControlDefault): boolean =>
     controlsAllowed && (value ?? fallback);
   const requestedControls = {
@@ -366,14 +368,16 @@ export function resolvePlayer(config: PlayerConfig = {}, overrides: PlayerOverri
     theme: resolveControl(configuredControls.theme, hostControlDefault),
   };
 
-  // Legacy host coupling: `controls` as a host option also unlocks the viewport.
+  const hasExplicitInteraction = config.interaction !== undefined;
+  const fallbackGesture = overrides.interactiveViewport === true || overrides.controls === true;
   const interactionOn =
-    overrides.interactiveViewport !== false &&
-    (overrides.interactiveViewport === true || config.interaction !== undefined || overrides.controls === true);
+    overrides.interactiveViewport === true ||
+    overrides.controls === true ||
+    (overrides.interactiveViewport !== false && hasExplicitInteraction);
   const gestures = {
-    zoom: interactionOn && (interaction.zoom ?? true),
-    pan: interactionOn && (interaction.pan ?? true),
-    doubleClickToReset: interactionOn && (interaction.doubleClickToReset ?? true),
+    zoom: interactionOn && (interaction.zoom ?? fallbackGesture),
+    pan: interactionOn && (interaction.pan ?? fallbackGesture),
+    doubleClickToReset: interactionOn && (interaction.doubleClickToReset ?? fallbackGesture),
   };
   const interactionEnabled = gestures.zoom || gestures.pan || gestures.doubleClickToReset;
   const configuredSpeeds = configuredControls.speeds?.length ? configuredControls.speeds : [0.25, 1];
@@ -405,7 +409,7 @@ export function resolvePlayer(config: PlayerConfig = {}, overrides: PlayerOverri
     interaction: {
       ...gestures,
       enabled: interactionEnabled,
-      clickToPlay: overrides.clickToPlay ?? (interactionOn && (interaction.clickToPlay ?? true)),
+      clickToPlay: overrides.clickToPlay ?? (interaction.clickToPlay ?? true),
       keyboard: interactionOn && (interaction.keyboard ?? false),
     },
     chrome: {

--- a/packages/core/tests/parser.test.ts
+++ b/packages/core/tests/parser.test.ts
@@ -717,7 +717,7 @@ beat main:
       theme: false,
     });
 
-    // When explicitly set, it should be true.
+    // When explicitly set, it should be respected.
     const resolvedWithCode = resolvePlayer({ controls: { code: true } });
     expect(resolvedWithCode.controls.code).toBe(true);
 
@@ -726,6 +726,28 @@ beat main:
 
     const resolvedWithOneSpeed = resolvePlayer({ controls: { speed: true, speeds: [0.25] } });
     expect(resolvedWithOneSpeed.controls).toMatchObject({ enabled: false, speed: false, speeds: [0.25] });
+
+    // Fit control button is opt-in per controls group, or enabled via controls: true.
+    expect(resolvePlayer({ controls: { fit: true } }).controls.fit).toBe(true);
+    expect(resolvePlayer({}, { controls: true }).controls.fit).toBe(true);
+    expect(resolvePlayer({ controls: { play: true } }).controls.fit).toBe(false);
+    expect(resolvePlayer({}).controls.fit).toBe(false);
+
+    // Interaction viewport gestures default to false when undeclared.
+    expect(resolvePlayer().interaction).toMatchObject({
+      enabled: false,
+      zoom: false,
+      pan: false,
+      doubleClickToReset: false,
+      clickToPlay: true,
+      keyboard: false,
+    });
+    expect(resolvePlayer({ interaction: { zoom: true } }).interaction).toMatchObject({
+      enabled: true,
+      zoom: true,
+      pan: false,
+      doubleClickToReset: false,
+    });
   });
 
   it("warns on unknown or malformed player settings", () => {

--- a/packages/renderer-dom/src/diagram.ts
+++ b/packages/renderer-dom/src/diagram.ts
@@ -112,6 +112,13 @@ export interface DiagramOptions {
    */
   contentPadding?: number;
   /**
+   * Initial fit-all-in-view state. Defaults to true when undeclared.
+   * If false, starts in unconstrained mode.
+   */
+  defaultFit?: boolean;
+  /** Alias for defaultFit. */
+  fit?: boolean;
+  /**
    * Optional custom fullscreen toggle handler.
    * When provided, the footer fullscreen control delegates toggling to this callback.
    */
@@ -444,6 +451,8 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     minReadableScale = 0.9,
     targetWidthRatio = 0.96,
     contentPadding,
+    defaultFit,
+    fit: explicitFitOption,
   } = opts;
 
   function detectContainerOrientation(previous?: "portrait" | "landscape"): "portrait" | "landscape" {
@@ -1175,7 +1184,16 @@ export function createDiagram(opts: DiagramOptions): Diagram {
   let controlsTimeEl: HTMLSpanElement | null = null;
   let controlsFitButton: HTMLButtonElement | null = null;
   let closeCodePanel: (() => void) | null = null;
-  let fitViewActive = false;
+  const explicitFit = defaultFit ?? explicitFitOption;
+  let fitViewActive =
+    explicitFit !== undefined
+      ? Boolean(explicitFit)
+      : plan.meta.player?.controls?.fit !== undefined
+        ? Boolean(plan.meta.player.controls.fit)
+        : opts.fitMode === "contain" || Boolean(fitViewButton);
+  if (fitViewActive) {
+    cameraLayer.style.setProperty("transform", "none", "important");
+  }
 
   const ICONS = {
     play: '<svg class="markdy-icon" width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>',
@@ -2066,7 +2084,7 @@ export function createDiagram(opts: DiagramOptions): Diagram {
     if (!fitViewButton) return;
     controlsFitButton = makeControlButton("Fit", "Fit all items in view and ignore camera zoom", ICONS.fit);
     controlsFitButton.className = "markdy-control-fit";
-    controlsFitButton.setAttribute("aria-pressed", "false");
+    controlsFitButton.setAttribute("aria-pressed", fitViewActive ? "true" : "false");
     controlsFitButton.addEventListener("click", toggleFitView);
     toolbar.appendChild(controlsFitButton);
   }

--- a/packages/renderer-dom/tests/diagram.smoke.test.ts
+++ b/packages/renderer-dom/tests/diagram.smoke.test.ts
@@ -744,19 +744,22 @@ beat b1:
     const fitButton = document.body.querySelector<HTMLButtonElement>(".markdy-control-fit")!;
 
     expect(fitButton).not.toBeNull();
-    expect(fitButton.getAttribute("aria-pressed")).toBe("false");
-
-    fitButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(fitButton.getAttribute("aria-pressed")).toBe("true");
-    // Camera zoom cues are outranked while fitted.
+    // Camera zoom cues are outranked while fitted by default.
     expect(cameraLayer.style.getPropertyPriority("transform")).toBe("important");
     expect(cameraLayer.style.transform).toBe("none");
-    expect(transformLayer.style.transform).toMatch(/translate\(.+\) scale\(.+\)/);
 
+    // Toggling fit button releases fit view.
     fitButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(fitButton.getAttribute("aria-pressed")).toBe("false");
     expect(cameraLayer.style.transform).toBe("");
     expect(transformLayer.style.transform).toBe("translate(0px, 0px) scale(1)");
+
+    // Toggling back activates fit view again.
+    fitButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(fitButton.getAttribute("aria-pressed")).toBe("true");
+    expect(cameraLayer.style.getPropertyPriority("transform")).toBe("important");
+    expect(cameraLayer.style.transform).toBe("none");
 
     diagram.destroy();
   });

--- a/packages/renderer-dom/tests/width-first-autoscale.test.ts
+++ b/packages/renderer-dom/tests/width-first-autoscale.test.ts
@@ -184,6 +184,7 @@ beat flow:
         code: "scene\nlayout LR\nservice Start\nservice Middle\nservice End\nbeat flow:\n  Start -> Middle -> End",
         autoplay: false,
         controls: { fit: true },
+        defaultFit: false,
       });
       const viewport = container.querySelector<HTMLElement>(".markdy-viewport")!;
       const fit = container.querySelector<HTMLButtonElement>(".markdy-control-fit")!;


### PR DESCRIPTION
## Summary
- Default `fit` state to active (`true` / `aria-pressed="true"`) when undeclared, ensuring diagrams fit cleanly in container bounds with pinned camera layer.
- Support explicit `fit: false` / `defaultFit: false` opt-out in player script, options, and `<Markdy />` Astro component.
- Add `fit` to flat player settings directives map in `@markdy/core`.
- Default viewport gestures (`zoom`, `pan`, `doubleClickToReset`) to `false` when undeclared, preventing accidental gesture capture when scrolling through content. Keep `clickToPlay` enabled by default for playback toggle on tap/click.
- Preserve `controls: true` legacy affordance pairing.
- Verified 100% tests passing across all packages (`@markdy/core`, `@markdy/renderer-dom`, `@markdy/cli`, website), visual regression gate (0.000% diff), and sub-frame performance budgets.